### PR TITLE
Add support for running queries without STRICT_TRANS_TABLES mode

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1938,8 +1938,6 @@ QUERY
 		$this->assertQuery( 'DELETE FROM _options' );
 	}
 
-
-
 	public function testOnConflictReplace()
 	{
 		$this->assertQuery(

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -374,7 +374,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_login',
 					'Type'    => 'varchar(60)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -382,7 +382,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_pass',
 					'Type'    => 'varchar(255)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -390,7 +390,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_nicename',
 					'Type'    => 'varchar(50)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -398,7 +398,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_email',
 					'Type'    => 'varchar(100)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -406,7 +406,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_url',
 					'Type'    => 'varchar(100)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -414,7 +414,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_registered',
 					'Type'    => 'datetime',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '0000-00-00 00:00:00',
 					'Extra'   => '',
@@ -422,7 +422,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_activation_key',
 					'Type'    => 'varchar(255)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -430,7 +430,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_status',
 					'Type'    => 'int(11)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '0',
 					'Extra'   => '',
@@ -438,7 +438,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'display_name',
 					'Type'    => 'varchar(250)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -488,7 +488,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'name',
 					'Type'    => 'varchar(20)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -524,7 +524,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'name',
 					'Type'    => 'varchar(20)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -1091,7 +1091,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'option_name',
 					'Type'    => 'text',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -1099,7 +1099,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'option_value',
 					'Type'    => 'text',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -1320,7 +1320,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'object_id',
 					'Type'    => 'bigint(20) unsigned',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => 'PRI',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1328,7 +1328,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'term_taxonomy_id',
 					'Type'    => 'bigint(20) unsigned',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => 'PRI',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1336,7 +1336,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'term_name',
 					'Type'    => 'varchar(11)',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1369,7 +1369,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'object_id',
 					'Type'    => 'bigint(20) unsigned',
-					'Null'    => 'YES',
+					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1938,36 +1938,24 @@ QUERY
 		$this->assertQuery( 'DELETE FROM _options' );
 	}
 
-	public function testIgnoreNotNull()
+
+
+	public function testOnConflictReplace()
 	{
 		$this->assertQuery(
-			"INSERT INTO _options VALUES(1,'test', NULL)"
-		);
-		$this->assertEquals(
-			'',
-			$this->assertQuery(
-				"SELECT option_value FROM _options WHERE option_name = 'test'"
-			)[0]->option_value
+			"CREATE TABLE _tmp_table (
+				ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+				name varchar(20) NOT NULL default 'default-value',
+				UNIQUE KEY name (name)
+			);"
 		);
 
 		$this->assertQuery(
-			"UPDATE _options SET option_value = '1' WHERE option_name = 'test'"
+			"INSERT INTO _tmp_table (name) VALUES (null);"
 		);
 		$this->assertEquals(
-			'1',
-			$this->assertQuery(
-				"SELECT option_value FROM _options WHERE option_name = 'test'"
-			)[0]->option_value
-		);
-
-		$this->assertQuery(
-			"UPDATE _options SET option_value = NULL WHERE option_name = 'test'"
-		);
-		$this->assertEquals(
-			'',
-			$this->assertQuery(
-				"SELECT option_value FROM _options WHERE option_name = 'test'"
-			)[0]->option_value
+			'default-value',
+			$this->assertQuery("SELECT name FROM _tmp_table")[0]->name
 		);
 	}
 }

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1944,16 +1944,56 @@ QUERY
 			"CREATE TABLE _tmp_table (
 				ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 				name varchar(20) NOT NULL default 'default-value',
-				UNIQUE KEY name (name)
+				unique_name varchar(20) NOT NULL default 'unique-default-value',
+				inline_unique_name varchar(20) NOT NULL default 'inline-unique-default-value',
+				UNIQUE KEY unique_name (unique_name)
 			);"
 		);
 
 		$this->assertQuery(
-			"INSERT INTO _tmp_table (name) VALUES (null);"
+			"INSERT INTO _tmp_table (ID, name, unique_name, inline_unique_name) VALUES (1, null, null, null);"
 		);
