### PR TITLE
Support FORCE INDEX queries

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -146,6 +146,22 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertEquals( 1, $result[0]->output );
 	}
 
+	public function testSelectIndexHintForce() {
+		$this->assertQuery( "INSERT INTO _options (option_name) VALUES ('first');" );
+		$result = $this->assertQuery(
+			'SELECT 1 as output FROM _options FORCE INDEX (PRIMARY, post_parent) WHERE 1=1'
+		);
+		$this->assertEquals( 1, $result[0]->output );
+	}
+
+	public function testSelectIndexHintUseGroup() {
+		$this->assertQuery( "INSERT INTO _options (option_name) VALUES ('first');" );
+		$result = $this->assertQuery(
+			'SELECT 1 as output FROM _options USE KEY FOR GROUP BY (PRIMARY, post_parent) WHERE 1=1'
+		);
+		$this->assertEquals( 1, $result[0]->output );
+	}
+
 	public function testLeftFunction1Char() {
 		$result = $this->assertQuery(
 			'SELECT LEFT("abc", 1) as output'

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1419,7 +1419,7 @@ class WP_SQLite_Translator {
 			if ( $this->skip_index_hint() ) {
 				continue;
 			}
-			
+
 			$this->rewriter->consume();
 		}
 		$this->rewriter->consume_all();
@@ -1474,32 +1474,31 @@ class WP_SQLite_Translator {
 
 	/**
 	 * Ignores the FORCE INDEX clause
-	 * 
-	 * 
+	 *
+	 *
 	 *    USE {INDEX|KEY}
-     *      [FOR {JOIN|ORDER BY|GROUP BY}] ([index_list])
-  	 *  | {IGNORE|FORCE} {INDEX|KEY}
-     *      [FOR {JOIN|ORDER BY|GROUP BY}] (index_list)
+	 *      [FOR {JOIN|ORDER BY|GROUP BY}] ([index_list])
+	 *  | {IGNORE|FORCE} {INDEX|KEY}
+	 *      [FOR {JOIN|ORDER BY|GROUP BY}] (index_list)
 	 * @see https://dev.mysql.com/doc/refman/8.3/en/index-hints.html
 	 * @return bool
 	 */
-	private function skip_index_hint()
-	{
+	private function skip_index_hint() {
 		$force = $this->rewriter->peek();
 		if ( ! $force || ! $force->matches(
-			WP_SQLite_Token::TYPE_KEYWORD,
-			WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
-			array( 'USE', 'FORCE', 'IGNORE' )
-		) ) {
+				WP_SQLite_Token::TYPE_KEYWORD,
+				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+				array( 'USE', 'FORCE', 'IGNORE' )
+			) ) {
 			return false;
 		}
 
-		$index = $this->rewriter->peek_nth(2);
-		if ( ! $index || !$index->matches(
-			WP_SQLite_Token::TYPE_KEYWORD,
-			WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
-			array( 'INDEX', 'KEY' )
-		) ) {
+		$index = $this->rewriter->peek_nth( 2 );
+		if ( ! $index || ! $index->matches(
+				WP_SQLite_Token::TYPE_KEYWORD,
+				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+				array( 'INDEX', 'KEY' )
+			) ) {
 			return false;
 		}
 
@@ -1508,18 +1507,18 @@ class WP_SQLite_Translator {
 
 		$maybe_for = $this->rewriter->peek();
 		if ( $maybe_for && $maybe_for->matches(
-			WP_SQLite_Token::TYPE_KEYWORD,
-			WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
-			array( 'FOR' )
-		) ) {
+				WP_SQLite_Token::TYPE_KEYWORD,
+				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+				array( 'FOR' )
+			) ) {
 			$this->rewriter->skip(); // FOR
 
 			$token = $this->rewriter->peek();
 			if ( $token && $token->matches(
-				WP_SQLite_Token::TYPE_KEYWORD,
-				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
-				array( 'JOIN', 'ORDER', 'GROUP' )
-			) ) {
+					WP_SQLite_Token::TYPE_KEYWORD,
+					WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+					array( 'JOIN', 'ORDER', 'GROUP' )
+				) ) {
 				$this->rewriter->skip(); // JOIN, ORDER, GROUP
 				if ( 'BY' === strtoupper( $this->rewriter->peek()->value ) ) {
 					$this->rewriter->skip(); // BY
@@ -3277,8 +3276,8 @@ class WP_SQLite_Translator {
 				$database_expression = $this->rewriter->skip();
 				$stmt                = $this->execute_sqlite_query(
 					<<<SQL
-					SELECT 
-						name as `Name`, 
+					SELECT
+						name as `Name`,
 						'myisam' as `Engine`,
 						10 as `Version`,
 						'Fixed' as `Row_format`,
@@ -3296,13 +3295,13 @@ class WP_SQLite_Translator {
 						null as `Checksum`,
 						'' as `Create_options`,
 						'' as `Comment`
-					FROM sqlite_master 
+					FROM sqlite_master
 					WHERE
-						type='table' 
+						type='table'
 						AND name LIKE :pattern
 					ORDER BY name
 SQL,
-					
+
 					array(
 						':pattern' => $pattern,
 					)

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1416,6 +1416,10 @@ class WP_SQLite_Translator {
 				continue;
 			}
 
+			if ( $this->skip_index_hint() ) {
+				continue;
+			}
+			
 			$this->rewriter->consume();
 		}
 		$this->rewriter->consume_all();
@@ -1466,6 +1470,72 @@ class WP_SQLite_Translator {
 				$stmt->fetchAll( $this->pdo_fetch_mode )
 			);
 		}
+	}
+
+	/**
+	 * Ignores the FORCE INDEX clause
+	 * 
+	 * 
+	 *    USE {INDEX|KEY}
+     *      [FOR {JOIN|ORDER BY|GROUP BY}] ([index_list])
+  	 *  | {IGNORE|FORCE} {INDEX|KEY}
+     *      [FOR {JOIN|ORDER BY|GROUP BY}] (index_list)
+	 * @see https://dev.mysql.com/doc/refman/8.3/en/index-hints.html
+	 * @return bool
+	 */
+	private function skip_index_hint()
+	{
+		$force = $this->rewriter->peek();
+		if ( ! $force || ! $force->matches(
+			WP_SQLite_Token::TYPE_KEYWORD,
+			WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+			array( 'USE', 'FORCE', 'IGNORE' )
+		) ) {
+			return false;
+		}
+
+		$index = $this->rewriter->peek_nth(2);
+		if ( ! $index || !$index->matches(
+			WP_SQLite_Token::TYPE_KEYWORD,
+			WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+			array( 'INDEX', 'KEY' )
+		) ) {
+			return false;
+		}
+
+		$this->rewriter->skip(); // USE, FORCE, IGNORE
+		$this->rewriter->skip(); // INDEX, KEY
+
+		$maybe_for = $this->rewriter->peek();
+		if ( $maybe_for && $maybe_for->matches(
+			WP_SQLite_Token::TYPE_KEYWORD,
+			WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+			array( 'FOR' )
+		) ) {
+			$this->rewriter->skip(); // FOR
+
+			$token = $this->rewriter->peek();
+			if ( $token && $token->matches(
+				WP_SQLite_Token::TYPE_KEYWORD,
+				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+				array( 'JOIN', 'ORDER', 'GROUP' )
+			) ) {
+				$this->rewriter->skip(); // JOIN, ORDER, GROUP
+				if ( 'BY' === strtoupper( $this->rewriter->peek()->value ) ) {
+					$this->rewriter->skip(); // BY
+				}
+			}
+		}
+
+		// Skip everything until the closing parenthesis.
+		$this->rewriter->skip(
+			array(
+				'type'  => WP_SQLite_Token::TYPE_OPERATOR,
+				'value' => ')',
+			)
+		);
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Adds support for a legacy MySQL syntax where SELECT queries can contain FORCE INDEX keywords. It forces the database to use an index when it otherwise wouldn't. With this PR, the SQLite query translator will ignore that part of the query.

Closes #45

 ## Testing instructions

Confirm the unit tests pass:

```
php ./vendor/bin/phpunit -c ./phpunit.xml.dist
```