### PR TITLE
WordPress nightly compat: Bump the db_version to 8.0 

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -349,7 +349,7 @@ class WP_SQLite_DB extends wpdb {
 	 * @see wpdb::db_version()
 	 */
 	public function db_version() {
-		return '5.5';
+		return '8.0';
 	}
 
 	/**


### PR DESCRIPTION
WordPress minimum MySQL version was recently bumped to 5.5, which means this plugin no longer works with the trunk WordPress version. Let's bump the reported db version to 8.0 to keep the version check happy for a longer while.

The version bump was done here:

https://github.com/WordPress/wordpress-develop/commit/e1265a3732eedaf6bf12f87b080e19ebd65a08a6

<img width="811" alt="CleanShot 2023-12-09 at 22 40 34@2x" src="https://github.com/WordPress/sqlite-database-integration/assets/205419/00cd35db-0935-4cb5-8327-a4654b5d6b0c">

cc @aristath 