+		$result = $this->assertQuery("SELECT name, unique_name, inline_unique_name FROM _tmp_table");
+
+		$result = $this->assertQuery("SELECT name, unique_name, inline_unique_name FROM _tmp_table");
 		$this->assertEquals(
-			'default-value',
-			$this->assertQuery("SELECT name FROM _tmp_table")[0]->name
+			array(
+				(object) array(
+					'name' => 'default-value',
+					'unique_name' => 'unique-default-value',
+					'inline_unique_name' => 'inline-unique-default-value',
+				),
+			),
+			$result
+		);
+
+		$this->assertQuery(
+			"INSERT INTO _tmp_table (ID, name, unique_name, inline_unique_name) VALUES (2, '1', '2', '3');"
+		);
+		$this->assertQuery(
+			"UPDATE _tmp_table SET name = null WHERE ID = 2;"
+		);
+
+		$result = $this->assertQuery("SELECT name FROM _tmp_table WHERE ID = 2");
+		$this->assertEquals(
+			array(
+				(object) array(
+					'name' => 'default-value',
+				),
+			),
+			$result
+		);
+
+		// This should fail because of the UNIQUE constraint
+		$this->assertQuery(
+			"UPDATE _tmp_table SET unique_name = NULL WHERE ID = 2;",
+			'UNIQUE constraint failed: _tmp_table.unique_name'
+		);
+
+		// Inline unique constraint aren't supported currently, so this should pass
+		$this->assertQuery(
+			"UPDATE _tmp_table SET inline_unique_name = NULL WHERE ID = 2;",
+			''
 		);
 	}
 }

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -374,7 +374,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_login',
 					'Type'    => 'varchar(60)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -382,7 +382,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_pass',
 					'Type'    => 'varchar(255)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -390,7 +390,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_nicename',
 					'Type'    => 'varchar(50)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -398,7 +398,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_email',
 					'Type'    => 'varchar(100)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -406,7 +406,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_url',
 					'Type'    => 'varchar(100)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -414,7 +414,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_registered',
 					'Type'    => 'datetime',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '0000-00-00 00:00:00',
 					'Extra'   => '',
@@ -422,7 +422,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_activation_key',
 					'Type'    => 'varchar(255)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -430,7 +430,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'user_status',
 					'Type'    => 'int(11)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '0',
 					'Extra'   => '',
@@ -438,7 +438,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'display_name',
 					'Type'    => 'varchar(250)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -488,7 +488,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'name',
 					'Type'    => 'varchar(20)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -524,7 +524,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'name',
 					'Type'    => 'varchar(20)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -1091,7 +1091,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'option_name',
 					'Type'    => 'text',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -1099,7 +1099,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'option_value',
 					'Type'    => 'text',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '',
 					'Extra'   => '',
@@ -1320,7 +1320,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'object_id',
 					'Type'    => 'bigint(20) unsigned',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => 'PRI',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1328,7 +1328,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'term_taxonomy_id',
 					'Type'    => 'bigint(20) unsigned',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => 'PRI',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1336,7 +1336,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'term_name',
 					'Type'    => 'varchar(11)',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1369,7 +1369,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				(object) array(
 					'Field'   => 'object_id',
 					'Type'    => 'bigint(20) unsigned',
-					'Null'    => 'NO',
+					'Null'    => 'YES',
 					'Key'     => '',
 					'Default' => '0',
 					'Extra'   => '',
@@ -1936,5 +1936,38 @@ QUERY
 		);
 
 		$this->assertQuery( 'DELETE FROM _options' );
