### PR TITLE
Add support for `CURRENT_TIMESTAMP()` calls with parentheses

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -2859,6 +2859,46 @@ QUERY
 		);
 	}
 
+	public function testCurrentTimestamp() {
+		// SELECT
+		$results = $this->assertQuery(
+			'SELECT
+				current_timestamp AS t1,
+				CURRENT_TIMESTAMP AS t2,
+				current_timestamp() AS t3,
+				CURRENT_TIMESTAMP() AS t4'
+		);
+		$this->assertIsArray( $results );
+		$this->assertCount( 1, $results );
+		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $results[0]->t1 );
+		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $results[0]->t2 );
+		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $results[0]->t3 );
+
+		// INSERT
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('first', current_timestamp())"
+		);
+		$results = $this->assertQuery( 'SELECT option_value AS t FROM _dates' );
+		$this->assertCount( 1, $results );
+		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $results[0]->t );
+
+		// UPDATE
+		$this->assertQuery( 'UPDATE _dates SET option_value = NULL' );
+		$results = $this->assertQuery( 'SELECT option_value AS t FROM _dates' );
+		$this->assertCount( 1, $results );
+		$this->assertEmpty( $results[0]->t );
+
+		$this->assertQuery( 'UPDATE _dates SET option_value = CURRENT_TIMESTAMP()' );
+		$results = $this->assertQuery( 'SELECT option_value AS t FROM _dates' );
+		$this->assertCount( 1, $results );
+		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $results[0]->t );
+
+		// DELETE
+		// We can only assert that the query passes. It is not guaranteed that we'll actually
+		// delete the existing record, as the delete query could fall into a different second.
+		$this->assertQuery( 'DELETE FROM _dates WHERE option_value = CURRENT_TIMESTAMP()' );
+	}
+
 	/**
 	 * @dataProvider mysqlVariablesToTest
 	 */

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -2876,7 +2876,7 @@ QUERY
 
 		// INSERT
 		$this->assertQuery(
-			"INSERT INTO _dates (option_name, option_value) VALUES ('first', current_timestamp())"
+			"INSERT INTO _dates (option_name, option_value) VALUES ('first', CURRENT_TIMESTAMP())"
 		);
 		$results = $this->assertQuery( 'SELECT option_value AS t FROM _dates' );
 		$this->assertCount( 1, $results );


### PR DESCRIPTION
While SQLite does support `CURRENT_TIMESTAMP` function calls natively, it doesn't support calling the function with parentheses in the form of `CURRENT_TIMESTAMP()`.

This pull request removes the parentheses after `CURRENT_TIMESTAMP` keyword for all types of queries.

The following types of queries will now work:

```sql
SELECT
    current_timestamp AS t1,
    CURRENT_TIMESTAMP AS t2,
    current_timestamp() AS t3,
    CURRENT_TIMESTAMP() AS t4;

INSERT INTO _dates (option_name, option_value) VALUES ('first', current_timestamp());

UPDATE _dates SET option_value = CURRENT_TIMESTAMP();

DELETE FROM _dates WHERE option_value = CURRENT_TIMESTAMP();
```

Closes https://github.com/WordPress/sqlite-database-integration/pull/129.