### PR TITLE
Address PK issues for show create table queries

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -396,6 +396,16 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 	}
 
+	public function testShowCreateTableWithColumnKeys() {
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+	`ID` bigint PRIMARY KEY AUTO_INCREMENT NOT NULL,
+	`option_name` varchar(255) DEFAULT '',
+	`option_value` text NOT NULL DEFAULT '',
+	KEY _tmp_table__composite (option_name, option_value),
+	UNIQUE KEY _tmp_table__option_name (option_name) );" );
+	}
+
 	public function testSelectIndexHintForce() {
 		$this->assertQuery( "INSERT INTO _options (option_name) VALUES ('first');" );
 		$result = $this->assertQuery(

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -279,7 +279,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		# TODO: Should we fix mismatch with original `option_value` text NOT NULL,` without default?
 		$this->assertEquals(
 			"CREATE TABLE `_tmp_table` (
-	`ID` bigint NOT NULL DEFAULT 0 AUTO_INCREMENT,
+	`ID` bigint NOT NULL AUTO_INCREMENT,
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
 	PRIMARY KEY (`ID`),
@@ -308,7 +308,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		# TODO: Should we fix mismatch with original `option_value` text NOT NULL,` without default?
 		$this->assertEquals(
 			"CREATE TABLE `_tmp_table` (
-	`ID` bigint NOT NULL DEFAULT 0 AUTO_INCREMENT,
+	`ID` bigint NOT NULL AUTO_INCREMENT,
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
 	PRIMARY KEY (`ID`),
@@ -361,7 +361,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$results = $this->engine->get_query_results();
 		$this->assertEquals(
 			'CREATE TABLE `_tmp_table` (
-	`ID` bigint NOT NULL DEFAULT 0 AUTO_INCREMENT,
+	`ID` bigint NOT NULL AUTO_INCREMENT,
 	`option_name` smallint NOT NULL DEFAULT 14,
 	`option_value` text NOT NULL DEFAULT \'\',
 	PRIMARY KEY (`ID`),

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -278,12 +278,13 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$results = $this->engine->get_query_results();
 		# TODO: Should we fix mismatch with original `option_value` text NOT NULL,` without default?
 		$this->assertEquals(
-			"CREATE TABLE _tmp_table (
-	`ID` bigint PRIMARY KEY AUTO_INCREMENT NOT NULL,
+			"CREATE TABLE `_tmp_table` (
+	`ID` bigint NOT NULL DEFAULT 0 AUTO_INCREMENT,
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
-	KEY _tmp_table__composite (option_name, option_value),
-	UNIQUE KEY _tmp_table__option_name (option_name)
+	PRIMARY KEY (`ID`),
+	KEY `_tmp_table__composite` (`option_name`, `option_value`),
+	UNIQUE KEY `_tmp_table__option_name` (`option_name`)
 );",
 			$results[0]->{'Create Table'}
 		);
@@ -306,12 +307,13 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$results = $this->engine->get_query_results();
 		# TODO: Should we fix mismatch with original `option_value` text NOT NULL,` without default?
 		$this->assertEquals(
-			"CREATE TABLE _tmp_table (
-	`ID` bigint PRIMARY KEY AUTO_INCREMENT NOT NULL,
+			"CREATE TABLE `_tmp_table` (
+	`ID` bigint NOT NULL DEFAULT 0 AUTO_INCREMENT,
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
-	KEY _tmp_table__composite (option_name, option_value),
-	UNIQUE KEY _tmp_table__option_name (option_name)
+	PRIMARY KEY (`ID`),
+	KEY `_tmp_table__composite` (`option_name`, `option_value`),
+	UNIQUE KEY `_tmp_table__option_name` (`option_name`)
 );",
 			$results[0]->{'Create Table'}
 		);
@@ -329,8 +331,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 		$results = $this->engine->get_query_results();
 		$this->assertEquals(
-			'CREATE TABLE _tmp_table (
-	`ID` bigint NOT NULL
+			'CREATE TABLE `_tmp_table` (
+	`ID` bigint NOT NULL DEFAULT 0
 );',
 			$results[0]->{'Create Table'}
 		);
@@ -358,11 +360,12 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 		$results = $this->engine->get_query_results();
 		$this->assertEquals(
-			'CREATE TABLE _tmp_table (
-	`ID` bigint PRIMARY KEY AUTO_INCREMENT NOT NULL,
+			'CREATE TABLE `_tmp_table` (
+	`ID` bigint NOT NULL DEFAULT 0 AUTO_INCREMENT,
 	`option_name` smallint NOT NULL DEFAULT 14,
 	`option_value` text NOT NULL DEFAULT \'\',
-	KEY _tmp_table__option_name (option_name)
+	PRIMARY KEY (`ID`),
+	KEY `_tmp_table__option_name` (`option_name`)
 );',
 			$results[0]->{'Create Table'}
 		);

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -371,6 +371,29 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 	}
 
