### PR TITLE
fix: do not allow to fall into infinite query loop on error

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-pdo-engine.php
+++ b/wp-includes/sqlite/class-wp-sqlite-pdo-engine.php
@@ -604,7 +604,7 @@ class WP_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 		$output .= '<p>Queries made or created this session were:</p>';
 		$output .= '<ol>';
 		foreach ( $this->queries as $q ) {
-			$output .= '<li>' . esc_html( $q ) . '</li>';
+			$output .= '<li>' . htmlspecialchars( $q ) . '</li>';
 		}
 		$output .= '</ol>';
 		$output .= '</div>';
@@ -613,7 +613,7 @@ class WP_SQLite_PDO_Engine extends PDO { // phpcs:ignore
 			$output .= sprintf(
 				'Error occurred at line %1$d in Function %2$s. Error message was: %3$s.',
 				(int) $this->errors[ $num ]['line'],
-				'<code>' . esc_html( $this->errors[ $num ]['function'] ) . '</code>',
+				'<code>' . htmlspecialchars( $this->errors[ $num ]['function'] ) . '</code>',
 				$m
 			);
 			$output .= '</div>';


### PR DESCRIPTION
Internally, `esc_html` calls database to find if site actually uses
utf8. This has some serious implications during our new database
installation (after hitting *install* button) because we land in
undetermined state.

1. User hits *install* button.
2. We are not installing database yet, just checking if it's available.
3. We found out that db is not present (missing tables points that, but
   we collect errors).
4. During error collection we call `esc_html` to sanitize text, which
   again calls `get_options`, resulting in another error being collected
   and prepared for output, which recursively fails.

---

The situation doesn't look better if we immediately enter installation
state (navigating directly to `wp-admin/install.php`). This ensures that
`WP_INSTALLING` constant is defined and introduces some safety checks,
but those merely limits to suppressing errors, yet those are still
collected in HTML format.

The easiest solution allowing us to properly install database would be
to drop formatting function because of it's dependencies in favour of
native PHP function. Nevertheless, it might be reconsidered whether we
actually need HTML output and such sanitization, especially when
sometimes wpdb error outputs encoded HTML, resulting in illegible wall
of plain HTML (not parsed by browser). Following original `wpdb` class
implementation, we might opt-in for concise error messages, which
doesn't require complex formatting (especially within database driver
logic).

Signed-off-by: Bart Jaskulski <bjaskulski@protonmail.com>
