### PR TITLE
Avoid calling strtotime with "0000-00-00 00:00:00" arg

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1574,7 +1574,12 @@ class WP_SQLite_Translator {
 		 * and stop relying on this MySQL feature,
 		 */
 		if ( 1 === preg_match( '/^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})$/', $value, $matches ) ) {
-			if ( false === strtotime( $value ) ) {
+			/*
+			 * Calling strtotime("0000-00-00 00:00:00") in 32-bit environments triggers
+			 * an "out of integer range" warning – let's avoid that call for the popular
+			 * case of "zero" dates.
+			 */
+			if ( $value !== "0000-00-00 00:00:00" && false === strtotime( $value ) ) {
 				$value = '0000-00-00 00:00:00';
 			}
 		}


### PR DESCRIPTION
Calling strtotime("0000-00-00 00:00:00") in 32-bit runtimes like WordPress Playground triggers an "out of integer range" warning:

<img width="1214" alt="CleanShot 2023-03-27 at 10 05 37@2x" src="https://user-images.githubusercontent.com/205419/227879750-398e95c9-4fb6-487d-898c-3830a3fd6401.png">

Let's avoid that call for the popular case of "zero" dates.

cc @aristath @OllieJones