+	public function testShowCreateTableWithPrimaryKeyColumnsReverseOrdered() {
+		$this->assertQuery(
+			'CREATE TABLE `_tmp_table` (
+				`ID_A` BIGINT NOT NULL,
+				`ID_B` BIGINT NOT NULL,
+				PRIMARY KEY (`ID_B`, `ID_A`)
+			);'
+		);
+
+		$this->assertQuery(
+			'SHOW CREATE TABLE _tmp_table;'
+		);
+		$results = $this->engine->get_query_results();
+		$this->assertEquals(
+'CREATE TABLE `_tmp_table` (
+	`ID_A` bigint NOT NULL DEFAULT 0,
+	`ID_B` bigint NOT NULL DEFAULT 0,
+	PRIMARY KEY (`ID_B`, `ID_A`)
+);',
+			$results[0]->{'Create Table'}
+		);
+	}
+
 	public function testSelectIndexHintForce() {
 		$this->assertQuery( "INSERT INTO _options (option_name) VALUES ('first');" );
 		$result = $this->assertQuery(

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -403,7 +403,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
 	KEY _tmp_table__composite (option_name, option_value),
-	UNIQUE KEY _tmp_table__option_name (option_name) );" );
+	UNIQUE KEY _tmp_table__option_name (option_name) );"
+		);
 	}
 
 	public function testSelectIndexHintForce() {

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -386,7 +386,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 		$results = $this->engine->get_query_results();
 		$this->assertEquals(
-'CREATE TABLE `_tmp_table` (
+			'CREATE TABLE `_tmp_table` (
 	`ID_A` bigint NOT NULL DEFAULT 0,
 	`ID_B` bigint NOT NULL DEFAULT 0,
 	`ID_C` bigint NOT NULL DEFAULT 0,

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -376,7 +376,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			'CREATE TABLE `_tmp_table` (
 				`ID_A` BIGINT NOT NULL,
 				`ID_B` BIGINT NOT NULL,
-				PRIMARY KEY (`ID_B`, `ID_A`)
+				`ID_C` BIGINT NOT NULL,
+				PRIMARY KEY (`ID_B`, `ID_A`, `ID_C`)
 			);'
 		);
 
@@ -388,7 +389,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 'CREATE TABLE `_tmp_table` (
 	`ID_A` bigint NOT NULL DEFAULT 0,
 	`ID_B` bigint NOT NULL DEFAULT 0,
