### PR TITLE
Add toggle to SQLite Admin Bar item display via PHP filter hook

### DIFF
--- a/admin-page.php
+++ b/admin-page.php
@@ -146,4 +146,7 @@ function sqlite_plugin_adminbar_item( $admin_bar ) {
 	);
 	$admin_bar->add_node( $args );
 }
-add_action( 'admin_bar_menu', 'sqlite_plugin_adminbar_item', 999 );
+$show_sqlite_adminbar = apply_filters( 'sqlite_show_adminbar', '__return_true' );
+if ( $show_sqlite_adminbar ) {
+	add_action( 'admin_bar_menu', 'sqlite_plugin_adminbar_item', 999 );
+}

--- a/admin-page.php
+++ b/admin-page.php
@@ -146,7 +146,7 @@ function sqlite_plugin_adminbar_item( $admin_bar ) {
 	);
 	$admin_bar->add_node( $args );
 }
-$show_sqlite_adminbar = apply_filters( 'sqlite_show_adminbar', '__return_true' );
+$show_sqlite_adminbar = apply_filters( 'sqlite_plugin_adminbar_show', '__return_true' );
 if ( $show_sqlite_adminbar ) {
 	add_action( 'admin_bar_menu', 'sqlite_plugin_adminbar_item', 999 );
 }


### PR DESCRIPTION
I believe the goal should always be to surface the SQLite database state transparently, however that should be balanced with providing a WordPress experience that feels native, doesn't have excess clutter in screenshots, etc.

The current implementation's UX could either use a little refinement or relocation.

As the SQLite state is surfaced in the database, I think this proposed filter and/or...
* Reducing the surface area/color prescription on the Admin Bar
* Tucking this item under the WordPress menu item in the Admin Bar as a secondary item that doesn't take up to-level area, but could be noted through some kind of notification indicator dot or other treatment on the WordPress logo mark.