### PR TITLE
Fix unlimited key lengths issue

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -267,8 +267,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
 				option_name VARCHAR(255) default '',
 				option_value TEXT NOT NULL,
-				UNIQUE KEY option_name (option_name),
-				KEY composite (option_name, option_value)
+				UNIQUE KEY option_name (option_name(100)),
+				KEY composite (option_name(100), option_value(100))
 			);"
 		);
 
@@ -283,8 +283,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
 	PRIMARY KEY (`ID`),
-	KEY `composite` (`option_name`, `option_value`),
-	UNIQUE KEY `option_name` (`option_name`)
+	KEY `composite` (`option_name`(100), `option_value`(100)),
+	UNIQUE KEY `option_name` (`option_name`(100))
 );",
 			$results[0]->{'Create Table'}
 		);
@@ -337,8 +337,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 				ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
 				option_name VARCHAR(255) default '',
 				option_value TEXT NOT NULL,
-				UNIQUE KEY option_name (option_name),
-				KEY composite (option_name, option_value)
+				UNIQUE KEY option_name (option_name(100)),
+				KEY composite (option_name, option_value(100))
 			);"
 		);
 
@@ -353,8 +353,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`option_name` varchar(255) DEFAULT '',
 	`option_value` text NOT NULL DEFAULT '',
 	PRIMARY KEY (`ID`),
-	KEY `composite` (`option_name`, `option_value`),
-	UNIQUE KEY `option_name` (`option_name`)
+	KEY `composite` (`option_name`(100), `option_value`(100)),
+	UNIQUE KEY `option_name` (`option_name`(100))
 );",
 			$results[0]->{'Create Table'}
 		);
@@ -418,8 +418,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
 					option_name VARCHAR(255) default '',
 					option_value TEXT NOT NULL,
-					KEY `option_name` (`option_name`),
-					KEY `double__underscores` (`option_name`, `ID`)
+					KEY `option_name` (`option_name`(100)),
+					KEY `double__underscores` (`option_name`(100), `ID`)
 				);"
 		);
 
@@ -428,8 +428,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
 					option_name VARCHAR(255) default '',
 					option_value TEXT NOT NULL,
-					KEY `option_name` (`option_name`),
-					KEY `double__underscores` (`option_name`, `ID`)
+					KEY `option_name` (`option_name`(100)),
+					KEY `double__underscores` (`option_name`(100), `ID`)
 				);"
 		);
 	}
@@ -440,8 +440,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					ID BIGINT PRIMARY KEY AUTO_INCREMENT NOT NULL,
 					option_name VARCHAR(255) default '',
 					option_value TEXT NOT NULL,
-					KEY `option_name` (`option_name`),
-					KEY `double__underscores` (`option_name`, `ID`)
+					KEY `option_name` (`option_name`(100)),
+					KEY `double__underscores` (`option_name`(100), `ID`)
 				);"
 		);
 
@@ -455,8 +455,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`option_name` varchar(255) DEFAULT \'\',
 	`option_value` text NOT NULL DEFAULT \'\',
 	PRIMARY KEY (`ID`),
-	KEY `double__underscores` (`option_name`, `ID`),
-	KEY `option_name` (`option_name`)
+	KEY `double__underscores` (`option_name`(100), `ID`),
+	KEY `option_name` (`option_name`(100))
 );',
 			$results[0]->{'Create Table'}
 		);
@@ -486,8 +486,8 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`meta_key` varchar(255) DEFAULT NULL,
 	`meta_value` text DEFAULT NULL,
 	PRIMARY KEY (`id`),
