### PR TITLE
Add support for `ON UPDATE CURRENT_TIMESTAMP` columns

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -923,10 +923,8 @@ class WP_SQLite_Translator {
 			);
 		}
 
-		foreach ( $table->fields as $field ) {
-			if ( $field->on_update ) {
-				$this->add_column_on_update_current_timestamp( $table->name, $field->name );
-			}
+		foreach ( $on_updates as $column => $on_update ) {
+			$this->add_column_on_update_current_timestamp( $table->name, $column );
 		}
 	}
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1120,11 +1120,17 @@ class WP_SQLite_Translator {
 				continue;
 			}
 
-			if ( $token->matches(
-				WP_SQLite_Token::TYPE_KEYWORD,
-				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
-				array( 'ON UPDATE' )
-			) ) {
+			if (
+				$token->matches(
+					WP_SQLite_Token::TYPE_KEYWORD,
+					WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+					array( 'ON UPDATE' )
+				) && $this->rewriter->peek()->matches(
+					WP_SQLite_Token::TYPE_KEYWORD,
+					WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+					array( 'CURRENT_TIMESTAMP' )
+				)
+			) {
 				$this->rewriter->skip();
 				$result->on_update = true;
 				continue;
@@ -2992,9 +2998,15 @@ class WP_SQLite_Translator {
 							'value' => array( 'ON UPDATE' ),
 						)
 					);
-					$this->rewriter->drop_last();
-					$this->rewriter->skip();
-					$on_update = $column_name;
+					if ( $this->rewriter->peek()->matches(
+						WP_SQLite_Token::TYPE_KEYWORD,
+						WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
+						array( 'CURRENT_TIMESTAMP' )
+					) ) {
+						$this->rewriter->drop_last();
+						$this->rewriter->skip();
+						$on_update = $column_name;
+					}
 				}
 
 				// Drop "FIRST" and "AFTER <another-column>", as these are not supported in SQLite.


### PR DESCRIPTION
The `ON UPDATE CURRENT_TIMESTAMP` is a special MySQL-specific construct that can be used in column definitions. There is no such functionality in SQLite. This pull request implements the `ON UPDATE CURRENT_TIMESTAMP` functionality for both `CREATE` and `ALTER` table commands using **triggers**.

With queries such as:
```sql
CREATE TABLE _tmp_table (
	id int(11) NOT NULL,
	created_at timestamp NULL ON UPDATE CURRENT_TIMESTAMP
);

ALTER TABLE _tmp_table ADD COLUMN updated_at timestamp NULL ON UPDATE CURRENT_TIMESTAMP;
```

The following triggers will be added:
```sql
-- created_at
CREATE TRIGGER "___tmp_table_created_at_on_update__"
AFTER UPDATE ON "_tmp_table"
FOR EACH ROW
BEGIN
  UPDATE "_tmp_table" SET "created_at" = CURRENT_TIMESTAMP WHERE id = NEW.id;
END;

-- updated_at
CREATE TRIGGER "___tmp_table_updated_at_on_update__"
AFTER UPDATE ON "_tmp_table"
FOR EACH ROW
BEGIN
  UPDATE "_tmp_table" SET "updated_at" = CURRENT_TIMESTAMP WHERE id = NEW.id;
END;
```

When the `ON UPDATE` is dropped using a query such as the following:
```sql
ALTER TABLE _tmp_table
CHANGE created_at created_at timestamp NULL,
CHANGE COLUMN updated_at updated_at timestamp NULL
```

The triggers are dropped as well. To ensure this always works, the trigger is always dropped when a column is being altered. Then, if `ON UPDATE` is present, it will be recreated; otherwise, it will remain dropped.

Resolves https://github.com/WordPress/sqlite-database-integration/issues/148.