### PR TITLE
Add support for optional COLUMN in ALTER TABLE CHANGE query

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1074,6 +1074,57 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertEquals( 2, $result[0]->ID );
 	}
 
+
+	public function testAlterTableModifyColumnWithSkippedColumnKeyword() {
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				name varchar(20) NOT NULL default '',
+				lastname varchar(20) NOT NULL default '',
+				KEY composite (name, lastname),
+				UNIQUE KEY name (name)
+			);"
+		);
+		// Insert a record
+		$result = $this->assertQuery( "INSERT INTO _tmp_table (ID, name, lastname) VALUES (1, 'Johnny', 'Appleseed');" );
+		$this->assertEquals( 1, $result );
+
+		// Primary key violation:
+		$result = $this->engine->query( "INSERT INTO _tmp_table (ID, name, lastname) VALUES (1, 'Mike', 'Pearseed');" );
+		$this->assertEquals( false, $result );
+
+		// Unique constraint violation:
+		$result = $this->engine->query( "INSERT INTO _tmp_table (ID, name, lastname) VALUES (2, 'Johnny', 'Appleseed');" );
+		$this->assertEquals( false, $result );
+
+		// Rename the "name" field to "firstname":
+		$result = $this->engine->query( "ALTER TABLE _tmp_table CHANGE name firstname varchar(50) NOT NULL default 'mark';" );
+		$this->assertEquals( '', $this->engine->get_error_message() );
+		$this->assertEquals( 1, $result );
+
+		// Confirm the original data is still there:
+		$result = $this->engine->query( 'SELECT * FROM _tmp_table;' );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 1, $result[0]->ID );
+		$this->assertEquals( 'Johnny', $result[0]->firstname );
+		$this->assertEquals( 'Appleseed', $result[0]->lastname );
+
+		// Confirm the primary key is intact:
+		$result = $this->engine->query( "INSERT INTO _tmp_table (ID, firstname, lastname) VALUES (1, 'Mike', 'Pearseed');" );
+		$this->assertEquals( false, $result );
+
+		// Confirm the unique key is intact:
+		$result = $this->engine->query( "INSERT INTO _tmp_table (ID, firstname, lastname) VALUES (2, 'Johnny', 'Appleseed');" );
+		$this->assertEquals( false, $result );
+
+		// Confirm the autoincrement still works:
+		$result = $this->engine->query( "INSERT INTO _tmp_table (firstname, lastname) VALUES ('John', 'Doe');" );
+		$this->assertEquals( true, $result );
+		$result = $this->engine->query( "SELECT * FROM _tmp_table WHERE firstname='John';" );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 2, $result[0]->ID );
+	}
+
 	public function testAlterTableModifyColumnWithHyphens() {
 		$result = $this->assertQuery(
 			'CREATE TABLE wptests_dbdelta_test2 (

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2916,7 +2916,8 @@ class WP_SQLite_Translator {
 				)
 			);
 			$op_type          = strtoupper( $this->rewriter->consume()->token ?? '' );
-			$op_subject       = strtoupper( $this->rewriter->consume()->token ?? '' );
+			$op_raw_subject   = $this->rewriter->consume()->token ?? '';
+			$op_subject       = strtoupper( $op_raw_subject );
 			$mysql_index_type = $this->normalize_mysql_index_type( $op_subject );
 			$is_index_op      = (bool) $mysql_index_type;
 
@@ -2941,9 +2942,10 @@ class WP_SQLite_Translator {
 				);
 			} elseif ( 'DROP' === $op_type && 'COLUMN' === $op_subject ) {
 				$this->rewriter->consume_all();
-			} elseif ( 'CHANGE' === $op_type && 'COLUMN' === $op_subject ) {
+			} elseif ( 'CHANGE' === $op_type ) {
 				// Parse the new column definition.
-				$from_name        = $this->normalize_column_name( $this->rewriter->skip()->token );
+				$raw_from_name    = 'COLUMN' === $op_subject ? $this->rewriter->skip()->token : $op_raw_subject;
+				$from_name        = $this->normalize_column_name( $raw_from_name );
 				$new_field        = $this->parse_mysql_create_table_field();
 				$alter_terminator = end( $this->rewriter->output_tokens );
 				$this->update_data_type_cache(


### PR DESCRIPTION
This PR addresses an issue where the ALTER TABLE CHANGE with skipped COLUMNS keyword was ignored.

We supporter query

```sql
-- Processed correctly
ALTER TABLE _tmp_table CHANGE COLUMN name firstname varchar(50) NOT NULL default 'mark';

-- Was ignored
ALTER TABLE _tmp_table CHANGE name firstname varchar(50) NOT NULL default 'mark';
```
This PR fixes the issue by adding support for optional COLUMN in the ALTER TABLE CHANGE query