### PR TITLE
Add support for selecting journal mode

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -421,6 +421,11 @@ class WP_SQLite_Translator {
 			$this->pdo->query( 'PRAGMA foreign_keys = ON' );
 		}
 		$this->pdo->query( 'PRAGMA encoding="UTF-8";' );
+
+		$valid_journal_modes = array( 'DELETE', 'TRUNCATE', 'PERSIST', 'MEMORY', 'WAL', 'OFF' );
+		if ( defined( 'SQLITE_JOURNAL_MODE' ) && in_array( SQLITE_JOURNAL_MODE, $valid_journal_modes, true ) ) {
+			$this->pdo->query( 'PRAGMA journal_mode = ' . SQLITE_JOURNAL_MODE );
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is an alternative to #102 
Supporting `WAL` mode is good, however if we add support for that, we should also add supoport for other journaling types as well.
This PR adds a `SQLITE_JOURNAL_MODE` constant, and if it has one of the valid & supported values, then we make the query to set the `journal_mode` in the DB.

Props @soulteary 👍 