+	}
+
+	public function testIgnoreNotNull()
+	{
+		$this->assertQuery(
+			"INSERT INTO _options VALUES(1,'test', NULL)"
+		);
+		$this->assertEquals(
+			'',
+			$this->assertQuery(
+				"SELECT option_value FROM _options WHERE option_name = 'test'"
+			)[0]->option_value
+		);
+
+		$this->assertQuery(
+			"UPDATE _options SET option_value = '1' WHERE option_name = 'test'"
+		);
+		$this->assertEquals(
+			'1',
+			$this->assertQuery(
+				"SELECT option_value FROM _options WHERE option_name = 'test'"
+			)[0]->option_value
+		);
+
+		$this->assertQuery(
+			"UPDATE _options SET option_value = NULL WHERE option_name = 'test'"
+		);
+		$this->assertEquals(
+			'',
+			$this->assertQuery(
+				"SELECT option_value FROM _options WHERE option_name = 'test'"
+			)[0]->option_value
+		);
 	}
 }

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1097,7 +1097,7 @@ class WP_SQLite_Translator {
 				/**
 				 * WPDB removes the STRICT_TRANS_TABLES mode from MySQL queries.
 				 * This mode allows the use of `NULL` when NOT NULL is set on a column which falls back to DEFAULT.
-				 * SQLite does not support this behavior so we need to remove the NOT NULL constraint when DEFAULT exists..
+				 * SQLite does not support this behavior so we need to remove the NOT NULL constraint when DEFAULT exists.
 				 */
 				$result->not_null = false;
 				continue;

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1125,7 +1125,7 @@ class WP_SQLite_Translator {
 		}
 		/**
 		 * WPDB removes the STRICT_TRANS_TABLES mode from MySQL queries.
-		 * This mode allows the use of `NULL` when NOT NULL is set on a column which falls back to DEFAULT.
+		 * This mode allows the use of `NULL` when NOT NULL is set on a column that falls back to DEFAULT.
 		 * SQLite does not support this behavior, so we need to add the `ON CONFLICT REPLACE` clause to the column definition.
 		 */
 		if (null !== $field->default && $field->not_null) {

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1094,12 +1094,6 @@ class WP_SQLite_Translator {
 				array( 'DEFAULT' )
 			) ) {
 				$result->default = $this->rewriter->consume()->token;
-				/**
-				 * WPDB removes the STRICT_TRANS_TABLES mode from MySQL queries.
-				 * This mode allows the use of `NULL` when NOT NULL is set on a column which falls back to DEFAULT.
-				 * SQLite does not support this behavior so we need to remove the NOT NULL constraint when DEFAULT exists.
-				 */
-				$result->not_null = false;
 				continue;
 			}
 
@@ -1128,6 +1122,14 @@ class WP_SQLite_Translator {
 		}
 		if ( $field->not_null ) {
 			$definition .= ' NOT NULL';
+		}
+		/**
+		 * WPDB removes the STRICT_TRANS_TABLES mode from MySQL queries.
+		 * This mode allows the use of `NULL` when NOT NULL is set on a column which falls back to DEFAULT.
+		 * SQLite does not support this behavior, so we need to add the `ON CONFLICT REPLACE` clause to the column definition.
+		 */
+		if (null !== $field->default && $field->not_null) {
+			$definition .= ' ON CONFLICT REPLACE';
 		}
 		if ( null !== $field->default ) {
 			$definition .= ' DEFAULT ' . $field->default;

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1054,7 +1054,7 @@ class WP_SQLite_Translator {
 		$result->sqlite_data_type   = $skip_mysql_data_type_parts[0];
 		$result->mysql_data_type    = $skip_mysql_data_type_parts[1];
 
-		// Look for the NOT NULL and AUTO_INCREMENT flags.
+		// Look for the NOT NULL, PRIMARY KEY, DEFAULT, and AUTO_INCREMENT flags.
 		while ( true ) {
 			$token = $this->rewriter->skip();
 			if ( ! $token ) {
@@ -1094,6 +1094,12 @@ class WP_SQLite_Translator {
 				array( 'DEFAULT' )
 			) ) {
 				$result->default = $this->rewriter->consume()->token;
+				/**
+				 * WPDB removes the STRICT_TRANS_TABLES mode from MySQL queries.
+				 * This mode allows the use of `NULL` when NOT NULL is set on a column which falls back to DEFAULT.
+				 * SQLite does not support this behavior so we need to remove the NOT NULL constraint when DEFAULT exists..
+				 */
+				$result->not_null = false;
 				continue;
 			}
 
@@ -3207,8 +3213,8 @@ class WP_SQLite_Translator {
 				$database_expression = $this->rewriter->skip();
 				$stmt                = $this->execute_sqlite_query(
 					<<<SQL
-					SELECT 
-						name as `Name`, 
+					SELECT
+						name as `Name`,
 						'myisam' as `Engine`,
 						10 as `Version`,
 						'Fixed' as `Row_format`,
@@ -3226,13 +3232,13 @@ class WP_SQLite_Translator {
 						null as `Checksum`,
 						'' as `Create_options`,
 						'' as `Comment`
-					FROM sqlite_master 
+					FROM sqlite_master
 					WHERE
-						type='table' 
+						type='table'
 						AND name LIKE :pattern
 					ORDER BY name
 SQL,
-					
+
 					array(
 						':pattern' => $pattern,
 					)


### PR DESCRIPTION
[WPDB removes the STRICT_TRANS_TABLES mode](https://github.com/WordPress/WordPress/blob/master/wp-includes/class-wpdb.php#L648) from MySQL queries.
This mode allows the use of `NULL` when NOT NULL is set on a column that falls back to DEFAULT.
SQLite does not support this behavior, so we need to add the `ON CONFLICT REPLACE` clause to the column definition.

This PR changes the behavior of `CREATE` able to insert `ON CONFLICT REPLACE` when `NOT NULL` and `DEFAULT` exist.
This ensures when `NULL` is passed as a value it stores the `DEFAULT` as the value.

## Testing

Ensure tests pass by running `./vendor/bin/phpunit`.