### PR TITLE
Fix creating a table with `AUTOINCREMENT` and `ON UPDATE` followed by `PRIMARY KEY`

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1196,6 +1196,27 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $result[0]->created_at );
 	}
 
+	public function testColumnWithOnUpdateAndAutoincrementPrimaryKey() {
+		// CREATE TABLE with ON UPDATE, AUTO_INCREMENT, and PRIMARY KEY
+		$this->assertQuery(
+			'CREATE TABLE _tmp_table (
+				id int(11) NOT NULL AUTO_INCREMENT,
+				created_at timestamp NULL ON UPDATE CURRENT_TIMESTAMP,
+				PRIMARY KEY (id)
+			);'
+		);
+
+		// on INSERT, no timestamps are expected
+		$this->assertQuery( 'INSERT INTO _tmp_table (id) VALUES (1)' );
+		$result = $this->assertQuery( 'SELECT * FROM _tmp_table WHERE id = 1' );
+		$this->assertNull( $result[0]->created_at );
+
+		// on UPDATE, we expect timestamps in form YYYY-MM-DD HH:MM:SS
+		$this->assertQuery( 'UPDATE _tmp_table SET id = 2 WHERE id = 1' );
+		$result = $this->assertQuery( 'SELECT * FROM _tmp_table WHERE id = 2' );
+		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $result[0]->created_at );
+	}
+
 	public function testChangeColumnWithOnUpdate() {
 		// CREATE TABLE with ON UPDATE
 		$this->assertQuery(

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1145,8 +1145,7 @@ class WP_SQLite_Translator {
 					array( 'CURRENT_TIMESTAMP' )
 				)
 			) {
-				$this->rewriter->skip(); // ON UPDATE
-				$this->rewriter->skip(); // CURRENT_TIMESTAMP
+				$this->rewriter->skip();
 				$result->on_update = true;
 				continue;
 			}


### PR DESCRIPTION
This reverts e59eff8c2856a5c96fc0db5da1402d5a258c8aa8. The fix was wrong. When spotting it, I misunderstood that the first token was already consumed.

Without the fix, the new test fails with:
```
Cannot combine AUTOINCREMENT and multiple primary keys in SQLite.
```

This is because we've consumed one extra token (`,`), and the `PRIMARY KEY` then gets assigned to the `created_at` column as well.