### PR TITLE
Fix length of index names for a create table statement

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -283,8 +283,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
 	PRIMARY KEY (`ID`),
-	KEY `_tmp_table__composite` (`option_name`, `option_value`),
-	UNIQUE KEY `_tmp_table__option_name` (`option_name`)
+	KEY `composite` (`option_name`, `option_value`),
+	UNIQUE KEY `option_name` (`option_name`)
 );",
 			$results[0]->{'Create Table'}
 		);
@@ -312,8 +312,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
 	PRIMARY KEY (`ID`),
-	KEY `_tmp_table__composite` (`option_name`, `option_value`),
-	UNIQUE KEY `_tmp_table__option_name` (`option_name`)
+	KEY `composite` (`option_name`, `option_value`),
+	UNIQUE KEY `option_name` (`option_name`)
 );",
 			$results[0]->{'Create Table'}
 		);
@@ -365,9 +365,29 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`option_name` smallint NOT NULL DEFAULT 14,
 	`option_value` text NOT NULL DEFAULT \'\',
 	PRIMARY KEY (`ID`),
-	KEY `_tmp_table__option_name` (`option_name`)
+	KEY `option_name` (`option_name`)
 );',
 			$results[0]->{'Create Table'}
+		);
+	}
+
+	public function testCreateTablseWithIdenticalIndexNames() {
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table_a (
+					ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+					option_name VARCHAR(255) default '',
+					option_value TEXT NOT NULL,
+					KEY `option_name` (`option_name`)
+				);"
+		);
+
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table_b (
+					ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+					option_name VARCHAR(255) default '',
+					option_value TEXT NOT NULL,
+					KEY `option_name` (`option_name`)
+				);"
 		);
 	}
 


### PR DESCRIPTION
Fixes: #124 

This PR introduces some changes to how we determine the name of an index. SQLite requires that each index is uniquely named across the database (not just the table). This causes issues when multiple tables have the same key names when importing from MySQL. To avoid these issues, the index name is prefixed with the table name when it is created. This however results in the indexes having names that are too long for MySQL so when we run `show create table` the create statements have these prefixed keys that are too long.

To solve this,  we keep adding the table name as a prefix but we remove it when we generate the create statement. Furthermore, we ensure that the table name itself has no double underscores in it so we can be sure that we can split on `__` safely. The result is that each create table statement will have the original index name and prevents it from being too long.