### PR TITLE
Fix the behavior of `HAVING` clause

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -3077,6 +3077,56 @@ QUERY
 		);
 	}
 
+	public function testHavingWithoutGroupBy() {
+		$this->assertQuery(
+			'CREATE TABLE _tmp_table (
+				name varchar(20)
+			);'
+		);
+
+		$this->assertQuery(
+			"INSERT INTO _tmp_table VALUES ('a'), ('b'), ('b'), ('c'), ('c'), ('c')"
+		);
+
+		// HAVING condition satisfied
+		$result = $this->assertQuery(
+			"SELECT 'T' FROM _tmp_table HAVING COUNT(*) > 1"
+		);
+		$this->assertEquals(
+			array(
+				(object) array(
+					':param0' => 'T',
+				),
+			),
+			$result
+		);
+
+		// HAVING condition not satisfied
+		$result = $this->assertQuery(
+			"SELECT 'T' FROM _tmp_table HAVING COUNT(*) > 100"
+		);
+		$this->assertEquals(
+			array(),
+			$result
+		);
+
+		// DISTINCT ... HAVING, where only some results meet the HAVING condition
+		$result = $this->assertQuery(
+			'SELECT DISTINCT name FROM _tmp_table HAVING COUNT(*) > 1'
+		);
+		$this->assertEquals(
+			array(
+				(object) array(
+					'name' => 'b',
+				),
+				(object) array(
+					'name' => 'c',
+				),
+			),
+			$result
+		);
+	}
+
 	/**
 	 * @dataProvider mysqlVariablesToTest
 	 */

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -3048,6 +3048,35 @@ QUERY
 		$this->assertQuery( 'DELETE FROM _dates WHERE option_value = CURRENT_TIMESTAMP()' );
 	}
 
+	public function testGroupByHaving() {
+		$this->assertQuery(
+			'CREATE TABLE _tmp_table (
+				name varchar(20)
+			);'
+		);
+
+		$this->assertQuery(
+			"INSERT INTO _tmp_table VALUES ('a'), ('b'), ('b'), ('c'), ('c'), ('c')"
+		);
+
+		$result = $this->assertQuery(
+			'SELECT name, COUNT(*) as count FROM _tmp_table GROUP BY name HAVING COUNT(*) > 1'
+		);
+		$this->assertEquals(
+			array(
+				(object) array(
+					'name'  => 'b',
+					'count' => '2',
+				),
+				(object) array(
+					'name'  => 'c',
+					'count' => '3',
+				),
+			),
+			$result
+		);
+	}
+
 	/**
 	 * @dataProvider mysqlVariablesToTest
 	 */

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2607,13 +2607,9 @@ class WP_SQLite_Translator {
 			! $token->matches(
 				WP_SQLite_Token::TYPE_KEYWORD,
 				WP_SQLite_Token::FLAG_KEYWORD_RESERVED,
-				array( 'GROUP' )
+				array( 'GROUP BY' )
 			)
 		) {
-			return false;
-		}
-		$next = $this->rewriter->peek_nth( 2 )->value;
-		if ( 'BY' !== strtoupper( $next ?? '' ) ) {
 			return false;
 		}
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2619,7 +2619,7 @@ class WP_SQLite_Translator {
 	}
 
 	/**
-	 * Translate WHERE something HAVING something to WHERE something AND something.
+	 * Translate HAVING without GROUP BY to GROUP BY 1 HAVING.
 	 *
 	 * @param WP_SQLite_Token $token The token to translate.
 	 *
@@ -2638,8 +2638,15 @@ class WP_SQLite_Translator {
 		if ( $this->has_group_by ) {
 			return false;
 		}
-		$this->rewriter->skip();
-		$this->rewriter->add( new WP_SQLite_Token( 'AND', WP_SQLite_Token::TYPE_KEYWORD ) );
+
+		// GROUP BY is missing, add "GROUP BY 1" before the HAVING clause.
+		$having = $this->rewriter->skip();
+		$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_DELIMITER ) );
+		$this->rewriter->add( new WP_SQLite_Token( 'GROUP BY', WP_SQLite_Token::TYPE_KEYWORD ) );
+		$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_DELIMITER ) );
+		$this->rewriter->add( new WP_SQLite_Token( '1', WP_SQLite_Token::TYPE_NUMBER ) );
+		$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_DELIMITER ) );
+		$this->rewriter->add( $having );
 
 		return true;
 	}


### PR DESCRIPTION
The current implementation has a special handling for `HAVING` clauses without `GROUP BY` (this is [valid in MySQL](https://stackoverflow.com/questions/6924896/having-without-group-by) in some SQL modes). This implementation takes advantage of the equivalence of ungrouped HAVING with WHERE and rewrites such a `HAVING <condition>` clause to `AND <condition>`.

However, the current implementation has some issues:
1. The presence of `GROUP BY` in a query is incorrectly detected. The detection always fails, and thus every HAVING query is considered to be ungrouped. I added a fix in the first commit.
2. Rewriting `HAVING <condition>` to `AND <condition>` fails with an error `near "AND": syntax error` when no WHERE is included in the query. This is fixed in the second commit.
3. When an aggregate function is used in HAVING (e.g, `COUNT(*) > 1`), the query fails with: `misuse of aggregate function COUNT()`. This is because aggregate functions can't be used in the WHERE clause. This is fixed in the second commit.

To fix all of these issues, I implemented a fix for the `GROUP BY` detection (case 1), and changed the rewriting of `HAVING <condition>`  without `GROUP BY` to `GROUP BY 1 HAVING <condition>` (which fixes both case 2 and 3).