### PR TITLE
Require `DB_NAME` to be set only in the new driver

### DIFF
--- a/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -307,6 +307,11 @@ class WP_SQLite_DB extends wpdb {
 			$pdo = $GLOBALS['@pdo'];
 		}
 		if ( defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER ) {
+			if ( null === $this->dbname || '' === $this->dbname ) {
+				$this->bail( 'The database name was not set.', 'db_connect_fail' );
+				return false;
+			}
+
 			require_once __DIR__ . '/../../wp-includes/parser/class-wp-parser-grammar.php';
 			require_once __DIR__ . '/../../wp-includes/parser/class-wp-parser.php';
 			require_once __DIR__ . '/../../wp-includes/parser/class-wp-parser-node.php';

--- a/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -308,7 +308,10 @@ class WP_SQLite_DB extends wpdb {
 		}
 		if ( defined( 'WP_SQLITE_AST_DRIVER' ) && WP_SQLITE_AST_DRIVER ) {
 			if ( null === $this->dbname || '' === $this->dbname ) {
-				$this->bail( 'The database name was not set.', 'db_connect_fail' );
+				$this->bail(
+					'The database name was not set. The SQLite driver requires a database name to be set to emulate MySQL information schema tables.',
+					'db_connect_fail'
+				);
 				return false;
 			}
 

--- a/wp-includes/sqlite/db.php
+++ b/wp-includes/sqlite/db.php
@@ -66,5 +66,5 @@ if ( defined( 'SQLITE_DEBUG_CROSSCHECK' ) && SQLITE_DEBUG_CROSSCHECK && file_exi
 	require_once $crosscheck_tests_file_path;
 	$GLOBALS['wpdb'] = new WP_SQLite_Crosscheck_DB( DB_NAME );
 } else {
-	$GLOBALS['wpdb'] = new WP_SQLite_DB( DB_NAME );
+	$GLOBALS['wpdb'] = new WP_SQLite_DB( defined( 'DB_NAME' ) ? DB_NAME : '' );
 }


### PR DESCRIPTION
Require `DB_NAME` to be set only in the new driver.

As reported in https://github.com/WordPress/sqlite-database-integration/issues/194#issuecomment-2939491161:

> I have this plugin on a site, and the Plugins admin page offered me the upgrade. I upgraded, and it broke the site, due to previously I did not have define( 'DB_NAME', '...' ); in wp-config.php.

The error message was:

> Error: Undefined constant "DB_NAME" in .../wp-content/plugins/sqlite-database-integration/wp-includes/sqlite/db.php on line 69