### PR TITLE
Add support for SHOW TABLE STATUS LIKE queries

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -195,6 +195,119 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 	}
 
+	public function testShowTableStatusFrom()
+	{
+		// Created in setUp() function
+		$this->assertQuery("DROP TABLE _options");
+		$this->assertQuery("DROP TABLE _dates");
+
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				option_name TEXT NOT NULL default '',
+				option_value TEXT NOT NULL default ''
+			);"
+		);
+
+		$this->assertQuery(
+			"SHOW TABLE STATUS FROM 'mydb';"
+		);
+
+		$this->assertCount(
+			1,
+			$this->engine->get_query_results()
+		);
+	}
+
+	public function testShowTableStatusIn()
+	{
+		// Created in setUp() function
+		$this->assertQuery("DROP TABLE _options");
+		$this->assertQuery("DROP TABLE _dates");
+
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				option_name TEXT NOT NULL default '',
+				option_value TEXT NOT NULL default ''
+			);"
+		);
+
+		$this->assertQuery(
+			"SHOW TABLE STATUS IN 'mydb';"
+		);
+
+		$this->assertCount(
+			1,
+			$this->engine->get_query_results()
+		);
+	}
+
+	public function testShowTableStatusInTwoTables()
+	{
+		// Created in setUp() function
+		$this->assertQuery("DROP TABLE _options");
+		$this->assertQuery("DROP TABLE _dates");
+
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				option_name TEXT NOT NULL default '',
+				option_value TEXT NOT NULL default ''
+			);"
+		);
+
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table2 (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				option_name TEXT NOT NULL default '',
+				option_value TEXT NOT NULL default ''
+			);"
+		);
+		$this->assertQuery(
+			"SHOW TABLE STATUS IN 'mydb';"
+		);
+
+		$this->assertCount(
+			2,
+			$this->engine->get_query_results()
+		);
+	}
+
+	public function testShowTableStatusLike() {
+		// Created in setUp() function
+		$this->assertQuery("DROP TABLE _options");
+		$this->assertQuery("DROP TABLE _dates");
+
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table1 (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				option_name TEXT NOT NULL default '',
+				option_value TEXT NOT NULL default ''
+			);"
+		);
+
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table2 (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				option_name TEXT NOT NULL default '',
+				option_value TEXT NOT NULL default ''
+			);"
+		);
+
+		$this->assertQuery(
+			"SHOW TABLE STATUS LIKE '_tmp_table1';"
+		);
+		$this->assertCount(
+			1,
+			$this->engine->get_query_results()
+		);
+		$this->assertEquals(
+			'_tmp_table1',
+			$this->engine->get_query_results()[0]->Name
+		);
+	}
+
 	public function testCreateTable() {
 		$result = $this->assertQuery(
 			"CREATE TABLE wptests_users (

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -296,10 +296,10 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 
 		$this->assertQuery(
-			"SHOW TABLE STATUS LIKE '_tmp_table1';"
+			"SHOW TABLE STATUS LIKE '_tmp_table%';"
 		);
 		$this->assertCount(
-			1,
+			2,
 			$this->engine->get_query_results()
 		);
 		$this->assertEquals(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,6 +8,17 @@ require_once __DIR__ . '/../wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-
 require_once __DIR__ . '/../wp-includes/sqlite/class-wp-sqlite-translator.php';
 
 /**
+ * Polyfills for WordPress functions
+ */
+
+function do_action( $tag, ...$args ) {
+}
+
+function apply_filters( $tag, $value, ...$args ) {
+	return $value;
+}
+
+/**
  * Polyfills for php 8 functions
  */
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3141,12 +3141,56 @@ class WP_SQLite_Translator {
 				return;
 
 			case 'TABLE STATUS':  // FROM `database`.
-				$this->rewriter->skip();
+				// Match the optional [{FROM | IN} db_name]
+				$database_expression = $this->rewriter->consume();
+				if ( $database_expression->token === 'FROM' || $database_expression->token === 'IN' ) {
+					$this->rewriter->consume();
+					$database_expression = $this->rewriter->consume();
+				}
+
+				$pattern = '%';
+				// [LIKE 'pattern' | WHERE expr]
+				if($database_expression->token === 'LIKE') {
+					$pattern = $this->rewriter->consume()->value;
+				} else if($database_expression->token === 'WHERE') {
+					// @TODO Support me please.
+				} else if($database_expression->token !== ';') {
+					throw new Exception( 'Syntax error: Unexpected token ' . $database_expression->token .' in query '. $this->mysql_query );
+				}
+
 				$database_expression = $this->rewriter->skip();
 				$stmt                = $this->execute_sqlite_query(
-					"SELECT name as `Name`, 'myisam' as `Engine`, 0 as `Data_length`, 0 as `Index_length`, 0 as `Data_free` FROM sqlite_master WHERE type='table' ORDER BY name"
+					<<<SQL
+					SELECT 
+						name as `Name`, 
+						'myisam' as `Engine`,
+						10 as `Version`,
+						'Fixed' as `Row_format`,
+						0 as `Rows`,
+						0 as `Avg_row_length`,
+						0 as `Data_length`,
+						0 as `Max_data_length`,
+						0 as `Index_length`,
+						0 as `Data_free` ,
+						0 as `Auto_increment`,
+						'2024-03-20 15:33:20' as `Create_time`,
+						'2024-03-20 15:33:20' as `Update_time`,
+						null as `Check_time`,
+						null as `Collation`,
+						null as `Checksum`,
+						'' as `Create_options`,
+						'' as `Comment`
+					FROM sqlite_master 
+					WHERE
+						type='table' 
+						AND name LIKE :pattern
+					ORDER BY name
+SQL,
+					
+					array(
+						':pattern' => $pattern,
+					)
 				);
-
 				$tables = $this->strip_sqlite_system_tables( $stmt->fetchAll( $this->pdo_fetch_mode ) );
 				foreach ( $tables as $table ) {
 					$table_name  = $table->Name; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase


### PR DESCRIPTION
Adds support for the following queries:

* `SHOW TABLE STATUS FROM dbschema`
* `SHOW TABLE STATUS IN dbschema`
* `SHOW TABLE STATUS IN dbschema LIKE ""`
* `SHOW TABLE STATUS LIKE ""`

Also, brings the keys of the returned record in line with [MySQL spec](https://dev.mysql.com/doc/refman/8.0/en/extended-show.html). The values are mostly fake and supplying the correct ones will require more work.

## Follow-up work

Support `SHOW TABLE STATUS WHERE`

Closes https://github.com/WordPress/sqlite-database-integration/issues/75

cc @brandonpayton