### PR TITLE
Add support for table locking statements and transaction savepoints

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6238,4 +6238,60 @@ END;
 		$result = $this->assertQuery( 'SELECT @my_var' );
 		$this->assertEquals( 3, $result[0]->{'@my_var'} );
 	}
+
+	public function testLockingStatements(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT)' );
+
+		// When there is no lock, UNLOCK statement shouldn't fail.
+		$this->assertQuery( 'UNLOCK TABLES' );
+
+		// READ LOCK.
+		$this->assertQuery( 'LOCK TABLES t READ' );
+		$this->assertQuery( 'UNLOCK TABLES' );
+
+		// WRITE LOCK.
+		$this->assertQuery( 'LOCK TABLES t WRITE' );
+		$this->assertQuery( 'UNLOCK TABLES' );
+
+		// LOCK inside a transaction.
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'LOCK TABLES t WRITE' );
+		$this->assertQuery( 'UNLOCK TABLES' );
+		$this->assertQuery( 'COMMIT' );
+
+		// Transaction inside LOCK statements.
+		$this->assertQuery( 'LOCK TABLES t WRITE' );
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'COMMIT' );
+		$this->assertQuery( 'UNLOCK TABLES' );
+	}
+
+	public function testLockNonExistentTableForRead(): void {
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( "Table 'wp.t' doesn't exist" );
+		$this->assertQuery( 'LOCK TABLES t READ' );
+	}
+
+	public function testLockNonExistentTableForWrite(): void {
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( "Table 'wp.t' doesn't exist" );
+		$this->assertQuery( 'LOCK TABLES t WRITE' );
+	}
+
+	public function testLockMultipleWithNonExistentTable(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT)' );
+		$this->assertQuery( 'CREATE TABLE t3 (id INT)' );
+
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( "Table 'wp.t2' doesn't exist" );
+		$this->assertQuery( 'LOCK TABLES t1 READ, t2 READ, t3 WRITE' );
+	}
+
+	public function testLockTemporaryTables(): void {
+		$this->assertQuery( 'CREATE TEMPORARY TABLE t1 (id INT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT)' );
+		$this->assertQuery( 'CREATE TEMPORARY TABLE t3 (id INT)' );
+		$this->assertQuery( 'LOCK TABLES t1 READ, t2 READ, t3 WRITE' );
+		$this->assertQuery( 'UNLOCK TABLES' );
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6294,4 +6294,38 @@ END;
 		$this->assertQuery( 'LOCK TABLES t1 READ, t2 READ, t3 WRITE' );
 		$this->assertQuery( 'UNLOCK TABLES' );
 	}
