### PR TITLE
Fix compatibility with PHP < 7.3

### DIFF
--- a/admin-page.php
+++ b/admin-page.php
@@ -17,7 +17,7 @@ function sqlite_add_admin_menu() {
 		__( 'SQLite integration', 'sqlite-database-integration' ),
 		'manage_options',
 		'sqlite-integration',
-		'sqlite_integration_admin_screen',
+		'sqlite_integration_admin_screen'
 	);
 }
 add_action( 'admin_menu', 'sqlite_add_admin_menu' );


### PR DESCRIPTION
Trailing commas in function calls are only supported since PHP 7.3, see https://wiki.php.net/rfc/trailing-comma-function-calls.

Unfortunately there are no tests running whatsoever, so there might be more issues. However, this is the most prominent one I encountered when testing this plugin with WP-CLI.