-	KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82)),
-	KEY `meta_key_value` (`meta_key`(100),`meta_value`(82))
+	KEY `order_id_meta_key_meta_value` (`order_id`, `meta_key`(100), `meta_value`(100)),
+	KEY `meta_key_value` (`meta_key`(100), `meta_value`(100))
 );',
 			$results[0]->{'Create Table'}
 		);

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -464,7 +464,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 
 	public function testShowCreateTableLimitsKeyLengths() {
 		$this->assertQuery(
-			"CREATE TABLE _tmp__table (
+			'CREATE TABLE _tmp__table (
 					`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 					`order_id` bigint(20) unsigned DEFAULT NULL,
 					`meta_key` varchar(255) DEFAULT NULL,
@@ -472,7 +472,7 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					PRIMARY KEY (`id`),
 					KEY `meta_key_value` (`meta_key`(100),`meta_value`(82)),
 					KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82))
-				);"
+				);'
 		);
 
 		$this->assertQuery(

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -462,6 +462,37 @@ class WP_SQLite_Translator_Tests extends TestCase {
 		);
 	}
 
+	public function testShowCreateTableLimitsKeyLengths() {
+		$this->assertQuery(
+			"CREATE TABLE _tmp__table (
+					`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+					`order_id` bigint(20) unsigned DEFAULT NULL,
+					`meta_key` varchar(255) DEFAULT NULL,
+					`meta_value` text DEFAULT NULL,
+					PRIMARY KEY (`id`),
+					KEY `meta_key_value` (`meta_key`(100),`meta_value`(82)),
+					KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82))
+				);"
+		);
+
+		$this->assertQuery(
+			'SHOW CREATE TABLE _tmp__table;'
+		);
+		$results = $this->engine->get_query_results();
+		$this->assertEquals(
+			'CREATE TABLE `_tmp__table` (
+	`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+	`order_id` bigint(20) unsigned DEFAULT NULL,
+	`meta_key` varchar(255) DEFAULT NULL,
+	`meta_value` text DEFAULT NULL,
+	PRIMARY KEY (`id`),
+	KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82)),
+	KEY `meta_key_value` (`meta_key`(100),`meta_value`(82))
+);',
+			$results[0]->{'Create Table'}
+		);
+	}
+
 	public function testShowCreateTableWithPrimaryKeyColumnsReverseOrdered() {
 		$this->assertQuery(
 			'CREATE TABLE `_tmp_table` (

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -469,9 +469,11 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					`order_id` bigint(20) unsigned DEFAULT NULL,
 					`meta_key` varchar(20) DEFAULT NULL,
 					`meta_value` text DEFAULT NULL,
+					`meta_data` mediumblob DEFAULT NULL,
 					PRIMARY KEY (`id`),
 					KEY `meta_key_value` (`meta_key`(20),`meta_value`(82)),
-					KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82))
+					KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82)),
+					KEY `order_id_meta_key_meta_data` (`order_id`,`meta_key`(100),`meta_data`(100))
 				);'
 		);
 
@@ -485,7 +487,9 @@ class WP_SQLite_Translator_Tests extends TestCase {
 	`order_id` bigint(20) unsigned DEFAULT NULL,
 	`meta_key` varchar(20) DEFAULT NULL,
 	`meta_value` text DEFAULT NULL,
+	`meta_data` mediumblob DEFAULT NULL,
 	PRIMARY KEY (`id`),
+	KEY `order_id_meta_key_meta_data` (`order_id`, `meta_key`(20), `meta_data`(100)),
 	KEY `order_id_meta_key_meta_value` (`order_id`, `meta_key`(20), `meta_value`(100)),
 	KEY `meta_key_value` (`meta_key`(20), `meta_value`(100))
 );',

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -467,10 +467,10 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			'CREATE TABLE _tmp__table (
 					`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 					`order_id` bigint(20) unsigned DEFAULT NULL,
-					`meta_key` varchar(255) DEFAULT NULL,
+					`meta_key` varchar(20) DEFAULT NULL,
 					`meta_value` text DEFAULT NULL,
 					PRIMARY KEY (`id`),
-					KEY `meta_key_value` (`meta_key`(100),`meta_value`(82)),
+					KEY `meta_key_value` (`meta_key`(20),`meta_value`(82)),
 					KEY `order_id_meta_key_meta_value` (`order_id`,`meta_key`(100),`meta_value`(82))
 				);'
 		);