-	PRIMARY KEY (`ID_B`, `ID_A`)
+	`ID_C` bigint NOT NULL DEFAULT 0,
+	PRIMARY KEY (`ID_B`, `ID_A`, `ID_C`)
 );',
 			$results[0]->{'Create Table'}
 		);

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3579,6 +3579,15 @@ class WP_SQLite_Translator {
 	 */
 	private function get_primary_key_definition( $columns ) {
 		$primary_keys = array();
+
+		// Sort the columns by primary key order.
+		usort(
+			$columns,
+			function ( $a, $b ) {
+				return $a->pk - $b->pk;
+			}
+		);
+
 		foreach ( $columns as $column ) {
 			if ( '0' !== $column->pk ) {
 				$primary_keys[] = sprintf( '`%s`', $column->name );
@@ -3627,8 +3636,8 @@ class WP_SQLite_Translator {
 			'notnull'    => null,
 			'pk'         => null,
 		);
-		$columns  = $stmt->fetchAll( $this->pdo_fetch_mode );
-		$columns  = array_map(
+
+		return array_map(
 			function ( $row ) use ( $name_map ) {
 				$new       = array();
 				$is_object = is_object( $row );
@@ -3647,9 +3656,8 @@ class WP_SQLite_Translator {
 				}
 				return $is_object ? (object) $new : $new;
 			},
-			$columns
+			$this->get_table_columns( $table_name )
 		);
-		return $columns;
 	}
 
 	/**

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3578,7 +3578,7 @@ class WP_SQLite_Translator {
 		$primary_keys = array();
 		foreach ( $columns as $column ) {
 			if ( '0' !== $column->pk ) {
-				$primary_keys[] = sprintf('`%s`', $column->name );
+				$primary_keys[] = sprintf( '`%s`', $column->name );
 			}
 		}
 
@@ -3625,7 +3625,6 @@ class WP_SQLite_Translator {
 			'pk'         => null,
 		);
 		$columns  = $stmt->fetchAll( $this->pdo_fetch_mode );
-
 		$columns  = array_map(
 			function ( $row ) use ( $name_map ) {
 				$new       = array();

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3539,7 +3539,8 @@ class WP_SQLite_Translator {
 			// If the PK columns are the same as the unique key columns, skip the key.
 			// This is because the PK is already unique in MySQL.
 			$key_equals_pk = ! array_diff( $pks, array_column( $key['columns'], 'name' ) );
-			if ( $key['index']['unique'] && $key_equals_pk ) {
+			$is_auto_index = strpos( $key['index']['name'], 'sqlite_autoindex_' ) === 0;
+			if ( $is_auto_index && $key['index']['unique'] && $key_equals_pk ) {
 				continue;
 			}
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3442,6 +3442,11 @@ class WP_SQLite_Translator {
 		}
 	}
 
+	/**
+	 * Generates a MySQL compatible create statement for a SHOW CREATE TABLE query.
+	 *
+	 * @return void
+	 */
 	private function generate_create_statement() {
 		$table_name = $this->rewriter->consume()->value;
 		$columns    = $this->get_table_columns( $table_name );
@@ -3475,7 +3480,7 @@ class WP_SQLite_Translator {
 	}
 
 	/**
-	 * Get columns from pragma table info for the given table.
+	 * Get raw columns details from pragma table info for the given table.
 	 *
 	 * @param string $table_name
 	 *
@@ -3523,7 +3528,8 @@ class WP_SQLite_Translator {
 	/**
 	 * Get the key definitions for a create statement
 	 *
-	 * @param $table_name
+	 * @param string $table_name
+	 * @param array  $columns
 	 *
 	 * @return array An array of key definitions
 	 */
@@ -3617,16 +3623,15 @@ class WP_SQLite_Translator {
 	}
 
 	/**
-	 * Gets the columns from a table.
+	 * Gets the columns from a table for the SHOW COLUMNS query.
+	 *
+	 * The output is identical to the output of the MySQL `SHOW COLUMNS` query.
 	 *
 	 * @param string $table_name The table name.
 	 *
 	 * @return array The columns.
 	 */
 	private function get_columns_from( $table_name ) {
-		$stmt = $this->execute_sqlite_query(
-			"PRAGMA table_info(\"$table_name\");"
-		);
 		/* @todo we may need to add the Extra column if anybdy needs it. 'auto_increment' is the value */
 		$name_map = array(
 			'name'       => 'Field',

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3498,6 +3498,7 @@ class WP_SQLite_Translator {
 		$auto_increment_column = $this->get_autoincrement_column( $table_name );
 		$column_definitions    = array();
 		foreach ( $columns as $column ) {
+			$is_auto_incr = $auto_increment_column && strtolower( $auto_increment_column ) === strtolower( $column->name );
 			$definition   = array();
 			$definition[] = '`' . $column->name . '`';
 			$definition[] = $this->get_cached_mysql_data_type( $table_name, $column->name ) ?? $column->name;
@@ -3506,11 +3507,11 @@ class WP_SQLite_Translator {
 				$definition[] = 'NOT NULL';
 			}
 
-			if ( '' !== $column->dflt_value ) {
+			if ( '' !== $column->dflt_value && ! $is_auto_incr ) {
 				$definition[] = 'DEFAULT ' . $column->dflt_value; // quotes?
 			}
 
-			if ( $auto_increment_column && strtolower( $auto_increment_column ) === strtolower( $column->name ) ) {
+			if ( $is_auto_incr ) {
 				$definition[] = 'AUTO_INCREMENT';
 			}
 			$column_definitions[] = implode( ' ', $definition );

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3508,7 +3508,7 @@ class WP_SQLite_Translator {
 			}
 
 			if ( '' !== $column->dflt_value && ! $is_auto_incr ) {
-				$definition[] = 'DEFAULT ' . $column->dflt_value; // quotes?
+				$definition[] = 'DEFAULT ' . $column->dflt_value;
 			}
 
 			if ( $is_auto_incr ) {


### PR DESCRIPTION
Fixes: #123 

In this PR i propose a refactor of the handling of `show create table` queries.

The main issue was that it is possible for a primary key to be composite (more than one column). The existing implementation only supports a single PK which causes the `CREATE TABLE` statement to be invalid. An example of such a table is the `wp_term_relationships` found in WordPress:

```mysql
-- original MySQL statement
CREATE TABLE `wp_term_relationships` (
 `object_id` bigint(20) unsigned NOT NULL DEFAULT 0,
 `term_taxonomy_id` bigint(20) unsigned NOT NULL DEFAULT 0,
 `term_order` int(11) NOT NULL DEFAULT 0,
 PRIMARY KEY (`object_id`,`term_taxonomy_id`),
 KEY `term_taxonomy_id` (`term_taxonomy_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

-- statement produced by SQLite database integration
CREATE TABLE wp_term_relationships (
	`object_id` bigint(20) unsigned PRIMARY KEY AUTO_INCREMENT NOT NULL,
	`term_taxonomy_id` bigint(20) unsigned NOT NULL,
	`term_order` int(11) NOT NULL,
	KEY wp_term_relationships__term_taxonomy_id (term_taxonomy_id),
	UNIQUE KEY sqlite_autoindex_wp_term_relationships_1 (object_id, term_taxonomy_id)
);
```
SQLite also creates a unique key for any primary key (single or composite) which is something that is not necessary for MySQL and should be skipped from the final create statement.

## In this PR

- Refactor the code to separate things into smaller methods.
- Add the PK definition before the keys and remove it from the column definitions.
- Use backticks around table names, column names and key identifiers. This is to prevent issues when names of identifiers are using reserved keywords, ensure case sensitivity and allow them to contain special chars or spaces.
- Improve detection of AUTO_INCREMENT column. Now we falsely mark columns as AUTO_INCREMENT just because they happen to be the primary key and be of type integer.
- Fix creating an invalid UNIQUE KEY for the PK. When we find that the unique key is identical to the primary key, we can skip the unique key as it is redundant.

The final query output for `show create wp_term_relationships` looks as follows:

```mysql
DROP TABLE IF EXISTS `wp_term_relationships`;
CREATE TABLE `wp_term_relationships` (
	`object_id` bigint(20) unsigned NOT NULL DEFAULT 0,
	`term_taxonomy_id` bigint(20) unsigned NOT NULL DEFAULT 0,
	`term_order` int(11) NOT NULL DEFAULT 0,
	PRIMARY KEY (`object_id`, `term_taxonomy_id`),
	KEY `wp_term_relationships__idx_term_taxonomy_id_x` (`term_taxonomy_id`)
);
```

## Testing

- Run the unit tests
- Create a site with SQLite and then run `$wpdb->query('show create wp_term_relationships')` - The result should be a valid MySQL compatible query as shown above.