### PR TITLE
Fix & improve `ON UPDATE` trigger behavior

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -4397,12 +4397,16 @@ class WP_SQLite_Translator {
 	 */
 	private function add_column_on_update_current_timestamp( $table, $column ) {
 		$trigger_name = $this->get_column_on_update_current_timestamp_trigger_name( $table, $column );
+
+		// The trigger wouldn't work for virtual and "WITHOUT ROWID" tables,
+		// but currently that can't happen as we're not creating such tables.
+		// See: https://www.sqlite.org/rowidtable.html
 		$this->execute_sqlite_query(
 			"CREATE TRIGGER \"$trigger_name\"
 			AFTER UPDATE ON \"$table\"
 			FOR EACH ROW
 			BEGIN
-			  UPDATE \"$table\" SET \"$column\" = CURRENT_TIMESTAMP WHERE id = NEW.id;
+			  UPDATE \"$table\" SET \"$column\" = CURRENT_TIMESTAMP WHERE rowid = NEW.rowid;
 			END"
 		);
 	}

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3118,6 +3118,10 @@ class WP_SQLite_Translator {
 					$new_field->mysql_data_type
 				);
 
+				// Drop ON UPDATE trigger by the old column name.
+				$on_update_trigger_name = $this->get_column_on_update_current_timestamp_trigger_name( $this->table_name, $from_name );
+				$this->execute_sqlite_query( "DROP TRIGGER IF EXISTS \"$on_update_trigger_name\"" );
+
 				/*
 				 * In SQLite, there is no direct equivalent to the CHANGE COLUMN
 				 * statement from MySQL. We need to do a bit of work to emulate it.
@@ -3238,6 +3242,11 @@ class WP_SQLite_Translator {
 					);
 				}
 
+				// Add the ON UPDATE trigger if needed.
+				if ( $new_field->on_update ) {
+					$this->add_column_on_update_current_timestamp( $this->table_name, $new_field->name );
+				}
+
 				if ( ',' === $alter_terminator->token ) {
 					/*
 					 * If the terminator was a comma,
@@ -3329,9 +3338,6 @@ class WP_SQLite_Translator {
 				)
 			);
 			$this->rewriter->drop_last();
-
-			$on_update_trigger_name = $this->get_column_on_update_current_timestamp_trigger_name( $this->table_name, $op_subject );
-			$this->execute_sqlite_query( "DROP TRIGGER IF EXISTS \"$on_update_trigger_name\"" );
 
 			$this->execute_sqlite_query(
 				$this->rewriter->get_updated_query()

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1145,7 +1145,8 @@ class WP_SQLite_Translator {
 					array( 'CURRENT_TIMESTAMP' )
 				)
 			) {
-				$this->rewriter->skip();
+				$this->rewriter->skip(); // ON UPDATE
+				$this->rewriter->skip(); // CURRENT_TIMESTAMP
 				$result->on_update = true;
 				continue;
 			}


### PR DESCRIPTION
This just fixes and improves https://github.com/WordPress/sqlite-database-integration/pull/150.

With some further testing, I realized there were some issues in my original implementation:
1. The `ON UPDATE` trigger uses `id` instead of `rowid`. This is a regression — a query can fail now for anyone who uses `ON UPDATE` and doesn't have an `id` column. I somehow missed that 🤦‍♂️
2. The trigger is deleted with every column operation, not only for column `CHANGE`s, and it is actually missed by the `CHANGE` for creation as well, as that branch uses `continue`/`break` and skips the trigger creation below.

I fixed both and added test coverage.

