### PR TITLE
Support UPDATE LIMIT

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -133,6 +133,9 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertQuery(
 			"INSERT INTO _dates (option_name, option_value) VALUES ('first', '2003-05-27 00:00:45');"
 		);
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('second', '2003-05-28 00:00:45');"
+		);
 
 		$this->assertQuery(
 			"UPDATE _dates SET option_value = '2001-05-27 10:08:48' WHERE option_name = 'first' ORDER BY option_name LIMIT 1;"
@@ -140,13 +143,18 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$results = $this->engine->get_query_results();
 
 		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first';" );
+		$result2 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='second';" );
 
 		$this->assertEquals( '2001-05-27 10:08:48', $result1[0]->option_value );
+		$this->assertEquals( '2003-05-28 00:00:45', $result2[0]->option_value );
 	}
 
 	public function testUpdateWithLimitNoEndToken() {
 		$this->assertQuery(
 			"INSERT INTO _dates (option_name, option_value) VALUES ('first', '2003-05-27 00:00:45')"
+		);
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('second', '2003-05-28 00:00:45')"
 		);
 
 		$this->assertQuery(
@@ -155,8 +163,10 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$results = $this->engine->get_query_results();
 
 		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first'" );
+		$result2 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='second'" );
 
 		$this->assertEquals( '2001-05-27 10:08:48', $result1[0]->option_value );
+		$this->assertEquals( '2003-05-28 00:00:45', $result2[0]->option_value );
 	}
 
 	public function testCastAsBinary() {

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -129,6 +129,36 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertEquals( gmdate( 'Y' ), $results[0]->y );
 	}
 
