### PR TITLE
Allow filtering `wp_redirect`

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -15,8 +15,9 @@
  */
 function sqlite_plugin_activation_redirect( $plugin ) {
 	if ( plugin_basename( SQLITE_MAIN_FILE ) === $plugin ) {
-		wp_redirect( admin_url( 'options-general.php?page=sqlite-integration' ) );
-		exit;
+		if( wp_safe_redirect( admin_url( 'options-general.php?page=sqlite-integration' ) ) ) {
+			exit;
+		}
 	}
 }
 add_action( 'activated_plugin', 'sqlite_plugin_activation_redirect' );


### PR DESCRIPTION
Currently, if the `wp_redirect` filter is used and returns `false` (as it is designed to accommodate) the `wp_redirect()` function returns and `exit` is run anyway.

This PR implements the code pattern suggested in the `wp_redirect()` php docblock which does not exit if the function returns early with `false`. See: [pluggable.php](https://github.com/WordPress/WordPress/blob/8088dc8cecdab18f500648e58369dee27c6915a0/wp-includes/pluggable.php#L1516-L1518)

It also changes from using `wp_redirect()` to `wp_safe_redirect()` – AIUI the preferred function for local redirects.

```
// Do not redirect when activating `sqlite-database-integration` plugin.
add_filter( 'wp_redirect', function( string $location, int $status ): string|bool {
	if( str_ends_with( $location, 'sqlite-integration' ) ) {
		return false;
	}
	return $location;
}, 10, 2);
```

Allows #49 to be handled by WP CLI itself.
