### PR TITLE
[Query monitor] Tolerate null $value in boot.php

### DIFF
--- a/integrations/query-monitor/boot.php
+++ b/integrations/query-monitor/boot.php
@@ -69,17 +69,20 @@ if ( null === $wpdb->options ) {
 
 $query_monitor_active = false;
 try {
-	$value                = $wpdb->get_row(
+	$value = $wpdb->get_row(
 		$wpdb->prepare(
 			"SELECT option_value FROM $wpdb->options WHERE option_name = %s LIMIT 1",
 			'active_plugins'
 		)
 	);
-	$query_monitor_active = in_array(
-		'query-monitor/query-monitor.php',
-		unserialize( $value->option_value ),
-		true
-	);
+	// $value may be null on multisites
+	if ( null !== $value ) {
+		$query_monitor_active = in_array(
+			'query-monitor/query-monitor.php',
+			unserialize( $value->option_value ),
+			true
+		);
+	}
 } catch ( Throwable $e ) {
 	return;
 }

--- a/integrations/query-monitor/boot.php
+++ b/integrations/query-monitor/boot.php
@@ -75,7 +75,10 @@ try {
 			'active_plugins'
 		)
 	);
-	// $value may be null on multisites
+	/**
+	 * $value may be null during WordPress Playground multisite setup.
+	 * @see https://github.com/WordPress/sqlite-database-integration/pull/219.
+	 */
 	if ( null !== $value ) {
 		$query_monitor_active = in_array(
 			'query-monitor/query-monitor.php',


### PR DESCRIPTION
PR #217 added a line `global $wpdb` to `integration/query-monitor/boot.php` which triggered this warning in WordPress Playground multisite tests:

```
+ <b>Warning</b>:  Attempt to read property "option_value" on null in <b>/internal/shared/sqlite-database-integration/integrations/query-monitor/boot.php</b> on line <b>80</b><br />
```

Removing either `global $wpdb` or guarding against a null `$value` solves the failure. I assume there's a reason for adding `global $wpdb` so, in this PR, I'm adding a guard against a null value.