@@ -483,11 +483,11 @@ class WP_SQLite_Translator_Tests extends TestCase {
 			'CREATE TABLE `_tmp__table` (
 	`id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 	`order_id` bigint(20) unsigned DEFAULT NULL,
-	`meta_key` varchar(255) DEFAULT NULL,
+	`meta_key` varchar(20) DEFAULT NULL,
 	`meta_value` text DEFAULT NULL,
 	PRIMARY KEY (`id`),
-	KEY `order_id_meta_key_meta_value` (`order_id`, `meta_key`(100), `meta_value`(100)),
-	KEY `meta_key_value` (`meta_key`(100), `meta_value`(100))
+	KEY `order_id_meta_key_meta_value` (`order_id`, `meta_key`(20), `meta_value`(100)),
+	KEY `meta_key_value` (`meta_key`(20), `meta_value`(100))
 );',
 			$results[0]->{'Create Table'}
 		);

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3768,7 +3768,7 @@ class WP_SQLite_Translator {
 					}
 
 					// Set the data length to the varchar and text key length
-					if ( in_array( $this->field_types_translation[ $data_type ], [ 'text', 'blob'] ) ) {
+					if ( in_array( $this->field_types_translation[ $data_type ], [ 'text', 'blob'], true ) ) {
 						return sprintf( '`%s`(%s)', $column['name'], $data_length );
 					}
 					return sprintf( '`%s`', $column['name'] );

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3726,7 +3726,7 @@ class WP_SQLite_Translator {
 	 */
 	private function get_key_definitions( $table_name, $columns ) {
 		$key_length_limit = 100;
-		$key_definitions = array();
+		$key_definitions  = array();
 
 		$pks = array();
 		foreach ( $columns as $column ) {

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3725,6 +3725,7 @@ class WP_SQLite_Translator {
 	 * @return array An array of key definitions
 	 */
 	private function get_key_definitions( $table_name, $columns ) {
+		$key_length_limit = 100;
 		$key_definitions = array();
 
 		$pks = array();
@@ -3756,7 +3757,11 @@ class WP_SQLite_Translator {
 			$key_definition[] = sprintf( '`%s`', $index_name );
 
 			$cols = array_map(
-				function ( $column ) {
+				function ( $column ) use ( $table_name, $key_length_limit ) {
+					$data_type = strtolower( $this->get_cached_mysql_data_type( $table_name, $column['name'] ) );
+					if ( 'text' === $data_type || str_starts_with( $data_type, 'varchar' ) ) {
+						return sprintf( '`%s`(%s)', $column['name'], $key_length_limit );
+					}
 					return sprintf( '`%s`', $column['name'] );
 				},
 				$key['columns']

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3767,8 +3767,13 @@ class WP_SQLite_Translator {
 						$data_length = min( $matches[2], $key_length_limit ); // "255"
 					}
 
-					// Set the data length to the varchar and text key length
-					if ( in_array( $this->field_types_translation[ $data_type ], array( 'text', 'blob' ), true ) ) {
+					// Set the data length to the varchar and text key lengths
+					// char, varchar, varbinary, tinyblob, tinytext, blob, text, mediumblob, mediumtext, longblob, longtext
+					if ( str_ends_with( $data_type, 'char' ) ||
+						str_ends_with( $data_type, 'text' ) ||
+						str_ends_with( $data_type, 'blob' ) ||
+						str_starts_with( $data_type, 'var' )
+					) {
 						return sprintf( '`%s`(%s)', $column['name'], $data_length );
 					}
 					return sprintf( '`%s`', $column['name'] );

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3758,12 +3758,12 @@ class WP_SQLite_Translator {
 
 			$cols = array_map(
 				function ( $column ) use ( $table_name, $key_length_limit ) {
-					$data_type = strtolower( $this->get_cached_mysql_data_type( $table_name, $column['name'] ) );
+					$data_type   = strtolower( $this->get_cached_mysql_data_type( $table_name, $column['name'] ) );
 					$data_length = $key_length_limit;
 
 					// Extract the length from the data type. Make it lower if needed.
 					if ( 1 === preg_match( '/^(\w+)\((\d+)\)$/', $data_type, $matches ) ) {
-						$data_type = $matches[1]; // "varchar"
+						$data_type   = $matches[1]; // "varchar"
 						$data_length = min( $matches[2], $key_length_limit ); // "255"
 					}
 

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3759,8 +3759,17 @@ class WP_SQLite_Translator {
 			$cols = array_map(
 				function ( $column ) use ( $table_name, $key_length_limit ) {
 					$data_type = strtolower( $this->get_cached_mysql_data_type( $table_name, $column['name'] ) );
+					$data_length = $key_length_limit;
+
+					// Extract the length from the data type. Make it lower if needed.
+					if ( 1 === preg_match( '/^(\w+)\((\d+)\)$/', $data_type, $matches ) ) {
+						$data_type = $matches[1]; // "varchar"
+						$data_length = min( $matches[2], $key_length_limit ); // "255"
+					}
+
+					// Set the data length to the varchar and text key length
 					if ( 'text' === $data_type || str_starts_with( $data_type, 'varchar' ) ) {
-						return sprintf( '`%s`(%s)', $column['name'], $key_length_limit );
+						return sprintf( '`%s`(%s)', $column['name'], $data_length );
 					}
 					return sprintf( '`%s`', $column['name'] );
 				},

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3762,7 +3762,7 @@ class WP_SQLite_Translator {
 					$data_length = $key_length_limit;
 
 					// Extract the length from the data type. Make it lower if needed. Skip 'unsigned' parts and whitespace.
-					if ( 1 === preg_match( '/^(\w+)\s*\(\s*(\d+)\s*\)\s*(.*)?$/', $data_type, $matches ) ) {
+					if ( 1 === preg_match( '/^(\w+)\s*\(\s*(\d+)\s*\)/', $data_type, $matches ) ) {
 						$data_type   = $matches[1]; // "varchar"
 						$data_length = min( $matches[2], $key_length_limit ); // "255"
 					}

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3768,7 +3768,7 @@ class WP_SQLite_Translator {
 					}
 
 					// Set the data length to the varchar and text key length
-					if ( in_array( $this->field_types_translation[ $data_type ], [ 'text', 'blob'], true ) ) {
+					if ( in_array( $this->field_types_translation[ $data_type ], array( 'text', 'blob' ), true ) ) {
 						return sprintf( '`%s`(%s)', $column['name'], $data_length );
 					}
 					return sprintf( '`%s`', $column['name'] );

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -3761,14 +3761,14 @@ class WP_SQLite_Translator {
 					$data_type   = strtolower( $this->get_cached_mysql_data_type( $table_name, $column['name'] ) );
 					$data_length = $key_length_limit;
 
-					// Extract the length from the data type. Make it lower if needed.
-					if ( 1 === preg_match( '/^(\w+)\((\d+)\)$/', $data_type, $matches ) ) {
+					// Extract the length from the data type. Make it lower if needed. Skip 'unsigned' parts and whitespace.
+					if ( 1 === preg_match( '/^(\w+)\s*\(\s*(\d+)\s*\)\s*(.*)?$/', $data_type, $matches ) ) {
 						$data_type   = $matches[1]; // "varchar"
 						$data_length = min( $matches[2], $key_length_limit ); // "255"
 					}
 
 					// Set the data length to the varchar and text key length
-					if ( 'text' === $data_type || str_starts_with( $data_type, 'varchar' ) ) {
+					if ( in_array( $this->field_types_translation[ $data_type ], [ 'text', 'blob'] ) ) {
 						return sprintf( '`%s`(%s)', $column['name'], $data_length );
 					}
 					return sprintf( '`%s`', $column['name'] );


### PR DESCRIPTION
Fixes https://github.com/WordPress/sqlite-database-integration/issues/167

I propose to fix an issue where dumping the table with keys that use multiple long fields produces SQL code that produces an error.