### PR TITLE
Revert the QM_RUN_IN_CLI constant

### DIFF
--- a/integrations/query-monitor/boot.php
+++ b/integrations/query-monitor/boot.php
@@ -39,9 +39,7 @@ if ( defined( 'WP_INSTALLING' ) && WP_INSTALLING ) {
 }
 
 if ( 'cli' === php_sapi_name() && ! defined( 'QM_TESTS' ) ) {
-	if ( ! defined( 'QM_RUN_IN_CLI' ) || ! QM_RUN_IN_CLI ) {
-		return;
-	}
+	return;
 }
 
 if ( defined( 'DOING_CRON' ) && DOING_CRON ) {


### PR DESCRIPTION
https://github.com/WordPress/sqlite-database-integration/pull/215 added a `QM_RUN_IN_CLI` check to enable running Query Monitor with the CLI sapi (it's always `cli` in Playground). Turns out, QM_TESTS is enough and shouldn't have any side-effects (at least in the current release). Let's roll back `QM_RUN_IN_CLI`.