+
+	public function testTransactionSavepoints(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT)' );
+
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (1)' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertSame( array( '1' ), (array) array_column( $result, 'id' ) );
+
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (2)' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertSame( array( '1', '2' ), (array) array_column( $result, 'id' ) );
+
+		$this->assertQuery( 'SAVEPOINT sp2' );
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (3)' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertSame( array( '1', '2', '3' ), (array) array_column( $result, 'id' ) );
+
+		$this->assertQuery( 'ROLLBACK TO SAVEPOINT sp1' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertSame( array( '1' ), (array) array_column( $result, 'id' ) );
+
+		$this->assertQuery( 'RELEASE SAVEPOINT sp1' );
+		$this->assertQuery( 'ROLLBACK' );
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertSame( array(), (array) array_column( $result, 'id' ) );
+	}
+
+	public function testRollbackNonExistentTransactionSavepoint(): void {
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( 'no such savepoint: sp1' );
+		$this->assertQuery( 'ROLLBACK TO SAVEPOINT sp1' );
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -4144,27 +4144,27 @@ QUERY
 		return array(
 			array(
 				'SELECT * FROM _wp_sqlite_t',
-				"Invalid identifier `_wp_sqlite_t`, prefix '_wp_sqlite_' is reserved",
+				"Invalid identifier '_wp_sqlite_t', prefix '_wp_sqlite_' is reserved",
 			),
 			array(
 				'SELECT _wp_sqlite_t FROM t',
-				"Invalid identifier `_wp_sqlite_t`, prefix '_wp_sqlite_' is reserved",
+				"Invalid identifier '_wp_sqlite_t', prefix '_wp_sqlite_' is reserved",
 			),
 			array(
 				'SELECT t._wp_sqlite_t FROM t',
-				"Invalid identifier `t`.`_wp_sqlite_t`, prefix '_wp_sqlite_' is reserved",
+				"Invalid identifier '_wp_sqlite_t', prefix '_wp_sqlite_' is reserved",
 			),
 			array(
 				'CREATE TABLE _wp_sqlite_t (id INT)',
-				"Invalid identifier `_wp_sqlite_t`, prefix '_wp_sqlite_' is reserved",
+				"Invalid identifier '_wp_sqlite_t', prefix '_wp_sqlite_' is reserved",
 			),
 			array(
 				'ALTER TABLE _wp_sqlite_t ADD COLUMN name TEXT',
-				"Invalid identifier `_wp_sqlite_t`, prefix '_wp_sqlite_' is reserved",
+				"Invalid identifier '_wp_sqlite_t', prefix '_wp_sqlite_' is reserved",
 			),
 			array(
 				'DROP TABLE _wp_sqlite_t',
-				"Invalid identifier `_wp_sqlite_t`, prefix '_wp_sqlite_' is reserved",
+				"Invalid identifier '_wp_sqlite_t', prefix '_wp_sqlite_' is reserved",
 			),
 		);
 	}

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -812,7 +812,8 @@ class WP_SQLite_Driver {
 			 */
 			$this->execute_sqlite_query( $this->is_readonly ? 'BEGIN' : 'BEGIN IMMEDIATE' );
 		} else {
-			$this->execute_sqlite_query( 'SAVEPOINT LEVEL' . $this->transaction_level );
+			$savepoint_name = $this->get_internal_savepoint_name( $this->transaction_level );
+			$this->execute_sqlite_query( sprintf( 'SAVEPOINT %s', $savepoint_name ) );
 		}
 		++$this->transaction_level;
 	}
@@ -829,7 +830,8 @@ class WP_SQLite_Driver {
 		if ( 0 === $this->transaction_level ) {
 			$this->execute_sqlite_query( 'COMMIT' );
 		} else {
-			$this->execute_sqlite_query( 'RELEASE SAVEPOINT LEVEL' . $this->transaction_level );
+			$savepoint_name = $this->get_internal_savepoint_name( $this->transaction_level );
+			$this->execute_sqlite_query( sprintf( 'RELEASE SAVEPOINT %s', $savepoint_name ) );
 		}
 	}
 
@@ -845,7 +847,8 @@ class WP_SQLite_Driver {
 		if ( 0 === $this->transaction_level ) {
 			$this->execute_sqlite_query( 'ROLLBACK' );
 		} else {
-			$this->execute_sqlite_query( 'ROLLBACK TO SAVEPOINT LEVEL' . $this->transaction_level );
+			$savepoint_name = $this->get_internal_savepoint_name( $this->transaction_level );
+			$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
 		}
 	}
 