+	public function testUpdateWithLimit() {
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('first', '2003-05-27 00:00:45');"
+		);
+
+		$this->assertQuery(
+			"UPDATE _dates SET option_value = '2001-05-27 10:08:48' WHERE option_name = 'first' ORDER BY option_name LIMIT 1;"
+		);
+		$results = $this->engine->get_query_results();
+
+		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first';" );
+
+		$this->assertEquals( '2001-05-27 10:08:48', $result1[0]->option_value );
+	}
+
+	public function testUpdateWithLimitNoEndToken() {
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('first', '2003-05-27 00:00:45')"
+		);
+
+		$this->assertQuery(
+			"UPDATE _dates SET option_value = '2001-05-27 10:08:48' WHERE option_name = 'first' ORDER BY option_name LIMIT 1"
+		);
+		$results = $this->engine->get_query_results();
+
+		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first'" );
+
+		$this->assertEquals( '2001-05-27 10:08:48', $result1[0]->option_value );
+	}
+
 	public function testCastAsBinary() {
 		$this->assertQuery(
 			// Use a confusing alias to make sure it replaces only the correct token

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -140,13 +140,26 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertQuery(
 			"UPDATE _dates SET option_value = '2001-05-27 10:08:48' WHERE option_name = 'first' ORDER BY option_name LIMIT 1;"
 		);
-		$results = $this->engine->get_query_results();
 
 		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first';" );
 		$result2 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='second';" );
 
 		$this->assertEquals( '2001-05-27 10:08:48', $result1[0]->option_value );
 		$this->assertEquals( '2003-05-28 00:00:45', $result2[0]->option_value );
+
+		$this->assertQuery(
+			"UPDATE _dates SET option_value = '2001-05-27 10:08:49' WHERE option_name = 'first';"
+		);
+		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first';" );
+		$this->assertEquals( '2001-05-27 10:08:49', $result1[0]->option_value );
+
+		$this->assertQuery(
+			"UPDATE _dates SET option_value = '2001-05-12 10:00:40' WHERE option_name in ( SELECT option_name from _dates );"
+		);
+		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first';" );
+		$result2 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='second';" );
+		$this->assertEquals( '2001-05-12 10:00:40', $result1[0]->option_value );
+		$this->assertEquals( '2001-05-12 10:00:40', $result2[0]->option_value );
 	}
 
 	public function testUpdateWithLimitNoEndToken() {
@@ -167,6 +180,20 @@ class WP_SQLite_Translator_Tests extends TestCase {
 
 		$this->assertEquals( '2001-05-27 10:08:48', $result1[0]->option_value );
 		$this->assertEquals( '2003-05-28 00:00:45', $result2[0]->option_value );
+
+		$this->assertQuery(
+			"UPDATE _dates SET option_value = '2001-05-27 10:08:49' WHERE option_name = 'first'"
+		);
+		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first'" );
+		$this->assertEquals( '2001-05-27 10:08:49', $result1[0]->option_value );
+
+		$this->assertQuery(
+			"UPDATE _dates SET option_value = '2001-05-12 10:00:40' WHERE option_name in ( SELECT option_name from _dates )"
+		);
+		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first'" );
+		$result2 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='second'" );
+		$this->assertEquals( '2001-05-12 10:00:40', $result1[0]->option_value );
+		$this->assertEquals( '2001-05-12 10:00:40', $result2[0]->option_value );
 	}
 
 	public function testCastAsBinary() {

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -227,12 +227,12 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$return = $this->assertQuery(
 			"UPDATE _dates SET option_value = 'second' LIMIT 1"
 		);
-		$this->assertSame( 2, $return, 'UPDATE query did not return 2 when two row were changed' );
+		$this->assertSame( 1, $return, 'UPDATE query did not return 2 when two row were changed' );
 		
 		$result1 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='first'" );
 		$result2 = $this->engine->query( "SELECT option_value FROM _dates WHERE option_name='second'" );
-		$this->assertEquals( '2003-05-27 10:08:48', $result1[0]->option_value );
-		$this->assertEquals( 'second', $result2[0]->option_value );
+		$this->assertEquals( 'second', $result1[0]->option_value );
+		$this->assertEquals( '2003-05-27 10:08:48', $result2[0]->option_value );
 	}
 
 	public function testCastAsBinary() {

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1620,21 +1620,25 @@ class WP_SQLite_Translator {
 	}
 
 	private function prepare_update_for_limit_or_order() {
-			$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
-			$this->rewriter->add( new WP_SQLite_Token( 'rowid', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ) );
-			$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
-			$this->rewriter->add( new WP_SQLite_Token( 'IN', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ) );
-			$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
-			$this->rewriter->add( new WP_SQLite_Token( '(', WP_SQLite_Token::TYPE_OPERATOR ) );
-			$this->rewriter->add( new WP_SQLite_Token( 'SELECT', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ) );
-			$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
-			$this->rewriter->add( new WP_SQLite_Token( 'rowid', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ) );
-			$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
-			$this->rewriter->add( new WP_SQLite_Token( 'FROM', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ) );
-			$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
-			$this->rewriter->add( new WP_SQLite_Token( $this->table_name, WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ) );
-			$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
-			$this->rewriter->add( new WP_SQLite_Token( 'WHERE', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ) );
+		$this->rewriter->add_many(
+			array(
+				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
+				new WP_SQLite_Token( 'rowid', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
+				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
+				new WP_SQLite_Token( 'IN', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
+				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
+				new WP_SQLite_Token( '(', WP_SQLite_Token::TYPE_OPERATOR ),
+				new WP_SQLite_Token( 'SELECT', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
+				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
+				new WP_SQLite_Token( 'rowid', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
+				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
+				new WP_SQLite_Token( 'FROM', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
+				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
+				new WP_SQLite_Token( $this->table_name, WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
+				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
+				new WP_SQLite_Token( 'WHERE', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
+			)
+		);
 	}
 	/**
 	 * Executes a INSERT or REPLACE statement.

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1550,7 +1550,7 @@ class WP_SQLite_Translator {
 	 */
 	private function execute_update() {
 		$this->rewriter->consume(); // Update.
-		$limit = $this->rewriter->peek(
+		$limit    = $this->rewriter->peek(
 			array(
 				'type'  => WP_SQLite_Token::TYPE_KEYWORD,
 				'value' => 'LIMIT',
@@ -1562,13 +1562,13 @@ class WP_SQLite_Translator {
 				'value' => 'ORDER BY',
 			)
 		);
-		$where = $this->rewriter->peek(
+		$where    = $this->rewriter->peek(
 			array(
 				'type'  => WP_SQLite_Token::TYPE_KEYWORD,
 				'value' => 'WHERE',
 			)
 		);
-		$params = array();
+		$params   = array();
 		while ( true ) {
 			$token = $this->rewriter->peek();
 			if ( ! $token ) {
@@ -1579,6 +1579,10 @@ class WP_SQLite_Translator {
 				$this->remember_last_reserved_keyword( $token );
 				$this->rewriter->consume();
 				$this->prepare_update_for_limit_or_order();
+			}
+
+			if ( $token->value === ';' && ( $limit || $order_by ) ) {
+				$this->rewriter->skip();
 			}
 
 			// Record the table name.
@@ -1604,8 +1608,8 @@ class WP_SQLite_Translator {
 			$this->rewriter->consume();
 		}
 
-		if ( $where && ( $limit || $order_by )  ) {
-			$this->rewriter->add( new WP_SQLite_Token( ')', WP_SQLite_Token::TYPE_OPERATOR ));
+		if ( $where && ( $limit || $order_by ) ) {
+			$this->rewriter->add( new WP_SQLite_Token( ')', WP_SQLite_Token::TYPE_OPERATOR ) );
 		}
 
 		$this->rewriter->consume_all();

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1582,12 +1582,10 @@ class WP_SQLite_Translator {
 						new WP_SQLite_Token('WHERE', WP_SQLite_Token::TYPE_KEYWORD),
 					);
 					$needs_closing_parenthesis = true;
-					$this->remember_last_reserved_keyword($token);
 					$this->prepare_update_nested_query();
 				} else if ($token->value === 'WHERE') {
 					$has_where = true;
 					$needs_closing_parenthesis = true;
-					$this->remember_last_reserved_keyword($token);
 					$this->rewriter->consume();
 					$this->prepare_update_nested_query();
 					$this->rewriter->add(

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1598,9 +1598,9 @@ class WP_SQLite_Translator {
 				$this->prepare_update_for_limit_or_order();
 			}
 			/*
-			* In case we rewrite the query, we need to skip the semicolon.
-			* This is because the semicolon becomes part of the nested SELECT statement, and it breaks the query.
-			*/
+			 * In case we rewrite the query, we need to skip the semicolon.
+			 * This is because the semicolon becomes part of the nested SELECT statement, and it breaks the query.
+			 */
 			if ( $token->value === ';' && $token->type === WP_SQLite_Token::TYPE_DELIMITER && ( $limit || $order_by ) ) {
 				$this->rewriter->skip();
 			}

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1581,7 +1581,7 @@ class WP_SQLite_Translator {
 				$this->prepare_update_for_limit_or_order();
 			}
 
-			if ( $token->value === ';' && ( $limit || $order_by ) ) {
+			if ( $token->value === ';' && $token->type === WP_SQLite_Token::TYPE_DELIMITER && ( $limit || $order_by ) ) {
 				$this->rewriter->skip();
 			}
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1547,6 +1547,15 @@ class WP_SQLite_Translator {
 
 	/**
 	 * Executes an UPDATE statement.
+	 * Supported syntax:
+	 *
+	 * UPDATE [LOW_PRIORITY] [IGNORE] table_reference
+	 *    SET assignment_list
+	 *    [WHERE where_condition]
+	 *    [ORDER BY ...]
+	 *    [LIMIT row_count]
+	 *
+	 * @see https://dev.mysql.com/doc/refman/8.0/en/update.html
 	 */
 	private function execute_update() {
 		$this->rewriter->consume(); // Update.


### PR DESCRIPTION
Fixes https://github.com/WordPress/sqlite-database-integration/issues/27

### Proposal
`UPDATE` statement in SQLite, doesn't support `LIMIT` and `ORDER BY` statements.

The current implementation was throwing an error when this case occurred. ( For example when a user tries to add Woo plugin ).

![image](https://github.com/WordPress/sqlite-database-integration/assets/497103/57f1cceb-692d-4010-bee6-d2d45e00c7c9)

This pr aims to fix that.
