### PR TITLE
Support CREATE TABLE unique keys with no key name

### DIFF
--- a/tests/WP_SQLite_Query_Tests.php
+++ b/tests/WP_SQLite_Query_Tests.php
@@ -519,6 +519,23 @@ QUERY;
 			ON DUPLICATE KEY UPDATE `text` = "test1"'
 		);
 	}
+	public function testOnDuplicateKeyWithUnnamedKeys() {
+		$this->assertQuery(
+			'CREATE TABLE `test` (
+				`id` INT,
+				`name` VARCHAR(255),
+				`other` VARCHAR(255),
+				PRIMARY KEY (id),
+				UNIQUE KEY (name)
+			);'
+		);
+		// The order is deliberate to test that the query works with the keys in any order.
+		$this->assertQuery(
+			'INSERT INTO test (`name`, other)
+			VALUES ("name", "test")
+			ON DUPLICATE KEY UPDATE `other` = values(other)'
+		);
+	}
 
 	public function testShowColumns() {
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1186,7 +1186,9 @@ class WP_SQLite_Translator {
 		$result->value = $this->normalize_mysql_index_type( $constraint->value );
 		if ( $result->value ) {
 			$this->rewriter->skip(); // Constraint type.
-			if ( 'PRIMARY' !== $result->value ) {
+
+			$name = $this->rewriter->peek();
+			if ( $name->token !== '(' && 'PRIMARY' !== $result->value ) {
 				$result->name = $this->rewriter->skip()->value;
 			}
 
@@ -1202,6 +1204,10 @@ class WP_SQLite_Translator {
 				}
 				$this->rewriter->skip(); // `,` or `)`
 			} while ( $this->rewriter->depth > $constraint_depth );
+
+			if ( empty( $result->name ) ) {
+				$result->name = implode( '_', $result->columns );
+			}
 		}
 
 		do {

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1188,7 +1188,7 @@ class WP_SQLite_Translator {
 			$this->rewriter->skip(); // Constraint type.
 
 			$name = $this->rewriter->peek();
-			if ( $name->token !== '(' && 'PRIMARY' !== $result->value ) {
+			if ( '(' !== $name->token && 'PRIMARY' !== $result->value ) {
 				$result->name = $this->rewriter->skip()->value;
 			}
 


### PR DESCRIPTION
In a table like
```sql
CREATE TABLE `test` (
	`id` INT,
	`name` VARCHAR(255),
	`other` VARCHAR(255),
	PRIMARY KEY (id),
	UNIQUE KEY (name)
)
```

the internal name for the unique key would be `(` because typically a key would be defined with
```
UNIQUE KEY `name` (name)
```

Usually this wrong key name is not a problem unless a `INSERT .. ON DUPLICATE KEY` statement is used where the resulting `ON CONFLICT( "keyname" )` would be transformed to `ON CONFLICT( "" )` which then fails.

To fix this, this now derives a key name in case it is omitted..

cc @costasovo