@@ -4107,6 +4110,19 @@ class WP_SQLite_Driver {
 		// Prefix the original index name with the table name.
 		// This is to avoid conflicting index names in SQLite.
 		return $mysql_table_name . '__' . $mysql_index_name;
+	}
+
+	/**
+	 * Get an internal savepoint name.
+	 *
+	 * Internal savepoints are used to emulate MySQL transactions that are run
+	 * inside a wrapping SQLite transaction, as transactions can't be nested.
+	 *
+	 * @param  int $level The transaction nesting level.
+	 * @return string     The internal savepoint name.
+	 */
+	private function get_internal_savepoint_name( int $level ): string {
+		return sprintf( '%ssavepoint_%d', self::RESERVED_PREFIX, $level );
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1033,9 +1033,27 @@ class WP_SQLite_Driver {
 
 				// Unknown statement. Fall through to the default case.
 			case 'savepointStatement':
-				// ROLLBACK.
+				$savepoint_name = $this->translate( $subnode->get_first_child_node( 'identifier' ) );
+
+				// ROLLBACK/ROLLBACK TO SAVEPOINT <identifier>.
 				if ( WP_MySQL_Lexer::ROLLBACK_SYMBOL === $token->id ) {
-					$this->rollback();
+					if ( null === $savepoint_name ) {
+						$this->rollback();
+					} else {
+						$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
+					}
+					break;
+				}
+
+				// SAVEPOINT.
+				if ( WP_MySQL_Lexer::SAVEPOINT_SYMBOL === $token->id ) {
+					$this->execute_sqlite_query( sprintf( 'SAVEPOINT %s', $savepoint_name ) );
+					break;
+				}
+
+				// RELEASE SAVEPOINT.
+				if ( WP_MySQL_Lexer::RELEASE_SYMBOL === $token->id ) {
+					$this->execute_sqlite_query( sprintf( 'RELEASE SAVEPOINT %s', $savepoint_name ) );
 					break;
 				}
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2791,6 +2791,17 @@ class WP_SQLite_Driver {
 	private function translate_pure_identifier( WP_Parser_Node $node ): string {
 		$token = $node->get_first_child_token();
 		$value = $token->get_value();
+
+		if ( str_starts_with( $value, self::RESERVED_PREFIX ) ) {
+			throw $this->new_driver_exception(
+				sprintf(
+					"Invalid identifier '%s', prefix '%s' is reserved",
+					$value,
+					self::RESERVED_PREFIX
+				)
+			);
+		}
+
 		return '`' . str_replace( '`', '``', $value ) . '`';
 	}
 
@@ -2811,8 +2822,7 @@ class WP_SQLite_Driver {
 		?WP_Parser_Node $object_node = null,
 		?WP_Parser_Node $child_node = null
 	): string {
-		$parts                = array();
-		$uses_reserved_prefix = false;
+		$parts = array();
 
 		// Database name.
 		$is_information_schema = 'information_schema' === $this->db_name;
@@ -2861,38 +2871,16 @@ class WP_SQLite_Driver {
 				);
 				$parts[]     = $this->information_schema_builder->get_table_name( false, $object_name );
 			} else {
-				$quoted_object_name = $this->translate( $object_node );
-				$object_name        = $this->unquote_sqlite_identifier( $quoted_object_name );
-				if ( str_starts_with( $object_name, self::RESERVED_PREFIX ) ) {
-					$uses_reserved_prefix = true;
-				}
-				$parts[] = $quoted_object_name;
+				$parts[] = $this->translate( $object_node );
 			}
 		}
 
 		// Object child name (column, index, etc.).
 		if ( null !== $child_node ) {
-			$quoted_object_name = $this->translate( $child_node );
-			$object_name        = $this->unquote_sqlite_identifier( $quoted_object_name );
-			if ( str_starts_with( $object_name, self::RESERVED_PREFIX ) ) {
-				$uses_reserved_prefix = true;
-			}
-			$parts[] = $quoted_object_name;
+			$parts[] = $this->translate( $child_node );
 		}
 
-		$identifier = implode( '.', $parts );
-
-		if ( true === $uses_reserved_prefix ) {
-			throw $this->new_driver_exception(
-				sprintf(
-					"Invalid identifier %s, prefix '%s' is reserved",
-					$identifier,
-					self::RESERVED_PREFIX
-				)
-			);
-		}
-
-		return $identifier;
+		return implode( '.', $parts );
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -666,64 +666,34 @@ class WP_SQLite_Driver {
 				throw $this->new_driver_exception( 'Multi-query is not supported.' );
 			}
 
-			// Handle transaction commands.
-
 			/*
+			 * Determine if we need to wrap the translated queries in a transaction.
+			 *
 			 * [GRAMMAR]
-			 * beginWork: BEGIN_SYMBOL WORK_SYMBOL?
+			 * query:
+			 *   EOF
+			 *   | (simpleStatement | beginWork) (SEMICOLON_SYMBOL EOF? | EOF)
 			 */
-			$child = $ast->get_first_child();
-			if ( $child instanceof WP_Parser_Node && 'beginWork' === $child->rule_name ) {
+			$child_node = $ast->get_first_child_node();
+			if (
+				null === $child_node
+				|| 'beginWork' === $child_node->rule_name
+				|| $child_node->has_child_node( 'transactionOrLockingStatement' )
+			) {
+				$wrap_in_transaction = false;
+			} else {
+				$wrap_in_transaction = true;
+			}
+
+			if ( $wrap_in_transaction ) {
 				$this->begin_transaction();
-				return true;
 			}
 
-			if ( $child instanceof WP_Parser_Node && 'simpleStatement' === $child->rule_name ) {
-				/*
-				 * [GRAMMAR]
-				 * transactionOrLockingStatement:
-				 *   transactionStatement | savepointStatement | lockStatement | xaStatement
-				 */
-				$subchild = $child->get_first_child_node( 'transactionOrLockingStatement' );
-				if ( null !== $subchild ) {
-					$tokens = $subchild->get_descendant_tokens();
-					$token1 = $tokens[0];
-					$token2 = $tokens[1] ?? null;
-					if (
-						WP_MySQL_Lexer::START_SYMBOL === $token1->id
-						&& WP_MySQL_Lexer::TRANSACTION_SYMBOL === $token2->id
-					) {
-						$this->begin_transaction();
-						return true;
-					}
-
-					if (
-						WP_MySQL_Lexer::BEGIN_SYMBOL === $token1->id
-					) {
-						$this->begin_transaction();
-						return true;
-					}
-
-					if (
-						WP_MySQL_Lexer::COMMIT_SYMBOL === $token1->id
-					) {
-						$this->commit();
-						return true;
-					}
-
-					if (
-						WP_MySQL_Lexer::ROLLBACK_SYMBOL === $token1->id
-					) {
-						$this->rollback();
-						return true;
-					}
-				}
-			}
-
-			// Perform all the queries in a nested transaction.
-			$this->begin_transaction();
 			$this->execute_mysql_query( $ast );
-			$this->commit();
+
+			if ( $wrap_in_transaction ) {
+				$this->commit();
+			}
 			return $this->last_return_value;
 		} catch ( Throwable $e ) {
 			try {
@@ -895,6 +865,11 @@ class WP_SQLite_Driver {
 			);
 		}
 
+		if ( 'beginWork' === $children[0]->rule_name ) {
+			$this->begin_transaction();
+			return;
+		}
+
 		if ( 'simpleStatement' !== $children[0]->rule_name ) {
 			throw $this->new_driver_exception(
 				sprintf( 'Expected "simpleStatement" node, got: "%s"', $children[0]->rule_name )
@@ -904,6 +879,9 @@ class WP_SQLite_Driver {
 		// Process the "simpleStatement" AST node.
 		$node = $children[0]->get_first_child_node();
 		switch ( $node->rule_name ) {
+			case 'transactionOrLockingStatement':
+				$this->execute_transaction_or_locking_statement( $node );
+				break;
 			case 'selectStatement':
 				$this->is_readonly = true;
 				$this->execute_select_statement( $node );
@@ -1013,6 +991,49 @@ class WP_SQLite_Driver {
 			default:
 				throw $this->new_not_supported_exception(
 					sprintf( 'statement type: "%s"', $node->rule_name )
+				);
+		}
+	}
+
+	/**
+	 * Execute a MySQL transaction or locking statement in SQLite.
+	 *
+	 * @param  WP_Parser_Node $node       The "transactionOrLockingStatement" AST node.
+	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
+	 */
+	private function execute_transaction_or_locking_statement( WP_Parser_Node $node ): void {
+		$subnode = $node->get_first_child_node();
+		$token   = $node->get_first_descendant_token();
+		switch ( $subnode->rule_name ) {
+			case 'transactionStatement':
+				// START TRANSACTION.
+				if ( WP_MySQL_Lexer::START_SYMBOL === $token->id ) {
+					$this->begin_transaction();
+					break;
+				}
+
+				// COMMIT.
+				if ( WP_MySQL_Lexer::COMMIT_SYMBOL === $token->id ) {
+					$this->commit();
+					break;
+				}
+
+				// Unknown statement. Fall through to the default case.
+			case 'savepointStatement':
+				// ROLLBACK.
+				if ( WP_MySQL_Lexer::ROLLBACK_SYMBOL === $token->id ) {
+					$this->rollback();
+					break;
+				}
+
+				// Unknown statement. Fall through to the default case.
+			default:
+				throw $this->new_not_supported_exception(
+					sprintf(
+						'statement type: "%s" > "%s"',
+						$node->rule_name,
+						$subnode->rule_name
+					)
 				);
 		}
 	}

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -400,6 +400,16 @@ class WP_SQLite_Driver {
 	private $transaction_level = 0;
 
 	/**
+	 * Whether a MySQL table lock is active.
+	 *
+	 * Set to "true" when a lock is acquired using the MySQL LOCK statement.
+	 * Set to "false" when locks are released using the MySQL UNLOCK statement.
+	 *
+	 * @var bool
+	 */
+	private $table_lock_active = false;
+
+	/**
 	 * The PDO fetch mode used for the emulated query.
 	 *
 	 * @var mixed
@@ -1023,6 +1033,60 @@ class WP_SQLite_Driver {
 				// ROLLBACK.
 				if ( WP_MySQL_Lexer::ROLLBACK_SYMBOL === $token->id ) {
 					$this->rollback();
+					break;
+				}
+
+				// Unknown statement. Fall through to the default case.
+			case 'lockStatement':
+				// LOCK TABLE/LOCK TABLES.
+				if (
+					WP_MySQL_Lexer::LOCK_SYMBOL === $token->id
+					&& $subnode->has_child_node( 'lockItem' )
+				) {
+					// Check if the table(s) exists.
+					$lock_items = $subnode->get_child_nodes( 'lockItem' );
+					foreach ( $lock_items as $lock_item ) {
+						$table_name = $this->unquote_sqlite_identifier(
+							$this->translate( $lock_item->get_first_child_node( 'tableRef' ) )
+						);
+						try {
+							/*
+							* Attempt to query the table directly rather than checking
+							* SQLite schema or information schema tables, so that we
+							* can handle persistent and temporary tables in one query.
+							*/
+							$this->execute_sqlite_query(
+								sprintf( 'SELECT 1 FROM %s LIMIT 0', $table_name )
+							);
+						} catch ( PDOException $e ) {
+							throw $this->new_driver_exception(
+								sprintf( "Table '%s.%s' doesn't exist", $this->db_name, $table_name ),
+								'42S02'
+							);
+						}
+					}
+
+					// Start a transaction when no top-level transaction is active.
+					if ( 0 === $this->transaction_level ) {
+						$this->begin_transaction();
+						$this->table_lock_active = true;
+					}
+					break;
+				}
+
+				// UNLOCK TABLES/UNLOCK TABLE.
+				if (
+					WP_MySQL_Lexer::UNLOCK_SYMBOL === $token->id
+					&& (
+						$subnode->has_child_token( WP_MySQL_Lexer::TABLE_SYMBOL )
+						|| $subnode->has_child_token( WP_MySQL_Lexer::TABLES_SYMBOL )
+					)
+				) {
+					// Commit the transaction when created by the LOCK statement.
+					if ( 1 === $this->transaction_level && $this->table_lock_active ) {
+						$this->commit();
+						$this->table_lock_active = false;
+					}
 					break;
 				}
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1017,21 +1017,22 @@ class WP_SQLite_Driver {
 	private function execute_transaction_or_locking_statement( WP_Parser_Node $node ): void {
 		$subnode = $node->get_first_child_node();
 		$token   = $node->get_first_descendant_token();
+
 		switch ( $subnode->rule_name ) {
 			case 'transactionStatement':
 				// START TRANSACTION.
 				if ( WP_MySQL_Lexer::START_SYMBOL === $token->id ) {
 					$this->begin_transaction();
-					break;
+					return;
 				}
 
 				// COMMIT.
 				if ( WP_MySQL_Lexer::COMMIT_SYMBOL === $token->id ) {
 					$this->commit();
-					break;
+					return;
 				}
 
-				// Unknown statement. Fall through to the default case.
+				break;
 			case 'savepointStatement':
 				$savepoint_name = $this->translate( $subnode->get_first_child_node( 'identifier' ) );
 
@@ -1042,22 +1043,22 @@ class WP_SQLite_Driver {
 					} else {
 						$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
 					}
-					break;
+					return;
 				}
 
 				// SAVEPOINT.
 				if ( WP_MySQL_Lexer::SAVEPOINT_SYMBOL === $token->id ) {
 					$this->execute_sqlite_query( sprintf( 'SAVEPOINT %s', $savepoint_name ) );
-					break;
+					return;
 				}
 
 				// RELEASE SAVEPOINT.
 				if ( WP_MySQL_Lexer::RELEASE_SYMBOL === $token->id ) {
 					$this->execute_sqlite_query( sprintf( 'RELEASE SAVEPOINT %s', $savepoint_name ) );
-					break;
+					return;
 				}
 
-				// Unknown statement. Fall through to the default case.
+				break;
 			case 'lockStatement':
 				// LOCK TABLE/LOCK TABLES.
 				if (
@@ -1092,7 +1093,7 @@ class WP_SQLite_Driver {
 						$this->begin_transaction();
 						$this->table_lock_active = true;
 					}
-					break;
+					return;
 				}
 
 				// UNLOCK TABLES/UNLOCK TABLE.
@@ -1108,19 +1109,19 @@ class WP_SQLite_Driver {
 						$this->commit();
 						$this->table_lock_active = false;
 					}
-					break;
+					return;
 				}
 
-				// Unknown statement. Fall through to the default case.
-			default:
-				throw $this->new_not_supported_exception(
-					sprintf(
-						'statement type: "%s" > "%s"',
-						$node->rule_name,
-						$subnode->rule_name
-					)
-				);
+				break;
 		}
+
+		throw $this->new_not_supported_exception(
+			sprintf(
+				'statement type: "%s" > "%s"',
+				$node->rule_name,
+				$subnode->rule_name
+			)
+		);
 	}
 
 	/**
@@ -1727,11 +1728,11 @@ class WP_SQLite_Driver {
 		switch ( $keyword1->id ) {
 			case WP_MySQL_Lexer::DATABASES_SYMBOL:
 				$this->execute_show_databases_statement( $node );
-				break;
+				return;
 			case WP_MySQL_Lexer::COLUMNS_SYMBOL:
 			case WP_MySQL_Lexer::FIELDS_SYMBOL:
 				$this->execute_show_columns_statement( $node );
-				break;
+				return;
 			case WP_MySQL_Lexer::CREATE_SYMBOL:
 				if ( WP_MySQL_Lexer::TABLE_SYMBOL === $keyword2->id ) {
 					$table_name = $this->unquote_sqlite_identifier(
@@ -1754,7 +1755,7 @@ class WP_SQLite_Driver {
 					}
 					return;
 				}
-				// Fall through to default.
+				break;
 			case WP_MySQL_Lexer::INDEX_SYMBOL:
 			case WP_MySQL_Lexer::INDEXES_SYMBOL:
 			case WP_MySQL_Lexer::KEYS_SYMBOL:
@@ -1762,7 +1763,7 @@ class WP_SQLite_Driver {
 					$this->translate( $node->get_first_child_node( 'tableRef' ) )
 				);
 				$this->execute_show_index_statement( $table_name );
-				break;
+				return;
 			case WP_MySQL_Lexer::GRANTS_SYMBOL:
 				$this->set_results_from_fetched_data(
 					array(
@@ -1774,22 +1775,22 @@ class WP_SQLite_Driver {
 				return;
 			case WP_MySQL_Lexer::TABLE_SYMBOL:
 				$this->execute_show_table_status_statement( $node );
-				break;
+				return;
 			case WP_MySQL_Lexer::TABLES_SYMBOL:
 				$this->execute_show_tables_statement( $node );
-				break;
+				return;
 			case WP_MySQL_Lexer::VARIABLES_SYMBOL:
 				$this->last_result = true;
 				return;
-			default:
-				throw $this->new_not_supported_exception(
-					sprintf(
-						'statement type: "%s" > "%s"',
-						$node->rule_name,
-						$keyword1->get_value()
-					)
-				);
 		}
+
+		throw $this->new_not_supported_exception(
+			sprintf(
+				'statement type: "%s" > "%s"',
+				$node->rule_name,
+				$keyword1->get_value()
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR includes the following changes:

- Add support for `LOCK` and `UNLOCK` statements.
- Add support for transaction savepoints (`SAVEPOINT`, `ROLLBACK TO`, `RELEASE SAVEPOINT`)
- Improve verification of internal identifier names
