### PR TITLE
Bugfixes in SHOW CREATE TABLE and SHOW TABLES

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -258,7 +258,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			'SHOW CREATE TABLE _no_such_table;'
 		);
 		$results = $this->engine->get_query_results();
-		$this->assertCount(0, $results);
+		$this->assertCount( 0, $results );
 	}
 	public function testShowCreateTable1() {
 		$this->assertQuery(

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -260,6 +260,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$results = $this->engine->get_query_results();
 		$this->assertCount( 0, $results );
 	}
+
 	public function testShowCreateTable1() {
 		$this->assertQuery(
 			"CREATE TABLE _tmp_table (

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3238,8 +3238,8 @@ class WP_SQLite_Translator {
 	 */
 	private function execute_show() {
 		$this->rewriter->skip();
-		$what1 = strtoupper($this->rewriter->consume()->token);
-		$what2 = strtoupper($this->rewriter->consume()->token);
+		$what1 = strtoupper( $this->rewriter->consume()->token );
+		$what2 = strtoupper( $this->rewriter->consume()->token );
 		$what  = $what1 . ' ' . $what2;
 		switch ( $what ) {
 			case 'CREATE PROCEDURE':
@@ -3343,7 +3343,7 @@ class WP_SQLite_Translator {
 				$columns    = $this->get_columns_from( $table_name );
 				$keys       = $this->get_keys( $table_name );
 
-				if( empty( $columns ) ) {
+				if ( empty( $columns ) ) {
 					$this->set_results_from_fetched_data(
 						array()
 					);
@@ -3460,7 +3460,7 @@ class WP_SQLite_Translator {
 						':param' => $table_expression->value,
 					)
 				);
-				
+
 				$this->set_results_from_fetched_data(
 					array_column(
 						$stmt->fetchAll( $this->pdo_fetch_mode ),

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3238,8 +3238,8 @@ class WP_SQLite_Translator {
 	 */
 	private function execute_show() {
 		$this->rewriter->skip();
-		$what1 = $this->rewriter->consume()->token;
-		$what2 = $this->rewriter->consume()->token;
+		$what1 = strtoupper($this->rewriter->consume()->token);
+		$what2 = strtoupper($this->rewriter->consume()->token);
 		$what  = $what1 . ' ' . $what2;
 		switch ( $what ) {
 			case 'CREATE PROCEDURE':
@@ -3338,9 +3338,17 @@ class WP_SQLite_Translator {
 				return;
 
 			case 'CREATE TABLE':
-				$table_name = $this->rewriter->consume()->token;
+				// Value is unquoted table name
+				$table_name = $this->rewriter->consume()->value;
 				$columns    = $this->get_columns_from( $table_name );
 				$keys       = $this->get_keys( $table_name );
+
+				if( empty( $columns ) ) {
+					$this->set_results_from_fetched_data(
+						array()
+					);
+					return;
+				}
 
 				foreach ( $columns as $column ) {
 					$column      = (array) $column;
@@ -3452,8 +3460,12 @@ class WP_SQLite_Translator {
 						':param' => $table_expression->value,
 					)
 				);
+				
 				$this->set_results_from_fetched_data(
-					$stmt->fetchAll( $this->pdo_fetch_mode )
+					array_column(
+						$stmt->fetchAll( $this->pdo_fetch_mode ),
+						'Tables_in_db'
+					)
 				);
 				return;
 
@@ -3464,7 +3476,10 @@ class WP_SQLite_Translator {
 							"SELECT name FROM sqlite_master WHERE type='table'"
 						);
 						$this->set_results_from_fetched_data(
-							$stmt->fetchAll( $this->pdo_fetch_mode )
+							array_column(
+								$stmt->fetchAll( $this->pdo_fetch_mode ),
+								'Tables_in_db'
+							)
 						);
 						return;
 


### PR DESCRIPTION
Fixes a series of crashes encountered when

* SHOW TABLES now returns a flat list, not an array of objects – I'm not sure here. It makes `$tables = $wpdb->get_results("SHOW TABLES LIKE '{$prefix}%'", ARRAY_N);` work as expected [here](https://github.com/WordPress/playground-tools/blob/128123e84e25cf0421770f6885c6f26aaf0b05dc/packages/playground/src/playground-db.php#L90-L91), but is the right thing to return, or is this more about correct handling of the fetch mode, like ARRAY_N?
* `SHOW tables` isn't all uppercase
* There's no table tho SHOW CREATE: `SHOW CREATE TABLE _no_such_table;`
* The table identifier passed to SHOW CREATE is quoted:

```
'SHOW CREATETABLE `_tmp_table`;'
```

This PR makes the [Sandbox site plugin](https://wordpress.org/plugins/playground/) work in Playground

cc @bgrgicak @brandonpayton @wojtekn