### PR TITLE
Support for MySQL LEFT() function

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -146,12 +146,41 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertEquals( 1, $result[0]->output );
 	}
 
+	public function testLeftFunction1Char() {
+		$result = $this->assertQuery(
+			'SELECT LEFT("abc", 1) as output'
+		);
+		$this->assertEquals( "a", $result[0]->output );		
+	}
+
+	public function testLeftFunction5Chars() {
+		$result = $this->assertQuery(
+			'SELECT LEFT("Lorem ipsum", 5) as output'
+		);
+		$this->assertEquals( "Lorem", $result[0]->output );		
+	}
+
+	public function testLeftFunctionNullString() {
+		$result = $this->assertQuery(
+			'SELECT LEFT(NULL, 5) as output'
+		);
+		$this->assertEquals( null, $result[0]->output );		
+	}
+
+	public function testLeftFunctionNullLength() {
+		$result = $this->assertQuery(
+			'SELECT LEFT("Test", NULL) as output'
+		);
+		$this->assertEquals( null, $result[0]->output );		
+	}
+
 	public function testInsertSelectFromDual() {
 		$result = $this->assertQuery(
 			'INSERT INTO _options (option_name, option_value) SELECT "A", "b" FROM DUAL WHERE ( SELECT NULL FROM DUAL ) IS NULL'
 		);
 		$this->assertEquals( 1, $result );
 	}
+
 
 	public function testCreateTemporaryTable() {
 		$this->assertQuery(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -8,9 +8,22 @@ require_once __DIR__ . '/../wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-
 require_once __DIR__ . '/../wp-includes/sqlite/class-wp-sqlite-translator.php';
 
 /**
+ * Polyfills for WordPress functions
+ */
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action() {
+	}
+}
+
+if( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $tag, $value, ...$args ) {
+		return $value;
+	}
+}
+
+/**
  * Polyfills for php 8 functions
  */
-
 /**
  * @see https://www.php.net/manual/en/function.str-starts-with
  */

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1824,6 +1824,7 @@ class WP_SQLite_Translator {
 			|| $this->capture_group_by( $token )
 			|| $this->translate_ungrouped_having( $token )
 			|| $this->translate_like_escape( $token )
+			|| $this->translate_left_function( $token )
 		);
 	}
 
@@ -2022,6 +2023,41 @@ class WP_SQLite_Translator {
 
 		$this->rewriter->skip();
 		$this->rewriter->add( new WP_SQLite_Token( 'DATETIME', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_FUNCTION ) );
+		return true;
+	}
+
+	/**
+	 * Translate the LEFT() function.
+	 * 
+	 * > Returns the leftmost len characters from the string str, or NULL if any argument is NULL.
+	 * 
+	 * https://dev.mysql.com/doc/refman/8.3/en/string-functions.html#function_left
+	 *
+	 * @param WP_SQLite_Token $token The token to translate.
+	 *
+	 * @return bool
+	 */
+	private function translate_left_function( $token ) {
+		if (
+			! $token->matches(
+				WP_SQLite_Token::TYPE_KEYWORD,
+				WP_SQLite_Token::FLAG_KEYWORD_FUNCTION,
+				array( 'LEFT' )
+			)
+		) {
+			return false;
+		}
+
+		$this->rewriter->skip();
+		$this->rewriter->add( new WP_SQLite_Token( 'SUBSTRING', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_FUNCTION ) );
+		$this->rewriter->consume(
+			array(
+				'type'  => WP_SQLite_Token::TYPE_OPERATOR,
+				'value' => ',',
+			)
+		);
+		$this->rewriter->add( new WP_SQLite_Token( 1, WP_SQLite_Token::TYPE_NUMBER ) );
+		$this->rewriter->add( new WP_SQLite_Token( ',', WP_SQLite_Token::TYPE_OPERATOR ) );
 		return true;
 	}
 


### PR DESCRIPTION
Documented at https://dev.mysql.com/doc/refman/8.3/en/string-functions.html#function_left, the LEFT() function returns the leftmost len characters from the string str, or NULL if any argument is NULL.

This PR rewrites the LEFT() calls into SUBSTRING() calls.

Also adds WordPress polyfills to enable running PHPUnit tests.

Test with this command:

```shell
./vendor/bin/phpunit -c ./phpunit.xml.dist --filter testLeft
```