### PR TITLE
Fix default null values and NULL value update edge case

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -368,7 +368,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					'Type'    => 'bigint(20) unsigned',
 					'Null'    => 'NO',
 					'Key'     => 'PRI',
-					'Default' => null,
+					'Default' => '0',
 					'Extra'   => '',
 				),
 				(object) array(
@@ -1085,7 +1085,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					'Type'    => 'integer',
 					'Null'    => 'NO',
 					'Key'     => 'PRI',
-					'Default' => null,
+					'Default' => '0',
 					'Extra'   => '',
 				),
 				(object) array(
@@ -2007,9 +2007,9 @@ QUERY
 		$this->assertEquals(
 			array(
 				(object) array(
-					'ID' => '1',
+					'ID' => '2',
 					'name' => 'default-value',
-					'unique_name' => 'unique-default-value',
+					'unique_name' => '2',
 					'inline_unique_name' => 'inline-unique-default-value',
 					'no_default' => '',
 				),

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1996,4 +1996,40 @@ QUERY
 			''
 		);
 	}
+
+	public function testDefaultNullValue()
+	{
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+				name varchar(20) NOT NULL default NULL,
+				no_default varchar(20) NOT NULL
+			);"
+		);
+
+		$result = $this->assertQuery(
+			"DESCRIBE _tmp_table;"
+		);
+		$this->assertEquals(
+			array(
+				(object) array(
+					'Field'   => 'name',
+					'Type'    => 'varchar(20)',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => 'NULL',
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'no_default',
+					'Type'    => 'varchar(20)',
+					'Null'    => 'NO',
+					'Key'     => '',
+					// There is still a bug here if there is no default value Default should be empty of false
+					'Default' => 'NULL',
+					'Extra'   => '',
+				),
+			),
+			$result
+		);
+	}
 }

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1946,29 +1946,30 @@ QUERY
 				name varchar(20) NOT NULL default 'default-value',
 				unique_name varchar(20) NOT NULL default 'unique-default-value',
 				inline_unique_name varchar(20) NOT NULL default 'inline-unique-default-value',
+				no_default varchar(20) NOT NULL,
 				UNIQUE KEY unique_name (unique_name)
 			);"
 		);
 
 		$this->assertQuery(
-			"INSERT INTO _tmp_table (ID, name, unique_name, inline_unique_name) VALUES (1, null, null, null);"
+			"INSERT INTO _tmp_table VALUES (1, null, null, null, '');"
 		);
-		$result = $this->assertQuery("SELECT name, unique_name, inline_unique_name FROM _tmp_table");
-
-		$result = $this->assertQuery("SELECT name, unique_name, inline_unique_name FROM _tmp_table");
+		$result = $this->assertQuery("SELECT * FROM _tmp_table WHERE ID = 1");
 		$this->assertEquals(
 			array(
 				(object) array(
+					'ID' => '1',
 					'name' => 'default-value',
 					'unique_name' => 'unique-default-value',
 					'inline_unique_name' => 'inline-unique-default-value',
+					'no_default' => '',
 				),
 			),
 			$result
 		);
 
 		$this->assertQuery(
-			"INSERT INTO _tmp_table (ID, name, unique_name, inline_unique_name) VALUES (2, '1', '2', '3');"
+			"INSERT INTO _tmp_table VALUES (2, '1', '2', '3', '4');"
 		);
 		$this->assertQuery(
 			"UPDATE _tmp_table SET name = null WHERE ID = 2;"
@@ -1994,6 +1995,26 @@ QUERY
 		$this->assertQuery(
 			"UPDATE _tmp_table SET inline_unique_name = NULL WHERE ID = 2;",
 			''
+		);
+
+		// WPDB allows for NULL values in columns that don't have a default value and a NOT NULL constraint
+		$this->assertQuery(
+			"UPDATE _tmp_table SET no_default = NULL WHERE ID = 2;",
+			''
+		);
+
+		$result = $this->assertQuery("SELECT * FROM _tmp_table WHERE ID = 2");
+		$this->assertEquals(
+			array(
+				(object) array(
+					'ID' => '1',
+					'name' => 'default-value',
+					'unique_name' => 'unique-default-value',
+					'inline_unique_name' => 'inline-unique-default-value',
+					'no_default' => '',
+				),
+			),
+			$result
 		);
 	}
 

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -2024,8 +2024,7 @@ QUERY
 					'Type'    => 'varchar(20)',
 					'Null'    => 'NO',
 					'Key'     => '',
-					// There is still a bug here if there is no default value Default should be empty of false
-					'Default' => 'NULL',
+					'Default' => null,
 					'Extra'   => '',
 				),
 			),

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1128,10 +1128,12 @@ class WP_SQLite_Translator {
 		 * This mode allows the use of `NULL` when NOT NULL is set on a column that falls back to DEFAULT.
 		 * SQLite does not support this behavior, so we need to add the `ON CONFLICT REPLACE` clause to the column definition.
 		 */
-		if (null !== $field->default && $field->not_null) {
+		if ($field->not_null) {
 			$definition .= ' ON CONFLICT REPLACE';
 		}
-		if ( null !== $field->default ) {
+		if (null === $field->default) {
+			$definition .= ' DEFAULT NULL';
+		} else if (false !== $field->default) {
 			$definition .= ' DEFAULT ' . $field->default;
 		}
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1131,14 +1131,20 @@ class WP_SQLite_Translator {
 		if ($field->not_null) {
 			$definition .= ' ON CONFLICT REPLACE';
 		}
+		/**
+		 * The value of DEFAULT can be NULL. PHP would print this as an empty string, so we need a special case for it.
+		 */
 		if (null === $field->default) {
 			$definition .= ' DEFAULT NULL';
 		} else if (false !== $field->default) {
 			$definition .= ' DEFAULT ' . $field->default;
 		} else if ($field->not_null) {
+			/**
+			 * If the column is NOT NULL, we need to provide a default value to match WPDB behavior caused by removing the STRICT_TRANS_TABLES mode.
+			 */
 			if ('text' === $field->sqlite_data_type) {
 				$definition .= ' DEFAULT \'\'';
-			} else {
+			} else if (in_array($field->sqlite_data_type, array('integer', 'real'), true)) {
 				$definition .= ' DEFAULT 0';
 			}
 		}

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1135,6 +1135,12 @@ class WP_SQLite_Translator {
 			$definition .= ' DEFAULT NULL';
 		} else if (false !== $field->default) {
 			$definition .= ' DEFAULT ' . $field->default;
+		} else if ($field->not_null) {
+			if ('text' === $field->sqlite_data_type) {
+				$definition .= ' DEFAULT \'\'';
+			} else {
+				$definition .= ' DEFAULT 0';
+			}
 		}
 
 		/*

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1040,7 +1040,7 @@ class WP_SQLite_Translator {
 		$result->name             = '';
 		$result->sqlite_data_type = '';
 		$result->not_null         = false;
-		$result->default          = null;
+		$result->default          = false;
 		$result->auto_increment   = false;
 		$result->primary_key      = false;
 


### PR DESCRIPTION
This PR allows SQL to set `DEFAULT NULL` which currently isn't supported because the code is built as `DEFAULT ` (empty value instead of _NULL_).

It also adds support for updating a field to `NULL` that is `NOT NULL` and doesn't have a `DEFAULT` value.
The result of the update should be an empty value (_''_ for text and _0_ for numbers).

## Testing instructions

- confirm that all tests pass