### PR TITLE
Support multi-value column type modifiers for `_mysql_data_types_cache`

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -704,6 +704,43 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertEquals( 1, $result );
 	}
 
+	public function testCreateTableWithDecimalColumn() {
+		$result = $this->assertQuery(
+			'CREATE TABLE wptests_users (
+				ID bigint(20) unsigned NOT NULL auto_increment,
+				decimal_column DECIMAL(10,2) NOT NULL DEFAULT 0,
+				PRIMARY KEY  (ID),
+			)'
+		);
+		$this->assertEquals( '', $this->engine->get_error_message() );
+		$this->assertEquals( 1, $result );
+
+		$this->assertQuery( 'DESCRIBE wptests_users;' );
+		$results = $this->engine->get_query_results();
+		$this->assertEquals(
+			array(
+				(object) array(
+					'Field'   => 'ID',
+					'Type'    => 'bigint(20) unsigned',
+					'Null'    => 'NO',
+					'Key'     => 'PRI',
+					'Default' => '0',
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'decimal_column',
+					'Type'    => 'decimal(10,2)',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => 0,
+					'Extra'   => '',
+				),
+			),
+			$results
+		);
+
+	}
+
 	public function testAlterTableAddColumn() {
 		$result = $this->assertQuery(
 			"CREATE TABLE _tmp_table (

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -756,7 +756,6 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			),
 			$results
 		);
-
 	}
 
 	public function testAlterTableAddColumn() {

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -704,13 +704,15 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertEquals( 1, $result );
 	}
 
-	public function testCreateTableWithDecimalColumn() {
+	public function testCreateTableWithMultiValueColumnTypeModifiers() {
 		$result = $this->assertQuery(
-			'CREATE TABLE wptests_users (
+			"CREATE TABLE wptests_users (
 				ID bigint(20) unsigned NOT NULL auto_increment,
 				decimal_column DECIMAL(10,2) NOT NULL DEFAULT 0,
+				float_column FLOAT(10,2) NOT NULL DEFAULT 0,
+				enum_column ENUM('a', 'b', 'c') NOT NULL DEFAULT 'a',
 				PRIMARY KEY  (ID),
-			)'
+			)"
 		);
 		$this->assertEquals( '', $this->engine->get_error_message() );
 		$this->assertEquals( 1, $result );
@@ -733,6 +735,22 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					'Null'    => 'NO',
 					'Key'     => '',
 					'Default' => 0,
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'float_column',
+					'Type'    => 'float(10,2)',
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => 0,
+					'Extra'   => '',
+				),
+				(object) array(
+					'Field'   => 'enum_column',
+					'Type'    => "enum('a','b','c')",
+					'Null'    => 'NO',
+					'Key'     => '',
+					'Default' => 'a',
 					'Extra'   => '',
 				),
 			),

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3556,12 +3556,19 @@ class WP_SQLite_Translator {
 
 		$sqlite_data_type = $this->field_types_translation[ $mysql_data_type ];
 
-		// Skip the length, e.g. (10) in VARCHAR(10).
+		// Skip the type modifier, e.g. (20) for varchar(20) or (10,2) for decimal(10,2).
 		$paren_maybe = $this->rewriter->peek();
 		if ( $paren_maybe && '(' === $paren_maybe->token ) {
-			$mysql_data_type .= $this->rewriter->skip()->token;
-			$mysql_data_type .= $this->rewriter->skip()->token;
-			$mysql_data_type .= $this->rewriter->skip()->token;
+			$mysql_data_type .= $this->rewriter->skip()->token; // Skip '(' and add it to the data type
+
+			// Loop to capture everything until the closing parenthesis ')'
+			while ( true ) {
+				$token            = $this->rewriter->skip()->token;
+				$mysql_data_type .= $token;
+				if ( ')' === $token ) {
+					break;
+				}
+			}
 		}
 
 		// Skip the int keyword.

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -65,6 +65,7 @@ class WP_SQLite_Translator {
 		'double'             => 'real',
 		'decimal'            => 'real',
 		'dec'                => 'real',
+		'enum'               => 'text',
 		'numeric'            => 'real',
 		'fixed'              => 'real',
 		'date'               => 'text',

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3563,10 +3563,9 @@ class WP_SQLite_Translator {
 			$mysql_data_type .= $this->rewriter->skip()->token; // Skip '(' and add it to the data type
 
 			// Loop to capture everything until the closing parenthesis ')'
-			while ( true ) {
-				$token            = $this->rewriter->skip()->token;
-				$mysql_data_type .= $token;
-				if ( ')' === $token ) {
+			while ( $token = $this->rewriter->skip() ) {
+				$mysql_data_type .= $token->token;
+				if ( ')' === $token->token ) {
 					break;
 				}
 			}


### PR DESCRIPTION
Fixes: #122 

This fix will skip over tokens until it finds the closing bracket of the type modifier `)` instead of consuming exactly 3. This should account for data types that support more than one value as a modifier, such as: enum, float, decimal, double.

Additionally, I've added support for enums. There are plugins that use enum fields and it makes sense to convert those to text in SQLite.

## Testing instructions
Confirm the tests pass