### PR TITLE
Remove trailing comma in function call

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -633,7 +633,7 @@ class WP_SQLite_Translator {
 				$this->table_name,
 				$this->insert_columns,
 				$this->last_insert_id,
-				$this->affected_rows,
+				$this->affected_rows
 			);
 
 			// Commit the nested transaction.


### PR DESCRIPTION
Trailing commas in function calls have only been introduced in PHP 7.3.

Given that this project claims to work with PHP 5.6+, this PR removes a trailing comma that creates fatal errors on PHP 5.6 - 7.2.