### PR TITLE
Prevent adding a comma if key isn't in the first position

### DIFF
--- a/tests/WP_SQLite_Query_Tests.php
+++ b/tests/WP_SQLite_Query_Tests.php
@@ -506,16 +506,17 @@ QUERY;
 	}
 
 	public function testOnDuplicateKey() {
-		$this->assertQuery("
-			CREATE TABLE `test` (
+		$this->assertQuery(
+			'CREATE TABLE `test` (
 				`id` INT PRIMARY KEY,
 				`text` VARCHAR(255),
-			);
-		");
+			);'
+		);
 		// The order is deliberate to test that the query works with the keys in any order.
-		$this->assertQuery( "INSERT INTO test (`text`, `id`)
-			VALUES ('test', 1)
-			ON DUPLICATE KEY UPDATE `text` = 'test1'"
+		$this->assertQuery(
+			'INSERT INTO test (`text`, `id`)
+			VALUES ("test", 1)
+			ON DUPLICATE KEY UPDATE `text` = "test1"'
 		);
 	}
 

--- a/tests/WP_SQLite_Query_Tests.php
+++ b/tests/WP_SQLite_Query_Tests.php
@@ -505,6 +505,20 @@ QUERY;
 		$this->assertEquals( $obj, $unserialized );
 	}
 
+	public function testOnDuplicateKey() {
+		$this->assertQuery("
+			CREATE TABLE `test` (
+				`id` INT PRIMARY KEY,
+				`text` VARCHAR(255),
+			);
+		");
+		// The order is deliberate to test that the query works with the keys in any order.
+		$this->assertQuery( "INSERT INTO test (`text`, `id`)
+			VALUES ('test', 1)
+			ON DUPLICATE KEY UPDATE `text` = 'test1'"
+		);
+	}
+
 	public function testShowColumns() {
 
 		$query = 'SHOW COLUMNS FROM wp_posts';

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2803,9 +2803,10 @@ class WP_SQLite_Translator {
 		$this->rewriter->add( new WP_SQLite_Token( '(', WP_SQLite_Token::TYPE_OPERATOR ) );
 
 		$max = count( $conflict_columns );
-		foreach ( $conflict_columns as $i => $conflict_column ) {
+		$i = 0;
+		foreach ( $conflict_columns as $conflict_column ) {
 			$this->rewriter->add( new WP_SQLite_Token( '"' . $conflict_column . '"', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ) );
-			if ( $i !== $max - 1 ) {
+			if ( ++$i < $max ) {
 				$this->rewriter->add( new WP_SQLite_Token( ',', WP_SQLite_Token::TYPE_OPERATOR ) );
 				$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
 			}

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2803,7 +2803,7 @@ class WP_SQLite_Translator {
 		$this->rewriter->add( new WP_SQLite_Token( '(', WP_SQLite_Token::TYPE_OPERATOR ) );
 
 		$max = count( $conflict_columns );
-		$i = 0;
+		$i   = 0;
 		foreach ( $conflict_columns as $conflict_column ) {
 			$this->rewriter->add( new WP_SQLite_Token( '"' . $conflict_column . '"', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ) );
 			if ( ++$i < $max ) {


### PR DESCRIPTION
[WordPress Playground observed an issu](https://github.com/WordPress/wordpress-playground/issues/731)e with insert queries that use `ON DUPLICATE KEY` and don't have the KEY as the first value of the insert.

After investigating it it turns out that the condition for adding commas didn't work well in case the KEY value is in a "random" place.

This PR ensures the comma is added for all items except for the last one. 

## Testing instructions

- Ensure tests pass