### PR TITLE
Replace <<<SQL with " to fix PHP 7 compatibility

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3214,8 +3214,7 @@ class WP_SQLite_Translator {
 
 				$database_expression = $this->rewriter->skip();
 				$stmt                = $this->execute_sqlite_query(
-					<<<SQL
-					SELECT
+					"SELECT
 						name as `Name`,
 						'myisam' as `Engine`,
 						10 as `Version`,
@@ -3238,8 +3237,7 @@ class WP_SQLite_Translator {
 					WHERE
 						type='table'
 						AND name LIKE :pattern
-					ORDER BY name
-SQL,
+					ORDER BY name",
 
 					array(
 						':pattern' => $pattern,


### PR DESCRIPTION
<<<SQL breaks PHP 7 compatibility in WordPress Playground.

This PR replaces <<<SQL with `""`

## Testing instructions

Ensure tests pass by running ./vendor/bin/phpunit.