### PR TITLE
Support SHOW GRANTS FOR

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1250,7 +1250,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			$result,
 			array(
 				(object) array(
-					'Grants for root@localhost' => 'ALL PRIVILIGES'
+					'Grants for root@localhost' => 'GRANT *.* ON % TO `root`@`localhost`'
 				)
 			)
 		);

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -146,12 +146,41 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertEquals( 1, $result[0]->output );
 	}
 
+	public function testLeftFunction1Char() {
+		$result = $this->assertQuery(
+			'SELECT LEFT("abc", 1) as output'
+		);
+		$this->assertEquals( "a", $result[0]->output );		
+	}
+
+	public function testLeftFunction5Chars() {
+		$result = $this->assertQuery(
+			'SELECT LEFT("Lorem ipsum", 5) as output'
+		);
+		$this->assertEquals( "Lorem", $result[0]->output );		
+	}
+
+	public function testLeftFunctionNullString() {
+		$result = $this->assertQuery(
+			'SELECT LEFT(NULL, 5) as output'
+		);
+		$this->assertEquals( null, $result[0]->output );		
+	}
+
+	public function testLeftFunctionNullLength() {
+		$result = $this->assertQuery(
+			'SELECT LEFT("Test", NULL) as output'
+		);
+		$this->assertEquals( null, $result[0]->output );		
+	}
+
 	public function testInsertSelectFromDual() {
 		$result = $this->assertQuery(
 			'INSERT INTO _options (option_name, option_value) SELECT "A", "b" FROM DUAL WHERE ( SELECT NULL FROM DUAL ) IS NULL'
 		);
 		$this->assertEquals( 1, $result );
 	}
+
 
 	public function testCreateTemporaryTable() {
 		$this->assertQuery(
@@ -1250,7 +1279,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			$result,
 			array(
 				(object) array(
-					'Grants for root@localhost' => 'GRANT *.* ON % TO `root`@`localhost`'
+					'Grants for root@localhost' => 'GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, SHUTDOWN, PROCESS, FILE, REFERENCES, INDEX, ALTER, SHOW DATABASES, SUPER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER, CREATE TABLESPACE, CREATE ROLE, DROP ROLE ON *.* TO `root`@`localhost` WITH GRANT OPTION'
 				)
 			)
 		);

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1244,6 +1244,17 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			$fields
 		);
 	}
+	public function testShowGrantsFor() {
+		$result = $this->assertQuery( 'SHOW GRANTS FOR current_user();' );
+		$this->assertEquals(
+			$result,
+			array(
+				(object) array(
+					'Grants for root@localhost' => 'ALL PRIVILIGES'
+				)
+			)
+		);
+	}
 
 	public function testShowIndex() {
 		$result = $this->assertQuery(

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3026,6 +3026,14 @@ class WP_SQLite_Translator {
 				$this->results = true;
 				return;
 
+			case 'GRANTS FOR':
+				$this->set_results_from_fetched_data( array(
+					(object) array(
+						'Grants for root@localhost' => 'ALL PRIVILIGES'
+					)
+				) );
+				return;
+
 			case 'FULL COLUMNS':
 				$this->rewriter->consume();
 				// Fall through.

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3029,7 +3029,7 @@ class WP_SQLite_Translator {
 			case 'GRANTS FOR':
 				$this->set_results_from_fetched_data( array(
 					(object) array(
-						'Grants for root@localhost' => 'ALL PRIVILIGES'
+						'Grants for root@localhost' => 'GRANT *.* ON % TO `root`@`localhost`',
 					)
 				) );
 				return;

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1824,6 +1824,7 @@ class WP_SQLite_Translator {
 			|| $this->capture_group_by( $token )
 			|| $this->translate_ungrouped_having( $token )
 			|| $this->translate_like_escape( $token )
+			|| $this->translate_left_function( $token )
 		);
 	}
 
@@ -2022,6 +2023,41 @@ class WP_SQLite_Translator {
 
 		$this->rewriter->skip();
 		$this->rewriter->add( new WP_SQLite_Token( 'DATETIME', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_FUNCTION ) );
+		return true;
+	}
+
+	/**
+	 * Translate the LEFT() function.
+	 * 
+	 * > Returns the leftmost len characters from the string str, or NULL if any argument is NULL.
+	 * 
+	 * https://dev.mysql.com/doc/refman/8.3/en/string-functions.html#function_left
+	 *
+	 * @param WP_SQLite_Token $token The token to translate.
+	 *
+	 * @return bool
+	 */
+	private function translate_left_function( $token ) {
+		if (
+			! $token->matches(
+				WP_SQLite_Token::TYPE_KEYWORD,
+				WP_SQLite_Token::FLAG_KEYWORD_FUNCTION,
+				array( 'LEFT' )
+			)
+		) {
+			return false;
+		}
+
+		$this->rewriter->skip();
+		$this->rewriter->add( new WP_SQLite_Token( 'SUBSTRING', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_FUNCTION ) );
+		$this->rewriter->consume(
+			array(
+				'type'  => WP_SQLite_Token::TYPE_OPERATOR,
+				'value' => ',',
+			)
+		);
+		$this->rewriter->add( new WP_SQLite_Token( 1, WP_SQLite_Token::TYPE_NUMBER ) );
+		$this->rewriter->add( new WP_SQLite_Token( ',', WP_SQLite_Token::TYPE_OPERATOR ) );
 		return true;
 	}
 
@@ -3029,7 +3065,7 @@ class WP_SQLite_Translator {
 			case 'GRANTS FOR':
 				$this->set_results_from_fetched_data( array(
 					(object) array(
-						'Grants for root@localhost' => 'GRANT *.* ON % TO `root`@`localhost`',
+						'Grants for root@localhost' => 'GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, SHUTDOWN, PROCESS, FILE, REFERENCES, INDEX, ALTER, SHOW DATABASES, SUPER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER, CREATE TABLESPACE, CREATE ROLE, DROP ROLE ON *.* TO `root`@`localhost` WITH GRANT OPTION'
 					)
 				) );
 				return;


### PR DESCRIPTION
A naive implementation of SHOW GRANTS FOR

It returns all the privileges one can have and assumes a root user.

https://dev.mysql.com/doc/refman/8.0/en/show-grants.html

Testing instructions:

```
./vendor/bin/phpunit -c ./phpunit.xml.dist --filter testShowGrants
```