### PR TITLE
Fix invalid default values in `show create` output

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -457,6 +457,30 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 	}
 
+	public function testShowCreateTableWithCorrectDefaultValues() {
+		$this->assertQuery(
+			"CREATE TABLE _tmp__table (
+					ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
+					default_empty_string VARCHAR(255) default '',
+					null_no_default VARCHAR(255),
+				);"
+		);
+
+		$this->assertQuery(
+			'SHOW CREATE TABLE _tmp__table;'
+		);
+		$results = $this->engine->get_query_results();
+		$this->assertEquals(
+			'CREATE TABLE `_tmp__table` (
+	`ID` bigint NOT NULL AUTO_INCREMENT,
+	`default_empty_string` varchar(255) DEFAULT \'\',
+	`null_no_default` varchar(255),
+	PRIMARY KEY (`ID`)
+);',
+			$results[0]->{'Create Table'}
+		);
+	}
+
 	public function testSelectIndexHintForce() {
 		$this->assertQuery( "INSERT INTO _options (option_name) VALUES ('first');" );
 		$result = $this->assertQuery(

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3522,7 +3522,7 @@ class WP_SQLite_Translator {
 				$definition[] = 'NOT NULL';
 			}
 
-			if ( '' !== $column->dflt_value && ! $is_auto_incr ) {
+			if ( null !== $column->dflt_value && '' !== $column->dflt_value && ! $is_auto_incr ) {
 				$definition[] = 'DEFAULT ' . $column->dflt_value;
 			}
 


### PR DESCRIPTION
This PR addresses an issue where the output of `show create table` is incorrect when the table has a `NULL` column without a default value.

Here is an example:

```sql

-- Original MySQL query

CREATE TABLE `wp_usermeta` (
	`umeta_id` bigint(20) unsigned NOT NULL auto_increment,
	`user_id` bigint(20) unsigned NOT NULL default '0',
	`meta_key` varchar(255) default NULL,
	`meta_value` longtext,
	PRIMARY KEY  (`umeta_id`),
	KEY `user_id` (`user_id`),
	KEY `meta_key` (`meta_key`(191))
)

-- Output by `SHOW CREATE TABLE` via SQLite plugin

CREATE TABLE `wp_usermeta` (
	`umeta_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
	`user_id` bigint(20) unsigned NOT NULL DEFAULT '0',
	`meta_key` varchar(255) DEFAULT NULL,
	`meta_value` longtext DEFAULT , -- Default value missing
	PRIMARY KEY (`umeta_id`),
	KEY `meta_key` (`meta_key`),
	KEY `user_id` (`user_id`)
);

-- After this fix

CREATE TABLE `wp_usermeta` (
	`umeta_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
	`user_id` bigint(20) unsigned NOT NULL DEFAULT '0',
	`meta_key` varchar(255) DEFAULT NULL,
	`meta_value` longtext,
	PRIMARY KEY (`umeta_id`),
	KEY `meta_key` (`meta_key`),
	KEY `user_id` (`user_id`)
);
```
