### PR TITLE
Partially revert #117

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -419,7 +419,11 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			array(
 				(object) array(
 					'Tables_in_db' => '_tmp_table',
+<<<<<<< Updated upstream
 				),
+=======
+				)
+>>>>>>> Stashed changes
 			),
 			$this->engine->get_query_results()
 		);

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -455,7 +455,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			array(
 				(object) array(
 					'Tables_in_db' => '_tmp_table',
-				)
+				),
 			),
 			$this->engine->get_query_results()
 		);

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -419,11 +419,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			array(
 				(object) array(
 					'Tables_in_db' => '_tmp_table',
-<<<<<<< Updated upstream
-				),
-=======
 				)
->>>>>>> Stashed changes
 			),
 			$this->engine->get_query_results()
 		);

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3238,8 +3238,8 @@ class WP_SQLite_Translator {
 	 */
 	private function execute_show() {
 		$this->rewriter->skip();
-		$what1 = $this->rewriter->consume()->token;
-		$what2 = $this->rewriter->consume()->token;
+		$what1 = strtoupper( $this->rewriter->consume()->token );
+		$what2 = strtoupper( $this->rewriter->consume()->token );
 		$what  = $what1 . ' ' . $what2;
 		switch ( $what ) {
 			case 'CREATE PROCEDURE':
@@ -3338,9 +3338,17 @@ class WP_SQLite_Translator {
 				return;
 
 			case 'CREATE TABLE':
-				$table_name = $this->rewriter->consume()->token;
+				// Value is unquoted table name
+				$table_name = $this->rewriter->consume()->value;
 				$columns    = $this->get_columns_from( $table_name );
 				$keys       = $this->get_keys( $table_name );
+
+				if ( empty( $columns ) ) {
+					$this->set_results_from_fetched_data(
+						array()
+					);
+					return;
+				}
 
 				foreach ( $columns as $column ) {
 					$column      = (array) $column;
@@ -3452,6 +3460,7 @@ class WP_SQLite_Translator {
 						':param' => $table_expression->value,
 					)
 				);
+
 				$this->set_results_from_fetched_data(
 					$stmt->fetchAll( $this->pdo_fetch_mode )
 				);

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3462,10 +3462,7 @@ class WP_SQLite_Translator {
 				);
 
 				$this->set_results_from_fetched_data(
-					array_column(
-						$stmt->fetchAll( $this->pdo_fetch_mode ),
-						'Tables_in_db'
-					)
+					$stmt->fetchAll( $this->pdo_fetch_mode )
 				);
 				return;
 
@@ -3476,10 +3473,7 @@ class WP_SQLite_Translator {
 							"SELECT name FROM sqlite_master WHERE type='table'"
 						);
 						$this->set_results_from_fetched_data(
-							array_column(
-								$stmt->fetchAll( $this->pdo_fetch_mode ),
-								'Tables_in_db'
-							)
+							$stmt->fetchAll( $this->pdo_fetch_mode )
 						);
 						return;
 


### PR DESCRIPTION
There's more nuance to the type of the returned value than #117 antitipated. With that PR in, WooCommerce wouldn't work:

```
[06-Jun-2024 16:21:26 UTC] PHP Fatal error:  Uncaught TypeError: get_object_vars(): Argument #1 ($object) must be of type object, string given in /wordpress/wp-includes/class-wpdb.php:3
Stack trace:
#0 /wordpress/wp-includes/class-wpdb.php(3): get_object_vars('wp_wc_product_a...')
#1 /wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php(69): wpdb->get_var('SHOW TABLES LIK...')
#2 /wordpress/wp-content/plugins/woocommerce/src/Internal/ProductAttributesLookup/LookupDataStore.php(650): Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore->check_lookup_table_exists()
```

Let's revert and revisit later on

cc @bgrgicak @wojtekn