### PR TITLE
Use default value when `DB_NAME` constant is not defined

### DIFF
--- a/constants.php
+++ b/constants.php
@@ -52,6 +52,16 @@ if ( ! defined( 'FQDB' ) ) {
 	}
 }
 
+/**
+ * The DB_NAME constant is required by the SQLite driver.
+ *
+ * When DB_NAME is not defined, let's use a default value that corresponds to
+ * the default value of the constant in "wp-config-sample.php" and in Studio.
+ */
+if ( ! defined( 'DB_NAME' ) ) {
+	define( 'DB_NAME', 'database_name_here' );
+}
+
 // Allow enabling the SQLite AST driver via environment variable.
 if ( ! defined( 'WP_SQLITE_AST_DRIVER' ) && isset( $_ENV['WP_SQLITE_AST_DRIVER'] ) && 'true' === $_ENV['WP_SQLITE_AST_DRIVER'] ) {
 	define( 'WP_SQLITE_AST_DRIVER', true );


### PR DESCRIPTION
This is needed for integration of the new SQLite driver in Studio.

We discovered that Studio doesn't use the [default implemented in Playground](https://github.com/WordPress/wordpress-playground/blob/bf9c3fa4af0aa3dca4788569a4a0fad81e5fbc54/packages/playground/wordpress/src/boot.ts#L164), as it's using `wp-now` and [booting Playground differently](https://github.com/Automattic/wordpress-playground-private/pull/140).

As a hotfix, when there is no `DB_NAME` defined at all, we'll fall back to the same value that Studio is using through an [MU plugin with polyfills](https://github.com/WordPress/wordpress-playground/blob/bf9c3fa4af0aa3dca4788569a4a0fad81e5fbc54/packages/playground/wordpress/src/index.ts#L22).

A proper fix will be to make the SQLite driver independent of the `DB_NAME` constant.