### PR TITLE
#16 Flush the object cache when switching databases.

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -44,6 +44,17 @@ function sqlite_activation() {
 }
 add_action( 'admin_init', 'sqlite_activation' );
 
+// Flush the cache at the last moment before the redirect.
+add_filter(
+	'x_redirect_by',
+	function ( $result ) {
+		wp_cache_flush();
+		return $result;
+	},
+	PHP_INT_MAX,
+	1
+);
+
 /**
  * Add the db.php file in wp-content.
  *

--- a/deactivate.php
+++ b/deactivate.php
@@ -22,7 +22,12 @@ function sqlite_plugin_remove_db_file() {
 
 	// Init the filesystem if needed, then delete custom drop-in.
 	if ( $wp_filesystem || WP_Filesystem() ) {
+		// Flush any persistent cache.
+		wp_cache_flush();
+		// Delete the drop-in.
 		$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
+		// Flush the cache again to mitigate a possible race condition.
+		wp_cache_flush();
 	}
 
 	// Run an action on `shutdown`, to deactivate the option in the MySQL database.
@@ -47,12 +52,17 @@ function sqlite_plugin_remove_db_file() {
 				$value = maybe_unserialize( $row->option_value );
 				if ( is_array( $value ) ) {
 					$value_flipped = array_flip( $value );
-					unset( $value_flipped[ str_replace( WP_PLUGIN_DIR . '/', '', SQLITE_MAIN_FILE ) ] );
+					$items         = array_reverse( explode( DIRECTORY_SEPARATOR, SQLITE_MAIN_FILE ) );
+					$item          = $items[1] . DIRECTORY_SEPARATOR . $items[0];
+					unset( $value_flipped[ $item ] );
 					$value = array_flip( $value_flipped );
 					$wpdb_mysql->update( $wpdb_mysql->options, array( 'option_value' => maybe_serialize( $value ) ), array( 'option_name' => 'active_plugins' ) );
 				}
 			}
-		}
+		},
+		PHP_INT_MAX
 	);
+	// Flush any persistent cache.
+	wp_cache_flush();
 }
 register_deactivation_hook( SQLITE_MAIN_FILE, 'sqlite_plugin_remove_db_file' ); // Remove db.php file on plugin deactivation.


### PR DESCRIPTION
When activating or deactivating the plugin, it's necessary to flush the object cache as late as possible before switching databases.

This change uses PHP_INT_MAX for hook priorities to make sure the hooked functions are called very late.