### PR TITLE
Tolerate selecting MySQL system variables

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -2252,8 +2252,8 @@ QUERY
 	 * @dataProvider mysqlVariablesToTest
 	 */
 	public function testSelectVariable( $variable_name ) {
+		// Make sure the query does not error
 		$this->assertQuery( "SELECT $variable_name;" );
-		// TODO: Assert about results once we provide them
 	}
 
 	public static function mysqlVariablesToTest() {
@@ -2272,9 +2272,4 @@ QUERY
 			array( '@@SESSION.sql_mode' ),
 		);
 	}
-
-	// TODO:
-	//public function testSelectUnsupportedVariable() {
-	//	// TODO
-	//}
 }

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -2258,7 +2258,6 @@ QUERY
 
 	public static function mysqlVariablesToTest() {
 		return array(
-			// TODO: generate variable name permutations with mixed letter casing
 			// NOTE: This list was derived from the variables used by the UpdraftPlus plugin.
 			// We will start here and plan to expand supported variables over time.
 			array( '@@character_set_client' ),
@@ -2270,6 +2269,11 @@ QUERY
 			array( '@@GLOBAL.sql_mode' ),
 			array( '@@SESSION.max_allowed_packet' ),
 			array( '@@SESSION.sql_mode' ),
+
+			// Intentionally mix letter casing to help demonstrate case-insensitivity
+			array( '@@cHarActer_Set_cLient' ),
+			array( '@@gLoBAL.gTiD_purGed' ),
+			array( '@@sEssIOn.sqL_moDe' ),
 		);
 	}
 }

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -2247,4 +2247,34 @@ QUERY
 			$result
 		);
 	}
+
+	/**
+	 * @dataProvider mysqlVariablesToTest
+	 */
+	public function testSelectVariable( $variable_name ) {
+		$this->assertQuery( "SELECT $variable_name;" );
+		// TODO: Assert about results once we provide them
+	}
+
+	public static function mysqlVariablesToTest() {
+		return array(
+			// TODO: generate variable name permutations with mixed letter casing
+			// NOTE: This list was derived from the variables used by the UpdraftPlus plugin.
+			// We will start here and plan to expand supported variables over time.
+			array( '@@character_set_client' ),
+			array( '@@character_set_results' ),
+			array( '@@collation_connection' ),
+			array( '@@GLOBAL.gtid_purged' ),
+			array( '@@GLOBAL.log_bin' ),
+			array( '@@GLOBAL.log_bin_trust_function_creators' ),
+			array( '@@GLOBAL.sql_mode' ),
+			array( '@@SESSION.max_allowed_packet' ),
+			array( '@@SESSION.sql_mode' ),
+		);
+	}
+
+	// TODO:
+	//public function testSelectUnsupportedVariable() {
+	//	// TODO
+	//}
 }

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1453,8 +1453,9 @@ class WP_SQLite_Translator {
 			$updated_query                     = $this->get_information_schema_query( $updated_query );
 			$params                            = array();
 		} elseif (
-			strpos( $updated_query, '@@SESSION.sql_mode' ) !== false
-			|| strpos( $updated_query, 'CONVERT( ' ) !== false
+			// Examples: @@SESSION.sql_mode or @@GLOBAL.max_allowed_packet
+			preg_match( '/@@((SESSION|GLOBAL)\s*\.\s*)?\w+\b/i', $updated_query ) === 1 ||
+			strpos( $updated_query, 'CONVERT( ' ) !== false
 		) {
 			/*
 			 * If the query contains a function that is not supported by SQLite,

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1453,7 +1453,7 @@ class WP_SQLite_Translator {
 			$updated_query                     = $this->get_information_schema_query( $updated_query );
 			$params                            = array();
 		} elseif (
-			// Examples: @@SESSION.sql_mode or @@GLOBAL.max_allowed_packet
+			// Examples: @@SESSION.sql_mode, @@GLOBAL.max_allowed_packet, @@character_set_client
 			preg_match( '/@@((SESSION|GLOBAL)\s*\.\s*)?\w+\b/i', $updated_query ) === 1 ||
 			strpos( $updated_query, 'CONVERT( ' ) !== false
 		) {


### PR DESCRIPTION
The purpose of this PR is to add more support for selecting MySQL system variables. Fixes #104.

Related to:
https://github.com/WordPress/wordpress-playground/issues/1272 - "UpdraftPlus plugins doesn't fully work in Playground."

We'll start with failing tests for the set used by the UpdraftPlus plugin, but the ideal is to support as many MySQL variables as possible so there are no conflicts when using SQLite (and WordPress Playground).