### PR TITLE
Make nullable $previous optional in class-wp-sqlite-information-schema-exception.php

### DIFF
--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php
@@ -39,7 +39,7 @@ class WP_SQLite_Information_Schema_Exception extends Exception {
 		string $type,
 		string $message,
 		array $data = array(),
-		Throwable $previous = null
+		?Throwable $previous = null
 	) {
 		parent::__construct( $message, 0, $previous );
 		$this->type = $type;


### PR DESCRIPTION
Adds `?` to `?Throwable previous = null` to fix this deprecation warning:

[11-Jun-2025 18:07:04 UTC] PHP Deprecated:  WP_SQLite_Information_Schema_Exception::__construct(): Implicitly marking parameter $previous as nullable is deprecated, the explicit nullable type must be used instead in /internal/shared/sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-exception.php on line 38

cc @draganescu – are there any other deprecation warnings you've seen?