### PR TITLE
Query monitor: WordPress Playground compatibility

### DIFF
--- a/integrations/query-monitor/boot.php
+++ b/integrations/query-monitor/boot.php
@@ -39,7 +39,9 @@ if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 }
 
 if ( 'cli' === php_sapi_name() && ! defined( 'QM_TESTS' ) ) {
-	return;
+	if ( ! defined( 'QM_RUN_IN_CLI' ) || ! QM_RUN_IN_CLI ) {
+		return;
+	}
 }
 
 if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
@@ -54,6 +56,10 @@ if ( is_admin() ) {
 	if ( isset( $_POST['action'] ) && 'update-plugin' === $_POST['action'] ) {
 		return;
 	}
+}
+
+if ( ! isset( $wpdb ) ) {
+	return;
 }
 
 // 2. Check if Query Monitor is active.


### PR DESCRIPTION
Follows up in #212. Accounts for the WordPress Playground runtime, where the sapi name is `cli` and the `$wpdb` variable [may not be available](https://github.com/WordPress/wordpress-playground/blob/c27a05386ce480c19a67be316d9bc093ffeec256/packages/playground/wordpress/src/index.ts#L391-L462).

## Testing instructions

Just confirm it doesn't break CI. We don't have an easy way of running this PR in Playground (simply installing the plugin will trigger different code paths).