### PR TITLE
Replace protected consts with consts

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-lexer.php
+++ b/wp-includes/sqlite/class-wp-sqlite-lexer.php
@@ -33,7 +33,7 @@ class WP_SQLite_Lexer {
 	 *
 	 * @var string[]
 	 */
-	protected const PARSER_METHODS = array(
+	const PARSER_METHODS = array(
 		// It is best to put the parsers in order of their complexity
 		// (ascending) and their occurrence rate (descending).
 		//
@@ -77,7 +77,7 @@ class WP_SQLite_Lexer {
 	 *
 	 * @var string[]
 	 */
-	protected const KEYWORD_NAME_INDICATORS = array(
+	const KEYWORD_NAME_INDICATORS = array(
 		'FROM',
 		'SET',
 		'WHERE',
@@ -89,7 +89,7 @@ class WP_SQLite_Lexer {
 	 *
 	 * @var string[]
 	 */
-	protected const OPERATOR_NAME_INDICATORS = array(
+	const OPERATOR_NAME_INDICATORS = array(
 		',',
 		'.',
 	);


### PR DESCRIPTION
Fixes #81

This PR fixes PHP < 7.1 support by removing the use of const visibility modifiers.

## Testing instructions

- Checkout this branch
- Install the plugin on a PHP 7.0 or older server
```
export WP_ENV_PHP_VERSION="7.0" && wp-env start
```
- Go to /wp-admin/
- Click on _Settings > SQLite integration_
- Click _Install SQLite database
- Confirm that there are no PHP errors and the installer starts