### PR TITLE
Make Query Monitor enhancements work in Playground

### DIFF
--- a/integrations/query-monitor/boot.php
+++ b/integrations/query-monitor/boot.php
@@ -56,6 +56,7 @@ if ( is_admin() ) {
 	}
 }
 
+global $wpdb;
 if ( ! isset( $wpdb ) ) {
 	return;
 }

--- a/integrations/query-monitor/boot.php
+++ b/integrations/query-monitor/boot.php
@@ -125,3 +125,12 @@ if ( ! defined( 'SAVEQUERIES' ) ) {
 
 // 5. Mark the Query Monitor integration as loaded.
 define( 'SQLITE_QUERY_MONITOR_LOADED', true );
+
+// 6. Register the SQLite enhancements for Query Monitor.
+function register_sqlite_enhancements_for_query_monitor() {
+	require_once __DIR__ . '/plugin.php';
+}
+
+if ( function_exists( 'add_action' ) ) {
+	add_action( 'plugins_loaded', 'register_sqlite_enhancements_for_query_monitor' );
+}

--- a/load.php
+++ b/load.php
@@ -26,8 +26,3 @@ require_once __DIR__ . '/activate.php';
 require_once __DIR__ . '/deactivate.php';
 require_once __DIR__ . '/admin-notices.php';
 require_once __DIR__ . '/health-check.php';
-
-// Query Monitor integration:
-if ( defined( 'SQLITE_QUERY_MONITOR_LOADED' ) && SQLITE_QUERY_MONITOR_LOADED ) {
-	require_once __DIR__ . '/integrations/query-monitor/plugin.php';
-}


### PR DESCRIPTION
This PR moves the registration of the SQLite enhancements for Query Monitor to the Query Monitor boot process to make them work in Playground, as Playground only loads the SQLite driver and not all the SQLite Database Integration plugin.

<img width="737" height="435" alt="Screenshot 2025-07-25 at 13 27 21" src="https://github.com/user-attachments/assets/23dab435-b2c7-4194-a360-aea17a049772" />
