### PR TITLE
Implement disambiguation for unqualified columns in `ORDER BY`

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -31,6 +31,7 @@
 
 	<!-- Directories and third party library exclusions. -->
 	<exclude-pattern>/vendor/*</exclude-pattern>
+	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/wordpress/*</exclude-pattern>
 	<exclude-pattern>/wp-includes/sqlite/class-wp-sqlite-crosscheck-db.php</exclude-pattern>
 

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6466,6 +6466,116 @@ END;
 		$this->assertQuery( 'SELECT 1 FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name' );
 	}
 
+	public function testSelectGroupByAmbiguousColumnResolution(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+		$this->assertQuery( 'INSERT INTO t1 (id, name) VALUES (1, "A"), (2, "A")' );
+		$this->assertQuery( 'INSERT INTO t2 (id, name) VALUES (1, "B1"), (2, "B2")' );
+
+		// The "name" column will be resolved to "t1.name" as per the SELECT item.
+		$result = $this->assertQuery( 'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name' );
+		$this->assertEquals(
+			array( (object) array( 'name' => 'A' ) ),
+			$result
+		);
+
+		// The "name" column will be resolved to "t2.name" as per the SELECT item.
+		$result = $this->assertQuery( 'SELECT t2.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name' );
+		$this->assertEquals(
+			array(
+				(object) array( 'name' => 'B1' ),
+				(object) array( 'name' => 'B2' ),
+			),
+			$result
+		);
+
+		// Parenthesized column reference can be used in both SELECT and GROUP BY lists.
+		$result = $this->assertQuery( 'SELECT (t1.name) FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY (((name)))' );
+		$this->assertEquals(
+			array( (object) array( '(t1.name)' => 'A' ) ),
+			$result
+		);
+
+		/*
+		 * The following query fails with "ambiguous column name" in MySQL, but
+		 * in SQLite, it works. It's OK to keep this difference as MySQL behaves
+		 * rather strangely in this case:
+		 *
+		 *   1) This is OK in MySQL:
+		 *        SELECT t1.name AS col, 123 AS col ... GROUP BY col
+		 *   2) This fails in MySQL:
+		 *        SELECT t1.name AS col, t2.name AS col ... GROUP BY col
+		 */
+		$this->assertQuery( 'SELECT t1.name AS col, t2.name AS col FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY col' );
+	}
+
+	public function testSelectGroupByAmbiguousColumnError(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( 'ambiguous column name: name' );
+		$this->assertQuery( 'SELECT t1.name, t2.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name' );
+	}
+
+	public function testSelectGroupByAmbiguousColumnErrorWithoutSelectList(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( 'ambiguous column name: name' );
+		$this->assertQuery( 'SELECT 1 FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name' );
+	}
+
+	public function testSelectHavingAmbiguousColumnResolution(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+		$this->assertQuery( 'INSERT INTO t1 (id, name) VALUES (1, "A"), (2, "A")' );
+		$this->assertQuery( 'INSERT INTO t2 (id, name) VALUES (1, "B1"), (2, "B2")' );
+
+		// The "name" column will be resolved to "t1.name" as per the SELECT item.
+		$result = $this->assertQuery( 'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name' );
+		$this->assertEquals( array(), $result );
+
+		// The "name" column will be resolved to "t2.name" as per the SELECT item.
+		$result = $this->assertQuery( 'SELECT t2.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name' );
+		$this->assertEquals( array(), $result );
+
+		// Parenthesized column reference can be used in both SELECT and GROUP BY lists.
+		$result = $this->assertQuery( 'SELECT (t1.name) FROM t1 JOIN t2 ON t2.id = t1.id HAVING (((name)))' );
+		$this->assertEquals( array(), $result );
+
+		/*
+		 * The following query fails with "ambiguous column name" in MySQL, but
+		 * in SQLite, it works. It's OK to keep this difference as MySQL behaves
+		 * rather strangely in this case:
+		 *
+		 *   1) This is OK in MySQL:
+		 *        SELECT t1.name AS col, 123 AS col ... HAVING col
+		 *   2) This fails in MySQL:
+		 *        SELECT t1.name AS col, t2.name AS col ... HAVING col
+		 */
+		$this->assertQuery( 'SELECT t1.name AS col, t2.name AS col FROM t1 JOIN t2 ON t2.id = t1.id HAVING col' );
+	}
+
+	public function testSelectHavingAmbiguousColumnError(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( 'ambiguous column name: name' );
+		$this->assertQuery( 'SELECT t1.name, t2.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name' );
+	}
+
+	public function testSelectHavingAmbiguousColumnErrorWithoutSelectList(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( 'ambiguous column name: name' );
+		$this->assertQuery( 'SELECT 1 FROM t1 JOIN t2 ON t2.id = t1.id HAVING name' );
+	}
+
 	public function testRollbackNonExistentTransactionSavepoint(): void {
 		$this->expectException( 'WP_SQLite_Driver_Exception' );
 		$this->expectExceptionMessage( 'no such savepoint: sp1' );

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6323,6 +6323,149 @@ END;
 		$this->assertSame( array(), (array) array_column( $result, 'id' ) );
 	}
 
+	public function testSelectOrderByAmbiguousColumnResolution(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+		$this->assertQuery( 'INSERT INTO t1 (id, name) VALUES (1, "A1"), (2, "A2")' );
+		$this->assertQuery( 'INSERT INTO t2 (id, name) VALUES (1, "B2"), (2, "B1")' );
+
+		// The "name" column will be resolved to "t1.name" as per the SELECT item.
+		$result = $this->assertQuery( 'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC' );
+		$this->assertEquals(
+			array(
+				(object) array( 'name' => 'A2' ),
+				(object) array( 'name' => 'A1' ),
+			),
+			$result
+		);
+
+		// The "name" column will be resolved to "t2.name" as per the SELECT item.
+		$result = $this->assertQuery( 'SELECT t2.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC' );
+		$this->assertEquals(
+			array(
+				(object) array( 'name' => 'B2' ),
+				(object) array( 'name' => 'B1' ),
+			),
+			$result
+		);
+
+		// The "name" column will be resolved to "t1.name", the "id" column will be resolved to "t2.id".
+		$this->assertQuery( 'INSERT INTO t1 (id, name) VALUES (3, "A2")' );
+		$this->assertQuery( 'INSERT INTO t2 (id, name) VALUES (3, "A2")' );
+		$result = $this->assertQuery( 'SELECT t2.id, t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name, id DESC' );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'id'   => '1',
+					'name' => 'A1',
+				),
+				(object) array(
+					'id'   => '3',
+					'name' => 'A2',
+				),
+				(object) array(
+					'id'   => '2',
+					'name' => 'A2',
+				),
+			),
+			$result
+		);
+
+		// The "name" column will be resolved to "t1.name" in the subquery and to "t2.name" in the root query.
+		$result = $this->assertQuery(
+			'
+			SELECT t2.name, s.name AS subquery_name
+			FROM (SELECT t1.id, t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC LIMIT 1) s
+			JOIN t2 ON true
+			ORDER BY name DESC
+		'
+		);
+		$this->assertEquals(
+			array(
+				(object) array(
+					'name'          => 'B2',
+					'subquery_name' => 'A2',
+				),
+				(object) array(
+					'name'          => 'B1',
+					'subquery_name' => 'A2',
+				),
+				(object) array(
+					'name'          => 'A2',
+					'subquery_name' => 'A2',
+				),
+			),
+			$result
+		);
+
+		// Parenthesized column reference can be used in both SELECT and ORDER BY lists.
+		$result = $this->assertQuery( 'SELECT (t1.name) FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY (((name))) DESC' );
+		$this->assertEquals(
+			array(
+				(object) array( '(t1.name)' => 'A2' ),
+				(object) array( '(t1.name)' => 'A2' ),
+				(object) array( '(t1.name)' => 'A1' ),
+			),
+			$result
+		);
+
+		/*
+		 * With multiple identical aliases and no ambiguous column references,
+		 * it just works, although sometimes the order may differ from MySQL.
+		 * It may be nondeterministic, but it seems like MySQL picks the first
+		 * non-column alias, while SQLite sorts by the first alias in the list.
+		 *
+		 * When we replace "SELECT t1.name" with "SELECT t2.name" in the query
+		 * below, the SQLite order will differ from MySQL.
+		 */
+		$result = $this->assertQuery(
+			"
+			SELECT t1.name AS name, CONCAT(t1.name, '-one') AS name, CONCAT(t2.name, '-two') AS name
+			FROM t1 JOIN t2 ON t2.id = t1.id
+			ORDER BY name DESC
+		"
+		);
+		$this->assertEquals(
+			array(
+				(object) array( 'name' => 'B1-two' ),
+				(object) array( 'name' => 'A2-two' ),
+				(object) array( 'name' => 'B2-two' ),
+			),
+			$result
+		);
+
+		/*
+		 * The following query fails with "ambiguous column name" in MySQL, but
+		 * in SQLite, it works. It's OK to keep this difference as MySQL behaves
+		 * rather strangely in this case:
+		 *
+		 *   1) This is OK in MySQL:
+		 *        SELECT t1.name AS col, 123 AS col ... ORDER BY col
+		 *   2) This fails in MySQL:
+		 *        SELECT t1.name AS col, t2.name AS col ... ORDER BY col
+		 */
+		$this->assertQuery( 'SELECT t1.name AS col, t2.name AS col FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY col' );
+	}
+
+	public function testSelectOrderByAmbiguousColumnError(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( 'ambiguous column name: name' );
+		$this->assertQuery( 'SELECT t1.name, t2.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC' );
+	}
+
+
+	public function testSelectOrderByAmbiguousColumnErrorWithoutSelectList(): void {
+		$this->assertQuery( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->assertQuery( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		$this->expectException( 'WP_SQLite_Driver_Exception' );
+		$this->expectExceptionMessage( 'ambiguous column name: name' );
+		$this->assertQuery( 'SELECT 1 FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name' );
+	}
+
 	public function testRollbackNonExistentTransactionSavepoint(): void {
 		$this->expectException( 'WP_SQLite_Driver_Exception' );
 		$this->expectExceptionMessage( 'no such savepoint: sp1' );

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1409,6 +1409,57 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1_name` DESC',
 			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY `t1_name` DESC'
 		);
+
+		// With a parenthesized query body, the column should be disambiguated.
+		$this->assertQuery(
+			'( ( ( SELECT `t1`.`name` FROM `t1` ) ) ) ORDER BY `t1`.`name`',
+			'(((SELECT t1.name FROM t1))) ORDER BY name'
+		);
+
+		// The root query should not disambiguate from a nested SELECT item.
+		$this->assertQuery(
+			'SELECT ( SELECT `t1`.`name` FROM `t1` ) AS `t1_name` ORDER BY `name`',
+			'SELECT (SELECT t1.name FROM t1) AS t1_name ORDER BY name'
+		);
+
+		// With UNION, the column should not be disambiguated.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` UNION ALL SELECT `t2`.`name` FROM `t2` ORDER BY `name`',
+			'SELECT t1.name FROM t1 UNION ALL SELECT t2.name FROM t2 ORDER BY name'
+		);
+
+		// With EXCEPT, the column should not be disambiguated.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` EXCEPT SELECT `t2`.`name` FROM `t2` ORDER BY `name`',
+			'SELECT t1.name FROM t1 EXCEPT SELECT t2.name FROM t2 ORDER BY name'
+		);
+
+		// With INTERSECT, the column should not be disambiguated.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` INTERSECT SELECT `t2`.`name` FROM `t2` ORDER BY `name`',
+			'SELECT t1.name FROM t1 INTERSECT SELECT t2.name FROM t2 ORDER BY name'
+		);
+
+		// Test a complex query with CTEs.
+		$this->assertQuery(
+			'WITH'
+				. " `cte1` ( `name` ) AS ( SELECT 'a' UNION ALL SELECT 'b' ) ,"
+				. ' `cte2` ( `name` ) AS ( SELECT `t2`.`name` FROM `t2` JOIN `t1` ON `t1`.`id` = `t2`.`id` ORDER BY `t2`.`name` )'
+				. ' SELECT `t1`.`name` , ( SELECT `name` FROM `cte1` WHERE `id` = 1 ) AS `cte1_name` , ( SELECT `name` FROM `cte2` WHERE `id` = 2 ) AS `cte2_name`'
+				. ' FROM `t1`'
+				. ' ORDER BY `t1`.`name`',
+			"
+				WITH
+					cte1(name) AS (SELECT 'a' UNION ALL SELECT 'b'),
+					cte2(name) AS (SELECT t2.name FROM t2 JOIN t1 ON t1.id = t2.id ORDER BY name)
+				SELECT
+					t1.name,
+					(SELECT name FROM cte1 WHERE id = 1) AS cte1_name,
+					(SELECT name FROM cte2 WHERE id = 2) AS cte2_name
+				FROM t1
+				ORDER BY name
+			"
+		);
 	}
 
 	public function testSelectGroupByAmbiguousColumnResolution(): void {
@@ -1493,6 +1544,24 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		$this->assertQuery(
 			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1_name`',
 			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY `t1_name`'
+		);
+
+		// With UNION, the column should be disambiguated in its subquery (differs from ORDER BY).
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` UNION ALL SELECT `t2`.`name` FROM `t2` GROUP BY `t2`.`name`',
+			'SELECT t1.name FROM t1 UNION ALL SELECT t2.name FROM t2 GROUP BY name'
+		);
+
+		// With EXCEPT, the column should be disambiguated in its subquery (differs from ORDER BY).
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` EXCEPT SELECT `t2`.`name` FROM `t2` GROUP BY `t2`.`name`',
+			'SELECT t1.name FROM t1 EXCEPT SELECT t2.name FROM t2 GROUP BY name'
+		);
+
+		// With INTERSECT, the column should be disambiguated in its subquery (differs from ORDER BY).
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` INTERSECT SELECT `t2`.`name` FROM `t2` GROUP BY `t2`.`name`',
+			'SELECT t1.name FROM t1 INTERSECT SELECT t2.name FROM t2 GROUP BY name'
 		);
 	}
 
@@ -1580,6 +1649,24 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		$this->assertQuery(
 			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `name` = 1',
 			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name = 1'
+		);
+
+		// With UNION, the column should be disambiguated in its subquery (differs from ORDER BY).
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` UNION ALL SELECT `t2`.`name` FROM `t2` GROUP BY 1 HAVING `t2`.`name`',
+			'SELECT t1.name FROM t1 UNION ALL SELECT t2.name FROM t2 HAVING name'
+		);
+
+		// With EXCEPT, the column should be disambiguated in its subquery (differs from ORDER BY).
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` EXCEPT SELECT `t2`.`name` FROM `t2` GROUP BY 1 HAVING `t2`.`name`',
+			'SELECT t1.name FROM t1 EXCEPT SELECT t2.name FROM t2 HAVING name'
+		);
+
+		// With INTERSECT, the column should be disambiguated in its subquery (differs from ORDER BY).
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` INTERSECT SELECT `t2`.`name` FROM `t2` GROUP BY 1 HAVING `t2`.`name`',
+			'SELECT t1.name FROM t1 INTERSECT SELECT t2.name FROM t2 HAVING name'
 		);
 	}
 

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1406,8 +1406,180 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		// When the ORDER BY item uses an alias, there is no ambiguity.
 		$this->assertQuery(
-			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`t1_id` = `t1`.`id` ORDER BY `t1_name` DESC',
-			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY `t1_name` DESC'
+			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1_name` DESC',
+			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY `t1_name` DESC'
+		);
+	}
+
+	public function testSelectGroupByAmbiguousColumnResolution(): void {
+		$this->driver->query( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->driver->query( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		// Ambiguous column in GROUP BY clause is disambiguated by the SELECT item list.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1`.`name`',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name'
+		);
+
+		// Multiple ambiguous columns in GROUP BY clause are also disambiguated.
+		$this->assertQuery(
+			'SELECT `t1`.`id` , `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1`.`id`, `t1`.`name`',
+			'SELECT t1.id, t1.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY id, name'
+		);
+
+		// The disambiguation works with subqueries.
+		$this->assertQuery(
+			'SELECT `name` FROM ( SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1`.`name` ) GROUP BY `name`',
+			'SELECT name FROM (SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name) GROUP BY name'
+		);
+
+		// The disambiguation works in both root and subquery contexts at the same time.
+		$this->assertQuery(
+			'SELECT `ta`.`name` FROM ( SELECT `t2`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t2`.`name` ) `ta` GROUP BY `ta`.`name`',
+			'SELECT ta.name FROM (SELECT t2.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name) ta GROUP BY name'
+		);
+
+		// When the SELECT item is nested in a simple parentheses expression, the disambiguation still works.
+		$this->assertQuery(
+			'SELECT ( ( ( `t1`.`name` ) ) ) AS `(((t1.name)))` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1`.`name`',
+			'SELECT (((t1.name))) FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name'
+		);
+
+		// When the GROUP BY item is nested in a simple parentheses expression, the disambiguation still works.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1`.`name`',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY (((name)))'
+		);
+
+		// When the SELECT item is nested in a complex expression, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			"SELECT (`t1`.`name` || 'test') AS `CONCAT(t1.name, 'test')` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `name`",
+			"SELECT CONCAT(t1.name, 'test') FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name"
+		);
+
+		// When the GROUP BY item is nested in a complex expression, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			"SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY ( `name` || 'test' )",
+			"SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY (name || 'test')"
+		);
+
+		// When the SELECT list item uses an alias, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `name`',
+			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name'
+		);
+
+		// When the SELECT item list is ambiguous, the GROUP BY column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			'SELECT `t1`.`name` , `t2`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `name`',
+			'SELECT t1.name, t2.name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY name'
+		);
+
+		/*
+		 * The following edge case behaves differently than in MySQL.
+		 * This seems to be due to a quirk in SQLite, where the behavior of the
+		 * GROUP BY clause is different from the ORDER BY clause:
+		 *   - ORDER BY: SQLite will pick the first column or alias for sorting.
+		 *   - GROUP BY: SQLite will fail with an "ambiguous column name" error.
+		 *
+		 * @TODO: We can consider fixing this more correctly.
+		 */
+		$this->assertQuery(
+			"SELECT `t1`.`name` , 'test' AS `name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1`.`name`, `name`",
+			"SELECT t1.name, 'test' AS `name` FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY t1.name, name"
+		);
+
+		// When the GROUP BY item uses an alias, there is no ambiguity.
+		$this->assertQuery(
+			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY `t1_name`',
+			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id GROUP BY `t1_name`'
+		);
+	}
+
+	public function testSelectHavingAmbiguousColumnResolution(): void {
+		$this->driver->query( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->driver->query( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		// Ambiguous column in HAVING clause is disambiguated by the SELECT item list.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `t1`.`name`',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name'
+		);
+
+		// Multiple ambiguous columns in HAVING clause are also disambiguated (AND).
+		$this->assertQuery(
+			'SELECT `t1`.`id` , `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `t1`.`id` AND `t1`.`name`',
+			'SELECT t1.id, t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING id AND name'
+		);
+
+		// Multiple ambiguous columns in HAVING clause are also disambiguated (OR).
+		$this->assertQuery(
+			'SELECT `t1`.`id` , `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `t1`.`id` OR `t1`.`name`',
+			'SELECT t1.id, t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING id OR name'
+		);
+
+		// The disambiguation works with subqueries.
+		$this->assertQuery(
+			'SELECT `name` FROM ( SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `t1`.`name` ) GROUP BY 1 HAVING `name`',
+			'SELECT name FROM (SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name) HAVING name'
+		);
+
+		// The disambiguation works in both root and subquery contexts at the same time.
+		$this->assertQuery(
+			'SELECT `ta`.`name` FROM ( SELECT `t2`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `t2`.`name` ) `ta` GROUP BY 1 HAVING `ta`.`name`',
+			'SELECT ta.name FROM (SELECT t2.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name) ta HAVING name'
+		);
+
+		// When the HAVING item is nested in a simple parentheses expression, the disambiguation still works.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `t1`.`name`',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING (((name)))'
+		);
+
+		// When the SELECT item is nested in a complex expression, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			"SELECT (`t1`.`name` || 'test') AS `CONCAT(t1.name, 'test')` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `name`",
+			"SELECT CONCAT(t1.name, 'test') FROM t1 JOIN t2 ON t2.id = t1.id HAVING name"
+		);
+
+		// When the HAVING item is used in an aggregate function, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING COUNT ( `name` ) > 1',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING COUNT(name) > 1'
+		);
+
+		/*
+		 * The following edge case behaves differently than in MySQL.
+		 * This seems to be due to a quirk in SQLite, where the behavior of the
+		 * HAVING clause is different from the ORDER BY clause:
+		 *   - ORDER BY: SQLite will pick the first column or alias for sorting.
+		 *   - HAVING:   SQLite will fail with an "ambiguous column name" error.
+		 *
+		 * @TODO: We can consider fixing this more correctly.
+		 */
+		$this->assertQuery(
+			"SELECT `t1`.`name` , 'test' AS `name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `name`",
+			"SELECT t1.name, 'test' AS `name` FROM t1 JOIN t2 ON t2.id = t1.id HAVING name"
+		);
+
+		// When the HAVING item uses an alias, there is no ambiguity.
+		$this->assertQuery(
+			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `t1_name`',
+			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id HAVING `t1_name`'
+		);
+
+		/*
+		 * The following edge case should actually be disambiguated, as it is in MySQL.
+		 * THe HAVING clause behaves strangely in MySQL:
+		 *   - HAVING COUNT(name), HAVING SUM(name), etc. are not disambiguated.
+		 *   - HAVING name = 1, HAVING (name = (name + 1)), etc. are disambiguated.
+		 *   - With HAVING, MySQL seems to only recognize the columns listed in the SELECT clause.
+		 *
+		 * @TODO: We can consider fixing this more correctly.
+		 */
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` GROUP BY 1 HAVING `name` = 1',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id HAVING name = 1'
 		);
 	}
 

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1328,6 +1328,53 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		);
 	}
 
+	public function testSelectOrderByAmbiguousColumnResolution(): void {
+		$this->driver->query( 'CREATE TABLE t1 (id INT, name TEXT)' );
+		$this->driver->query( 'CREATE TABLE t2 (id INT, name TEXT)' );
+
+		// Ambiguous column in ORDER BY clause is disambiguated by the SELECT item list.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1`.`name`',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name'
+		);
+
+		// The ORDER BY direction is preserved when a column is disambiguated.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1`.`name` DESC',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC'
+		);
+
+		// Multiple ambiguous columns in ORDER BY clause are also disambiguated.
+		$this->assertQuery(
+			'SELECT `t1`.`id` , `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1`.`id` DESC, `t1`.`name` ASC',
+			'SELECT t1.id, t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY id DESC, name ASC'
+		);
+
+		// The disambiguation works with subqueries.
+		$this->assertQuery(
+			'SELECT `name` FROM ( SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1`.`name` ) ORDER BY `name`',
+			'SELECT name FROM (SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name) ORDER BY name'
+		);
+
+		// The disambiguation works in both root and subquery contexts at the same time.
+		$this->assertQuery(
+			'SELECT `ta`.`name` FROM ( SELECT `t2`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t2`.`name` ) `ta` ORDER BY `ta`.`name`',
+			'SELECT ta.name FROM (SELECT t2.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name) ta ORDER BY name'
+		);
+
+		// When the SELECT list item uses an alias, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `name` DESC',
+			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC'
+		);
+
+		// When the ORDER BY item uses an alias, there is no ambiguity.
+		$this->assertQuery(
+			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`t1_id` = `t1`.`id` ORDER BY `t1_name` DESC',
+			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY `t1_name` DESC'
+		);
+	}
+
 	private function assertQuery( $expected, string $query ): void {
 		$error = null;
 		try {

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1362,6 +1362,18 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'SELECT ta.name FROM (SELECT t2.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name) ta ORDER BY name'
 		);
 
+		// When the SELECT item is nested in a simple parentheses expression, the disambiguation still works.
+		$this->assertQuery(
+			'SELECT ( ( ( `t1`.`name` ) ) ) AS `(((t1.name)))` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1`.`name`',
+			'SELECT (((t1.name))) FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name'
+		);
+
+		// When the SELECT item is nested in a complex expression, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			"SELECT (`t1`.`name` || 'test') AS `CONCAT(t1.name, 'test')` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `name`",
+			"SELECT CONCAT(t1.name, 'test') FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name"
+		);
+
 		// When the SELECT list item uses an alias, the column is not disambiguated (like in MySQL).
 		$this->assertQuery(
 			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `name` DESC',

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1380,6 +1380,18 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'SELECT t1.name AS t1_name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC'
 		);
 
+		// When the SELECT item list is ambiguous, the ORDER BY column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			'SELECT `t1`.`name` , `t2`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `name` DESC',
+			'SELECT t1.name, t2.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC'
+		);
+
+		// When the SELECT item list is ambiguous with an alias, the ORDER BY column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			"SELECT `t1`.`name` , 'test' AS `name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `name` DESC",
+			"SELECT t1.name, 'test' AS `name` FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name DESC"
+		);
+
 		// When the ORDER BY item uses an alias, there is no ambiguity.
 		$this->assertQuery(
 			'SELECT `t1`.`name` AS `t1_name` FROM `t1` JOIN `t2` ON `t2`.`t1_id` = `t1`.`id` ORDER BY `t1_name` DESC',

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1368,10 +1368,22 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'SELECT (((t1.name))) FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name'
 		);
 
+		// When the ORDER BY item is nested in a simple parentheses expression, the disambiguation still works.
+		$this->assertQuery(
+			'SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `t1`.`name`',
+			'SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY (((name)))'
+		);
+
 		// When the SELECT item is nested in a complex expression, the column is not disambiguated (like in MySQL).
 		$this->assertQuery(
 			"SELECT (`t1`.`name` || 'test') AS `CONCAT(t1.name, 'test')` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY `name`",
 			"SELECT CONCAT(t1.name, 'test') FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY name"
+		);
+
+		// When the ORDER BY item is nested in a complex expression, the column is not disambiguated (like in MySQL).
+		$this->assertQuery(
+			"SELECT `t1`.`name` FROM `t1` JOIN `t2` ON `t2`.`id` = `t1`.`id` ORDER BY ( `name` || 'test' )",
+			"SELECT t1.name FROM t1 JOIN t2 ON t2.id = t1.id ORDER BY (name || 'test')"
 		);
 
 		// When the SELECT list item uses an alias, the column is not disambiguated (like in MySQL).

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2961,20 +2961,39 @@ class WP_SQLite_Driver {
 	 * @throws WP_SQLite_Driver_Exception When the translation fails.
 	 */
 	private function translate_query_expression( WP_Parser_Node $node ): string {
+		// Get the query expression subnode under which we need to look for the
+		// SELECT item list node. This prevents searching under "withClause".
+		$query_expr_main = (
+			$node->get_first_child_node( 'queryExpressionBody' )
+			?? $node->get_first_child_node( 'queryExpressionParens' )
+		);
+		$query_term      = $query_expr_main->get_first_descendant_node( 'queryTerm' );
+		$has_union       = $query_expr_main->has_child_token( WP_MySQL_Lexer::UNION_SYMBOL );
+		$has_except      = $query_expr_main->has_child_token( WP_MySQL_Lexer::EXCEPT_SYMBOL );
+		$has_intersect   = $query_term->has_child_token( WP_MySQL_Lexer::INTERSECT_SYMBOL );
+
 		/*
 		 * When the ORDER BY clause is present, we need to disambiguate the item
 		 * list and make sure they don't cause an "ambiguous column name" error.
 		 */
 		$disambiguated_order_list = array();
 		$order_clause             = $node->get_first_child_node( 'orderClause' );
-		if ( $order_clause ) {
-			$order_list       = $order_clause->get_first_child_node( 'orderList' );
-			$select_item_list = $node->get_first_descendant_node( 'selectItemList' );
+		if ( $order_clause && ! $has_union && ! $has_except && ! $has_intersect ) {
+			/*
+			 * [GRAMMAR]
+			 * queryExpression: (withClause)? (
+			 *   queryExpressionBody orderClause? limitClause?
+			 *   | queryExpressionParens orderClause? limitClause?
+			 * ) (procedureAnalyseClause)?
+			 */
 
+			// Create the SELECT item disambiguation map.
+			$select_item_list   = $query_expr_main->get_first_descendant_node( 'selectItemList' );
 			$disambiguation_map = $this->create_select_item_disambiguation_map( $select_item_list );
 
 			// For each "orderList" item, search for a matching SELECT item.
 			$disambiguated_order_list = array();
+			$order_list               = $order_clause->get_first_child_node( 'orderList' );
 			foreach ( $order_list->get_child_nodes() as $order_item ) {
 				/*
 				 * [GRAMMAR]

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2959,6 +2959,7 @@ class WP_SQLite_Driver {
 					continue;
 				}
 
+				$select_item_expr  = $this->unnest_parenthesized_expression( $select_item_expr );
 				$select_column_ref = $select_item->get_first_descendant_node( 'columnRef' );
 				if (
 					$select_column_ref
@@ -3022,6 +3023,46 @@ class WP_SQLite_Driver {
 		}
 
 		return $this->translate_sequence( $node->get_children() );
+	}
+
+	/**
+	 * Unnest parenthesized MySQL expression node.
+	 *
+	 * In MySQL, extra parentheses around simple expressions are not considered.
+	 *
+	 * For example, the "SELECT (((id)))" clause is equivalent to "SELECT id".
+	 * This means that the "(((id)))" part will behave as a column name rather
+	 * than as an expression, and the resulting column name will be just "id".
+	 *
+	 * @param  WP_Parser_Node $node The expression AST node.
+	 * @return WP_Parser_Node       The unnested expression.
+	 */
+	private function unnest_parenthesized_expression( WP_Parser_Node $node ): WP_Parser_Node {
+		$children = $node->get_children();
+
+		// Descend the "expr -> boolPri -> predicate -> bitExpr -> simpleExpr" tree,
+		// when on each level we have only a single child node (expression nesting).
+		if (
+			1 === count( $children )
+			&& $children[0] instanceof WP_Parser_Node
+			&& in_array( $children[0]->rule_name, array( 'expr', 'boolPri', 'predicate', 'bitExpr', 'simpleExpr' ), true )
+		) {
+			$unnested = $this->unnest_parenthesized_expression( $children[0] );
+			return $unnested === $children[0] ? $node : $unnested;
+		}
+
+		// Unnest "OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL" to "exprList".
+		if (
+			count( $children ) === 3
+			&& $children[0] instanceof WP_MySQL_Token && WP_MySQL_Lexer::OPEN_PAR_SYMBOL === $children[0]->id
+			&& $children[1] instanceof WP_Parser_Node && 'exprList' === $children[1]->rule_name
+			&& $children[2] instanceof WP_MySQL_Token && WP_MySQL_Lexer::CLOSE_PAR_SYMBOL === $children[2]->id
+			&& 1 === count( $children[1]->get_children() )
+		) {
+			return $this->unnest_parenthesized_expression( $children[1] );
+		}
+
+		return $node;
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2939,6 +2939,9 @@ class WP_SQLite_Driver {
 		 *   SELECT t1.name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY t1.name
 		 *
 		 * Note that the ORDER BY column was rewritten from "name" to "t1.name".
+		 *
+		 * @TODO: When multi-database support is implemented, we'll also need to
+		 *        consider column references in forms like "db.table.column".
 		 */
 		$disambiguated_order_list = array();
 		$order_clause             = $node->get_first_child_node( 'orderClause' );

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2512,6 +2512,8 @@ class WP_SQLite_Driver {
 
 		$rule_name = $node->rule_name;
 		switch ( $rule_name ) {
+			case 'queryExpression':
+				return $this->translate_query_expression( $node );
 			case 'querySpecification':
 				// Translate "HAVING ..." without "GROUP BY ..." to "GROUP BY 1 HAVING ...".
 				if ( $node->has_child_node( 'havingClause' ) && ! $node->has_child_node( 'groupByClause' ) ) {
@@ -2903,6 +2905,123 @@ class WP_SQLite_Driver {
 		}
 
 		return implode( '.', $parts );
+	}
+
+	/**
+	 * Translate a MySQL query expression to SQLite.
+	 *
+	 * @param  WP_Parser_Node $node       The "queryExpression" AST node.
+	 * @return string                     The translated value.
+	 * @throws WP_SQLite_Driver_Exception When the translation fails.
+	 */
+	private function translate_query_expression( WP_Parser_Node $node ): string {
+		/*
+		 * When the ORDER BY clause is present, we need to make sure it doesn't
+		 * cause an "ambiguous column name" error.
+		 *
+		 * In SQLite, all column names that exist in multiple tables used in the
+		 * query must be fully qualified in the ORDER BY clause. In MySQL, these
+		 * can be disambiguated in the SELECT item list.
+		 *
+		 * For example, with tables "t1" and "t2" both having a "name" column,
+		 * the following query will cause an "ambiguous column name" error in
+		 * SQLite, but not in MySQL:
+		 *
+		 *   SELECT t1.name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY name
+		 *
+		 * This is because MySQL first considers the "name" column that was used
+		 * in the SELECT list. If it is unambiguous, it will be used in ORDER BY.
+		 *
+		 * To address this, let's look for unqualified column references in the
+		 * ORDER BY clause and try to qualify them using the SELECT item list.
+		 * In other words, the above query will be rewritten as follows:
+		 *
+		 *   SELECT t1.name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY t1.name
+		 *
+		 * Note that the ORDER BY column was rewritten from "name" to "t1.name".
+		 */
+		$disambiguated_order_list = array();
+		$order_clause             = $node->get_first_child_node( 'orderClause' );
+		if ( $order_clause ) {
+			$order_list       = $order_clause->get_first_child_node( 'orderList' );
+			$select_item_list = $node->get_first_descendant_node( 'selectItemList' );
+
+			// Get a list of column references used in the SELECT item list.
+			$select_column_refs = array();
+			foreach ( $select_item_list->get_child_nodes() as $select_item ) {
+				// When the SELECT item uses an alias, the column is not disambiguated.
+				if ( $select_item->has_child_node( 'selectAlias' ) ) {
+					continue;
+				}
+
+				$select_item_expr = $select_item->get_first_child_node( 'expr' );
+				if ( ! $select_item_expr ) {
+					continue;
+				}
+
+				$select_column_ref = $select_item->get_first_descendant_node( 'columnRef' );
+				if (
+					$select_column_ref
+					&& $this->translate( $select_item_expr ) === $this->translate( $select_column_ref )
+				) {
+					$select_column_refs[] = $select_column_ref;
+				}
+			}
+
+			// For each ORDER BY item, try to find a corresponding SELECT item.
+			foreach ( $order_list->get_child_nodes() as $order_item ) {
+				$order_expr       = $order_item->get_first_child_node( 'expr' );
+				$order_column_ref = $order_expr->get_first_descendant_node( 'columnRef' );
+
+				$select_item_matches = array();
+				if (
+					$order_column_ref
+					&& $this->translate( $order_column_ref ) === $this->translate( $order_expr )
+					&& null === $order_column_ref->get_first_descendant_node( 'dotIdentifier' )
+				) {
+					// Look for select items that match the column reference.
+					foreach ( $select_column_refs as $select_column_ref ) {
+						$dot_identifiers = $select_column_ref->get_descendant_nodes( 'dotIdentifier' );
+						if ( count( $dot_identifiers ) === 0 ) {
+							continue;
+						}
+
+						$last_dot_identifier = end( $dot_identifiers );
+						$select_column_name  = $this->translate( $last_dot_identifier->get_first_child_node() );
+						$order_column_name   = $this->translate( $order_column_ref );
+						if ( $select_column_name === $order_column_name ) {
+							$select_item_matches[] = $this->translate( $select_column_ref );
+						}
+					}
+				}
+
+				if ( 1 === count( $select_item_matches ) ) {
+					$direction             = $order_item->get_first_child_node( 'direction' );
+					$translated_order_item = sprintf(
+						'%s%s',
+						$select_item_matches[0],
+						null !== $direction ? ( ' ' . $this->translate( $direction ) ) : ''
+					);
+				} else {
+					$translated_order_item = $this->translate( $order_item );
+				}
+				$disambiguated_order_list[] = $translated_order_item;
+			}
+
+			// Translate the query expression, replacing the ORDER BY list with
+			// the one that was constructed using the disambiguation algorithm.
+			$parts = array();
+			foreach ( $node->get_children() as $child ) {
+				if ( $child instanceof WP_Parser_Node && 'orderClause' === $child->rule_name ) {
+					$parts[] = 'ORDER BY ' . implode( ', ', $disambiguated_order_list );
+				} else {
+					$parts[] = $this->translate( $child );
+				}
+			}
+			return implode( ' ', $parts );
+		}
+
+		return $this->translate_sequence( $node->get_children() );
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2512,10 +2512,10 @@ class WP_SQLite_Driver {
 
 		$rule_name = $node->rule_name;
 		switch ( $rule_name ) {
-			case 'querySpecification':
-				return $this->translate_query_specification( $node );
 			case 'queryExpression':
 				return $this->translate_query_expression( $node );
+			case 'querySpecification':
+				return $this->translate_query_specification( $node );
 			case 'qualifiedIdentifier':
 			case 'tableRefWithWildcard':
 				$parts = $node->get_descendant_nodes( 'identifier' );
@@ -2893,66 +2893,6 @@ class WP_SQLite_Driver {
 		return implode( '.', $parts );
 	}
 
-	private function translate_query_specification( WP_Parser_Node $node ): string {
-		$group_by = $node->get_first_child_node( 'groupByClause' );
-		$having   = $node->get_first_child_node( 'havingClause' );
-
-		$group_by_clause = null;
-		$having_clause   = null;
-		if ( $group_by || $having ) {
-			$select_item_list   = $node->get_first_child_node( 'selectItemList' );
-			$disambiguation_map = $this->create_select_item_disambiguation_map( $select_item_list );
-
-			// Disambiguate the GROUP BY clause column references.
-			$disambiguated_group_by_list = array();
-			if ( $group_by ) {
-				$group_by_list = $group_by->get_first_child_node( 'orderList' );
-				foreach ( $group_by_list->get_child_nodes() as $group_by_item ) {
-					$group_by_expr                 = $group_by_item->get_first_child_node( 'expr' );
-					$disambiguated_item            = $this->disambiguate_item( $disambiguation_map, $group_by_expr );
-					$disambiguated_group_by_list[] = $disambiguated_item ?? $this->translate( $group_by_expr );
-				}
-				$group_by_clause = 'GROUP BY ' . implode( ', ', $disambiguated_group_by_list );
-			}
-
-			// Disambiguate the HAVING clause column references.
-			$disambiguated_having_list = array();
-			if ( $having ) {
-				$having_expr          = $having->get_first_child_node();
-				$having_expr_children = $having_expr->get_children();
-				foreach ( $having_expr_children as $having_item ) {
-					if ( $having_item instanceof WP_Parser_Node ) {
-						$disambiguated_item          = $this->disambiguate_item( $disambiguation_map, $having_item );
-						$disambiguated_having_list[] = $disambiguated_item ?? $this->translate( $having_item );
-					} else {
-						$disambiguated_having_list[] = $this->translate( $having_item );
-					}
-				}
-				$having_clause = 'HAVING ' . implode( ' ', $disambiguated_having_list );
-			}
-
-			$parts = array();
-			foreach ( $node->get_children() as $child ) {
-				if ( $child instanceof WP_Parser_Node && 'groupByClause' === $child->rule_name ) {
-					$parts[] = $group_by_clause;
-				} elseif ( $child instanceof WP_Parser_Node && 'havingClause' === $child->rule_name ) {
-					// Translate "HAVING ..." without "GROUP BY ..." to "GROUP BY 1 HAVING ...".
-					if ( ! $group_by ) {
-						$parts[] = 'GROUP BY 1';
-					}
-					$parts[] = $having_clause;
-				} else {
-					$part = $this->translate( $child );
-					if ( null !== $part ) {
-						$parts[] = $part;
-					}
-				}
-			}
-			return implode( ' ', $parts );
-		}
-		return $this->translate_sequence( $node->get_children() );
-	}
-
 	/**
 	 * Translate a MySQL query expression to SQLite.
 	 *
@@ -2975,6 +2915,8 @@ class WP_SQLite_Driver {
 		/*
 		 * When the ORDER BY clause is present, we need to disambiguate the item
 		 * list and make sure they don't cause an "ambiguous column name" error.
+		 *
+		 * @see WP_SQLite_Driver::disambiguate_item()
 		 */
 		$disambiguated_order_list = array();
 		$order_clause             = $node->get_first_child_node( 'orderClause' );
@@ -3023,6 +2965,92 @@ class WP_SQLite_Driver {
 			return implode( ' ', $parts );
 		}
 
+		return $this->translate_sequence( $node->get_children() );
+	}
+
+	/**
+	 * Translate a MySQL query specification node to SQLite.
+	 *
+	 * @param  WP_Parser_Node $node       The "querySpecification" AST node.
+	 * @return string                     The translated value.
+	 * @throws WP_SQLite_Driver_Exception When the translation fails.
+	 * @return string|null
+	 */
+	private function translate_query_specification( WP_Parser_Node $node ): string {
+		$group_by = $node->get_first_child_node( 'groupByClause' );
+		$having   = $node->get_first_child_node( 'havingClause' );
+
+		/*
+		 * When the GROUP BY or HAVING clause is present, we need to disambiguate
+		 * the items to ensure they don't cause an "ambiguous column name" error.
+		 *
+		 * @see WP_SQLite_Driver::disambiguate_item()
+		 */
+		$group_by_clause = null;
+		$having_clause   = null;
+		if ( $group_by || $having ) {
+			// Build a SELECT list disambiguation map for both GROUP BY and HAVING.
+			$select_item_list   = $node->get_first_child_node( 'selectItemList' );
+			$disambiguation_map = $this->create_select_item_disambiguation_map( $select_item_list );
+
+			// Disambiguate the GROUP BY clause column references.
+			$disambiguated_group_by_list = array();
+			if ( $group_by ) {
+				/*
+				 * [GRAMMAR]
+				 * groupByClause: GROUP_SYMBOL BY_SYMBOL orderList olapOption?
+				 */
+				$group_by_list = $group_by->get_first_child_node( 'orderList' );
+				foreach ( $group_by_list->get_child_nodes() as $group_by_item ) {
+					$group_by_expr                 = $group_by_item->get_first_child_node( 'expr' );
+					$disambiguated_item            = $this->disambiguate_item( $disambiguation_map, $group_by_expr );
+					$disambiguated_group_by_list[] = $disambiguated_item ?? $this->translate( $group_by_expr );
+				}
+				$group_by_clause = 'GROUP BY ' . implode( ', ', $disambiguated_group_by_list );
+			}
+
+			// Disambiguate the HAVING clause column references.
+			$disambiguated_having_list = array();
+			if ( $having ) {
+				/*
+				 * [GRAMMAR]
+				 * havingClause: HAVING_SYMBOL expr
+				 */
+				$having_expr          = $having->get_first_child_node();
+				$having_expr_children = $having_expr->get_children();
+				foreach ( $having_expr_children as $having_item ) {
+					if ( $having_item instanceof WP_Parser_Node ) {
+						$disambiguated_item          = $this->disambiguate_item( $disambiguation_map, $having_item );
+						$disambiguated_having_list[] = $disambiguated_item ?? $this->translate( $having_item );
+					} else {
+						$disambiguated_having_list[] = $this->translate( $having_item );
+					}
+				}
+				$having_clause = 'HAVING ' . implode( ' ', $disambiguated_having_list );
+			}
+
+			// Translate the query specification, replacing the ORDER BY/HAVING
+			// items with the ones that were disambiguated using the SELECT list.
+			$parts = array();
+			foreach ( $node->get_children() as $child ) {
+				if ( $child instanceof WP_Parser_Node && 'groupByClause' === $child->rule_name ) {
+					$parts[] = $group_by_clause;
+				} elseif ( $child instanceof WP_Parser_Node && 'havingClause' === $child->rule_name ) {
+					// SQLite doesn't allow using the "HAVING" clause without "GROUP BY".
+					// In such cases, let's prefix the "HAVING" clause with "GROUP BY 1".
+					if ( ! $group_by ) {
+						$parts[] = 'GROUP BY 1';
+					}
+					$parts[] = $having_clause;
+				} else {
+					$part = $this->translate( $child );
+					if ( null !== $part ) {
+						$parts[] = $part;
+					}
+				}
+			}
+			return implode( ' ', $parts );
+		}
 		return $this->translate_sequence( $node->get_children() );
 	}
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2916,32 +2916,8 @@ class WP_SQLite_Driver {
 	 */
 	private function translate_query_expression( WP_Parser_Node $node ): string {
 		/*
-		 * When the ORDER BY clause is present, we need to make sure it doesn't
-		 * cause an "ambiguous column name" error.
-		 *
-		 * In SQLite, all column names that exist in multiple tables used in the
-		 * query must be fully qualified in the ORDER BY clause. In MySQL, these
-		 * can be disambiguated in the SELECT item list.
-		 *
-		 * For example, with tables "t1" and "t2" both having a "name" column,
-		 * the following query will cause an "ambiguous column name" error in
-		 * SQLite, but not in MySQL:
-		 *
-		 *   SELECT t1.name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY name
-		 *
-		 * This is because MySQL first considers the "name" column that was used
-		 * in the SELECT list. If it is unambiguous, it will be used in ORDER BY.
-		 *
-		 * To address this, let's look for unqualified column references in the
-		 * ORDER BY clause and try to qualify them using the SELECT item list.
-		 * In other words, the above query will be rewritten as follows:
-		 *
-		 *   SELECT t1.name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY t1.name
-		 *
-		 * Note that the ORDER BY column was rewritten from "name" to "t1.name".
-		 *
-		 * @TODO: When multi-database support is implemented, we'll also need to
-		 *        consider column references in forms like "db.table.column".
+		 * When the ORDER BY clause is present, we need to disambiguate the item
+		 * list and make sure they don't cause an "ambiguous column name" error.
 		 */
 		$disambiguated_order_list = array();
 		$order_clause             = $node->get_first_child_node( 'orderClause' );
@@ -2949,104 +2925,24 @@ class WP_SQLite_Driver {
 			$order_list       = $order_clause->get_first_child_node( 'orderList' );
 			$select_item_list = $node->get_first_descendant_node( 'selectItemList' );
 
-			// Create a map of SELECT item column names to their qualified values.
-			$disambiguation_map = array();
-			foreach ( $select_item_list->get_child_nodes() as $select_item ) {
-				/*
-				 * [GRAMMAR]
-				 * selectItem: tableWild | (expr selectAlias?)
-				 */
+			$disambiguation_map = $this->create_select_item_disambiguation_map( $select_item_list );
 
-				// Skip when a "tableWild" node is used (no "expr" node).
-				$select_item_expr = $select_item->get_first_child_node( 'expr' );
-				if ( ! $select_item_expr ) {
-					continue;
-				}
-
-				// A SELECT item alias always needs to be preserved as-is.
-				$alias = $select_item->get_first_child_node( 'selectAlias' );
-				if ( $alias ) {
-					$alias_value                        = $this->translate( $alias->get_first_child_node() );
-					$disambiguation_map[ $alias_value ] = array( $alias_value );
-					continue;
-				}
-
-				// Skip when there is no column listed (no "columnRef" node).
-				$select_column_ref = $select_item_expr->get_first_descendant_node( 'columnRef' );
-				if ( ! $select_column_ref ) {
-					continue;
-				}
-
-				// Skip when the column reference is not qualified (no "dotIdentifier" node).
-				$dot_identifiers = $select_column_ref->get_descendant_nodes( 'dotIdentifier' );
-				if ( 0 === count( $dot_identifiers ) ) {
-					continue;
-				}
-
-				// Support also parenthesized column references (e.g. "(t.id)").
-				$select_item_expr = $this->unnest_parenthesized_expression( $select_item_expr );
-
-				// Consider only simple and parenthesized column references.
-				$expr_value   = $this->translate( $select_item_expr );
-				$column_value = $this->translate( $select_column_ref );
-				if ( $expr_value !== $column_value ) {
-					continue;
-				}
-
-				// The column name is the last "dotIdentifier" node.
-				$key = $this->translate( end( $dot_identifiers )->get_first_child_node() );
-
-				$disambiguation_map[ $key ]   = $disambiguation_map[ $key ] ?? array();
-				$disambiguation_map[ $key ][] = $column_value;
-			}
-
-			// For each ORDER BY item, try to find a corresponding SELECT item.
+			// For each "orderList" item, search for a matching SELECT item.
+			$disambiguated_order_list = array();
 			foreach ( $order_list->get_child_nodes() as $order_item ) {
 				/*
 				 * [GRAMMAR]
 				 * orderExpression: expr direction?
 				 */
-				$order_expr       = $order_item->get_first_child_node( 'expr' );
-				$order_column_ref = $order_expr->get_first_descendant_node( 'columnRef' );
+				$order_expr         = $order_item->get_first_child_node( 'expr' );
+				$order_direction    = $order_item->get_first_child_node( 'direction' );
+				$disambiguated_item = $this->disambiguate_item( $disambiguation_map, $order_expr );
 
-				// Skip when there is no column in the ORDER BY item (no "columnRef" node),
-				// or when the item is already qualified (has a "dotIdentifier" node).
-				if (
-					! $order_column_ref
-					|| null !== $order_column_ref->get_first_descendant_node( 'dotIdentifier' )
-				) {
-					$disambiguated_order_list[] = $this->translate( $order_item );
-					continue;
-				}
-
-				// Support also parenthesized ORDER BY column references (e.g. "(id)").
-				$order_expr = $this->unnest_parenthesized_expression( $order_expr );
-
-				// Consider only simple and parenthesized order column references.
-				$order_expr_value   = $this->translate( $order_expr );
-				$order_column_value = $this->translate( $order_column_ref );
-				if ( $order_expr_value !== $order_column_value ) {
-					$disambiguated_order_list[] = $this->translate( $order_item );
-					continue;
-				}
-
-				// Look for select items that match the column reference.
-				$order_column_name   = $this->translate( $order_column_ref );
-				$select_item_matches = $disambiguation_map[ $order_column_name ] ?? array();
-
-				// When we find exactly one SELECT item, we can disambiguate the
-				// reference. Otherwise, fall back to the original ORDER BY item.
-				if ( 1 === count( $select_item_matches ) ) {
-					$direction             = $order_item->get_first_child_node( 'direction' );
-					$translated_order_item = sprintf(
-						'%s%s',
-						$select_item_matches[0],
-						null !== $direction ? ( ' ' . $this->translate( $direction ) ) : ''
-					);
-				} else {
-					$translated_order_item = $this->translate( $order_item );
-				}
-				$disambiguated_order_list[] = $translated_order_item;
+				$disambiguated_order_list[] = sprintf(
+					'%s%s',
+					$disambiguated_item ?? $this->translate( $order_expr ),
+					null !== $order_direction ? ( ' ' . $this->translate( $order_direction ) ) : ''
+				);
 			}
 
 			// Translate the query expression, replacing the ORDER BY list with
@@ -3063,46 +2959,6 @@ class WP_SQLite_Driver {
 		}
 
 		return $this->translate_sequence( $node->get_children() );
-	}
-
-	/**
-	 * Unnest parenthesized MySQL expression node.
-	 *
-	 * In MySQL, extra parentheses around simple expressions are not considered.
-	 *
-	 * For example, the "SELECT (((id)))" clause is equivalent to "SELECT id".
-	 * This means that the "(((id)))" part will behave as a column name rather
-	 * than as an expression, and the resulting column name will be just "id".
-	 *
-	 * @param  WP_Parser_Node $node The expression AST node.
-	 * @return WP_Parser_Node       The unnested expression.
-	 */
-	private function unnest_parenthesized_expression( WP_Parser_Node $node ): WP_Parser_Node {
-		$children = $node->get_children();
-
-		// Descend the "expr -> boolPri -> predicate -> bitExpr -> simpleExpr" tree,
-		// when on each level we have only a single child node (expression nesting).
-		if (
-			1 === count( $children )
-			&& $children[0] instanceof WP_Parser_Node
-			&& in_array( $children[0]->rule_name, array( 'expr', 'boolPri', 'predicate', 'bitExpr', 'simpleExpr' ), true )
-		) {
-			$unnested = $this->unnest_parenthesized_expression( $children[0] );
-			return $unnested === $children[0] ? $node : $unnested;
-		}
-
-		// Unnest "OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL" to "exprList".
-		if (
-			count( $children ) === 3
-			&& $children[0] instanceof WP_MySQL_Token && WP_MySQL_Lexer::OPEN_PAR_SYMBOL === $children[0]->id
-			&& $children[1] instanceof WP_Parser_Node && 'exprList' === $children[1]->rule_name
-			&& $children[2] instanceof WP_MySQL_Token && WP_MySQL_Lexer::CLOSE_PAR_SYMBOL === $children[2]->id
-			&& 1 === count( $children[1]->get_children() )
-		) {
-			return $this->unnest_parenthesized_expression( $children[1] );
-		}
-
-		return $node;
 	}
 
 	/**
@@ -3831,6 +3687,175 @@ class WP_SQLite_Driver {
 			$fragment .= $value;
 		}
 		return $fragment;
+	}
+
+	/**
+	 * Unnest parenthesized MySQL expression node.
+	 *
+	 * In MySQL, extra parentheses around simple expressions are not considered.
+	 *
+	 * For example, the "SELECT (((id)))" clause is equivalent to "SELECT id".
+	 * This means that the "(((id)))" part will behave as a column name rather
+	 * than as an expression, and the resulting column name will be just "id".
+	 *
+	 * @param  WP_Parser_Node $node The expression AST node.
+	 * @return WP_Parser_Node       The unnested expression.
+	 */
+	private function unnest_parenthesized_expression( WP_Parser_Node $node ): WP_Parser_Node {
+		$children = $node->get_children();
+
+		// Descend the "expr -> boolPri -> predicate -> bitExpr -> simpleExpr" tree,
+		// when on each level we have only a single child node (expression nesting).
+		if (
+			1 === count( $children )
+			&& $children[0] instanceof WP_Parser_Node
+			&& in_array( $children[0]->rule_name, array( 'expr', 'boolPri', 'predicate', 'bitExpr', 'simpleExpr' ), true )
+		) {
+			$unnested = $this->unnest_parenthesized_expression( $children[0] );
+			return $unnested === $children[0] ? $node : $unnested;
+		}
+
+		// Unnest "OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL" to "exprList".
+		if (
+			count( $children ) === 3
+			&& $children[0] instanceof WP_MySQL_Token && WP_MySQL_Lexer::OPEN_PAR_SYMBOL === $children[0]->id
+			&& $children[1] instanceof WP_Parser_Node && 'exprList' === $children[1]->rule_name
+			&& $children[2] instanceof WP_MySQL_Token && WP_MySQL_Lexer::CLOSE_PAR_SYMBOL === $children[2]->id
+			&& 1 === count( $children[1]->get_children() )
+		) {
+			return $this->unnest_parenthesized_expression( $children[1] );
+		}
+
+		return $node;
+	}
+
+	/**
+	 * Disambiguate and translate an expression with a simple or parenthesized
+	 * column reference for use within an ORDER BY, GROUP BY, or HAVING clause.
+	 *
+	 * In SQLite, columns that exist in multiple tables used within a query must
+	 * be fully qualified when used in the ORDER BY, GROUP BY, or HAVING clause.
+	 * In MySQL, these can be disambiguated using the SELECT item list.
+	 *
+	 * For example, when tables "t1" and "t2" both have a column called "name",
+	 * the following query will cause an "ambiguous column name" error in SQLite,
+	 * but it will succeed in MySQL, using the "t1.name" from the SELECT clause:
+	 *
+	 *   SELECT t1.name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY name
+	 *
+	 * This is because MySQL primarily considers the "name" column that was used
+	 * in the SELECT list - when it is unambiguous, it will be used in ORDER BY.
+	 *
+	 * To emulate this behavior in SQLite, we will search for unqualified column
+	 * references in the ORDER BY, GROUP BY, or HAVING item expression, and try
+	 * to qualify them using the SELECT item list.
+	 *
+	 * In other words, the above query will be rewritten as follows:
+	 *
+	 *   SELECT t1.name FROM t1 JOIN t2 ON t2.t1_id = t1.id ORDER BY t1.name
+	 *
+	 * Note that the ORDER BY column was rewritten from "name" to "t1.name".
+	 *
+	 * @TODO: When multi-database support is implemented, we'll also need to
+	 *        consider column references in forms like "db.table.column".
+	 *
+	 * @param  array          $disambiguation_map The SELECT item disambiguation map (column name => array of select items).
+	 *                                            @see WP_SQLite_Driver::create_select_item_disambiguation_map()
+	 * @param  WP_Parser_Node $expr               The expression AST node or subnode.
+	 * @return string|null                        The disambiguated and translated expression;
+	 *                                            null when the expression cannot be disambiguated.
+	 */
+	private function disambiguate_item( array $disambiguation_map, WP_Parser_Node $expr ) {
+		// Skip when there is no column in the expression (no "columnRef" node),
+		// or when the column is already qualified (has a "dotIdentifier" node).
+		$column_ref = $expr->get_first_descendant_node( 'columnRef' );
+		if ( ! $column_ref || $column_ref->get_first_descendant_node( 'dotIdentifier' ) ) {
+			return null;
+		}
+
+		// Support also parenthesized column references (e.g. "(id)").
+		$expr = $this->unnest_parenthesized_expression( $expr );
+
+		// Consider only simple and parenthesized column references (as per MySQL).
+		$expr_value   = $this->translate( $expr );
+		$column_value = $this->translate( $column_ref );
+		if ( $expr_value !== $column_value ) {
+			return null;
+		}
+
+		// Look for SELECT items that match the column reference.
+		$column_name         = $this->translate( $column_ref );
+		$select_item_matches = $disambiguation_map[ $column_name ] ?? array();
+
+		// When we find exactly one matching SELECT list item, we can disambiguate
+		// the column reference. Otherwise, fall back to the original expression.
+		if ( 1 === count( $select_item_matches ) ) {
+			return $select_item_matches[0];
+		}
+		return null;
+	}
+
+	/**
+	 * Create a SELECT item disambiguation map from a SELECT item list for use
+	 * with the ORDER BY, GROUP BY, and HAVING clause disambiguation algorithm.
+	 *
+	 * @see WP_SQLite_Driver::disambiguate_item()
+	 *
+	 * @param  WP_Parser_Node $select_item_list The "selectItemList" AST node.
+	 * @return array                            The SELECT item disambiguation map (column name => array of select items).
+	 */
+	private function create_select_item_disambiguation_map( WP_Parser_Node $select_item_list ): array {
+		// Create a map of SELECT item column names to their qualified values.
+		$disambiguation_map = array();
+		foreach ( $select_item_list->get_child_nodes() as $select_item ) {
+			/*
+			 * [GRAMMAR]
+			 * selectItem: tableWild | (expr selectAlias?)
+			 */
+
+			// Skip when a "tableWild" node is used (no "expr" node).
+			$select_item_expr = $select_item->get_first_child_node( 'expr' );
+			if ( ! $select_item_expr ) {
+				continue;
+			}
+
+			// A SELECT item alias always needs to be preserved as-is.
+			$alias = $select_item->get_first_child_node( 'selectAlias' );
+			if ( $alias ) {
+				$alias_value                        = $this->translate( $alias->get_first_child_node() );
+				$disambiguation_map[ $alias_value ] = array( $alias_value );
+				continue;
+			}
+
+			// Skip when there is no column listed (no "columnRef" node).
+			$select_column_ref = $select_item_expr->get_first_descendant_node( 'columnRef' );
+			if ( ! $select_column_ref ) {
+				continue;
+			}
+
+			// Skip when the column reference is not qualified (no "dotIdentifier" node).
+			$dot_identifiers = $select_column_ref->get_descendant_nodes( 'dotIdentifier' );
+			if ( 0 === count( $dot_identifiers ) ) {
+				continue;
+			}
+
+			// Support also parenthesized column references (e.g. "(t.id)").
+			$select_item_expr = $this->unnest_parenthesized_expression( $select_item_expr );
+
+			// Consider only simple and parenthesized column references (as per MySQL).
+			$expr_value   = $this->translate( $select_item_expr );
+			$column_value = $this->translate( $select_column_ref );
+			if ( $expr_value !== $column_value ) {
+				continue;
+			}
+
+			// The column name is the last "dotIdentifier" node.
+			$key = $this->translate( end( $dot_identifiers )->get_first_child_node() );
+
+			$disambiguation_map[ $key ]   = $disambiguation_map[ $key ] ?? array();
+			$disambiguation_map[ $key ][] = $column_value;
+		}
+		return $disambiguation_map;
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2512,24 +2512,10 @@ class WP_SQLite_Driver {
 
 		$rule_name = $node->rule_name;
 		switch ( $rule_name ) {
+			case 'querySpecification':
+				return $this->translate_query_specification( $node );
 			case 'queryExpression':
 				return $this->translate_query_expression( $node );
-			case 'querySpecification':
-				// Translate "HAVING ..." without "GROUP BY ..." to "GROUP BY 1 HAVING ...".
-				if ( $node->has_child_node( 'havingClause' ) && ! $node->has_child_node( 'groupByClause' ) ) {
-					$parts = array();
-					foreach ( $node->get_children() as $child ) {
-						if ( $child instanceof WP_Parser_Node && 'havingClause' === $child->rule_name ) {
-							$parts[] = 'GROUP BY 1';
-						}
-						$part = $this->translate( $child );
-						if ( null !== $part ) {
-							$parts[] = $part;
-						}
-					}
-					return implode( ' ', $parts );
-				}
-				return $this->translate_sequence( $node->get_children() );
 			case 'qualifiedIdentifier':
 			case 'tableRefWithWildcard':
 				$parts = $node->get_descendant_nodes( 'identifier' );
@@ -2905,6 +2891,66 @@ class WP_SQLite_Driver {
 		}
 
 		return implode( '.', $parts );
+	}
+
+	private function translate_query_specification( WP_Parser_Node $node ): string {
+		$group_by = $node->get_first_child_node( 'groupByClause' );
+		$having   = $node->get_first_child_node( 'havingClause' );
+
+		$group_by_clause = null;
+		$having_clause   = null;
+		if ( $group_by || $having ) {
+			$select_item_list   = $node->get_first_child_node( 'selectItemList' );
+			$disambiguation_map = $this->create_select_item_disambiguation_map( $select_item_list );
+
+			// Disambiguate the GROUP BY clause column references.
+			$disambiguated_group_by_list = array();
+			if ( $group_by ) {
+				$group_by_list = $group_by->get_first_child_node( 'orderList' );
+				foreach ( $group_by_list->get_child_nodes() as $group_by_item ) {
+					$group_by_expr                 = $group_by_item->get_first_child_node( 'expr' );
+					$disambiguated_item            = $this->disambiguate_item( $disambiguation_map, $group_by_expr );
+					$disambiguated_group_by_list[] = $disambiguated_item ?? $this->translate( $group_by_expr );
+				}
+				$group_by_clause = 'GROUP BY ' . implode( ', ', $disambiguated_group_by_list );
+			}
+
+			// Disambiguate the HAVING clause column references.
+			$disambiguated_having_list = array();
+			if ( $having ) {
+				$having_expr          = $having->get_first_child_node();
+				$having_expr_children = $having_expr->get_children();
+				foreach ( $having_expr_children as $having_item ) {
+					if ( $having_item instanceof WP_Parser_Node ) {
+						$disambiguated_item          = $this->disambiguate_item( $disambiguation_map, $having_item );
+						$disambiguated_having_list[] = $disambiguated_item ?? $this->translate( $having_item );
+					} else {
+						$disambiguated_having_list[] = $this->translate( $having_item );
+					}
+				}
+				$having_clause = 'HAVING ' . implode( ' ', $disambiguated_having_list );
+			}
+
+			$parts = array();
+			foreach ( $node->get_children() as $child ) {
+				if ( $child instanceof WP_Parser_Node && 'groupByClause' === $child->rule_name ) {
+					$parts[] = $group_by_clause;
+				} elseif ( $child instanceof WP_Parser_Node && 'havingClause' === $child->rule_name ) {
+					// Translate "HAVING ..." without "GROUP BY ..." to "GROUP BY 1 HAVING ...".
+					if ( ! $group_by ) {
+						$parts[] = 'GROUP BY 1';
+					}
+					$parts[] = $having_clause;
+				} else {
+					$part = $this->translate( $child );
+					if ( null !== $part ) {
+						$parts[] = $part;
+					}
+				}
+			}
+			return implode( ' ', $parts );
+		}
+		return $this->translate_sequence( $node->get_children() );
 	}
 
 	/**

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2946,56 +2946,90 @@ class WP_SQLite_Driver {
 			$order_list       = $order_clause->get_first_child_node( 'orderList' );
 			$select_item_list = $node->get_first_descendant_node( 'selectItemList' );
 
-			// Get a list of column references used in the SELECT item list.
-			$select_column_refs = array();
+			// Create a map of SELECT item column names to their qualified values.
+			$disambiguation_map = array();
 			foreach ( $select_item_list->get_child_nodes() as $select_item ) {
-				// When the SELECT item uses an alias, the column is not disambiguated.
-				if ( $select_item->has_child_node( 'selectAlias' ) ) {
-					continue;
-				}
+				/*
+				 * [GRAMMAR]
+				 * selectItem: tableWild | (expr selectAlias?)
+				 */
 
+				// Skip when a "tableWild" node is used (no "expr" node).
 				$select_item_expr = $select_item->get_first_child_node( 'expr' );
 				if ( ! $select_item_expr ) {
 					continue;
 				}
 
-				$select_item_expr  = $this->unnest_parenthesized_expression( $select_item_expr );
-				$select_column_ref = $select_item->get_first_descendant_node( 'columnRef' );
-				if (
-					$select_column_ref
-					&& $this->translate( $select_item_expr ) === $this->translate( $select_column_ref )
-				) {
-					$select_column_refs[] = $select_column_ref;
+				// A SELECT item alias always needs to be preserved as-is.
+				$alias = $select_item->get_first_child_node( 'selectAlias' );
+				if ( $alias ) {
+					$alias_value                        = $this->translate( $alias->get_first_child_node() );
+					$disambiguation_map[ $alias_value ] = array( $alias_value );
+					continue;
 				}
+
+				// Skip when there is no column listed (no "columnRef" node).
+				$select_column_ref = $select_item_expr->get_first_descendant_node( 'columnRef' );
+				if ( ! $select_column_ref ) {
+					continue;
+				}
+
+				// Skip when the column reference is not qualified (no "dotIdentifier" node).
+				$dot_identifiers = $select_column_ref->get_descendant_nodes( 'dotIdentifier' );
+				if ( 0 === count( $dot_identifiers ) ) {
+					continue;
+				}
+
+				// Support also parenthesized column references (e.g. "(t.id)").
+				$select_item_expr = $this->unnest_parenthesized_expression( $select_item_expr );
+
+				// Consider only simple and parenthesized column references.
+				$expr_value   = $this->translate( $select_item_expr );
+				$column_value = $this->translate( $select_column_ref );
+				if ( $expr_value !== $column_value ) {
+					continue;
+				}
+
+				// The column name is the last "dotIdentifier" node.
+				$key = $this->translate( end( $dot_identifiers )->get_first_child_node() );
+
+				$disambiguation_map[ $key ]   = $disambiguation_map[ $key ] ?? array();
+				$disambiguation_map[ $key ][] = $column_value;
 			}
 
 			// For each ORDER BY item, try to find a corresponding SELECT item.
 			foreach ( $order_list->get_child_nodes() as $order_item ) {
+				/*
+				 * [GRAMMAR]
+				 * orderExpression: expr direction?
+				 */
 				$order_expr       = $order_item->get_first_child_node( 'expr' );
 				$order_column_ref = $order_expr->get_first_descendant_node( 'columnRef' );
 
-				$select_item_matches = array();
+				// Skip when there is no column in the ORDER BY item (no "columnRef" node),
+				// or when the item is already qualified (has a "dotIdentifier" node).
 				if (
-					$order_column_ref
-					&& $this->translate( $order_column_ref ) === $this->translate( $order_expr )
-					&& null === $order_column_ref->get_first_descendant_node( 'dotIdentifier' )
+					! $order_column_ref
+					|| null !== $order_column_ref->get_first_descendant_node( 'dotIdentifier' )
 				) {
-					// Look for select items that match the column reference.
-					foreach ( $select_column_refs as $select_column_ref ) {
-						$dot_identifiers = $select_column_ref->get_descendant_nodes( 'dotIdentifier' );
-						if ( count( $dot_identifiers ) === 0 ) {
-							continue;
-						}
-
-						$last_dot_identifier = end( $dot_identifiers );
-						$select_column_name  = $this->translate( $last_dot_identifier->get_first_child_node() );
-						$order_column_name   = $this->translate( $order_column_ref );
-						if ( $select_column_name === $order_column_name ) {
-							$select_item_matches[] = $this->translate( $select_column_ref );
-						}
-					}
+					$disambiguated_order_list[] = $this->translate( $order_item );
+					continue;
 				}
 
+				// Consider only simple and parenthesized order column references.
+				$order_expr_value   = $this->translate( $order_expr );
+				$order_column_value = $this->translate( $order_column_ref );
+				if ( $order_expr_value !== $order_column_value ) {
+					$disambiguated_order_list[] = $this->translate( $order_item );
+					continue;
+				}
+
+				// Look for select items that match the column reference.
+				$order_column_name   = $this->translate( $order_column_ref );
+				$select_item_matches = $disambiguation_map[ $order_column_name ] ?? array();
+
+				// When we find exactly one SELECT item, we can disambiguate the
+				// reference. Otherwise, fall back to the original ORDER BY item.
 				if ( 1 === count( $select_item_matches ) ) {
 					$direction             = $order_item->get_first_child_node( 'direction' );
 					$translated_order_item = sprintf(

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3016,6 +3016,9 @@ class WP_SQLite_Driver {
 					continue;
 				}
 
+				// Support also parenthesized ORDER BY column references (e.g. "(id)").
+				$order_expr = $this->unnest_parenthesized_expression( $order_expr );
+
 				// Consider only simple and parenthesized order column references.
 				$order_expr_value   = $this->translate( $order_expr );
 				$order_column_value = $this->translate( $order_column_ref );

--- a/wp-setup.sh
+++ b/wp-setup.sh
@@ -37,14 +37,16 @@ services:
       - ../:/var/www/src/wp-content/plugins/sqlite-database-integration
 
   php:
-    image: wordpressdevelop/php:8.3-fpm
+    # PHP temporarily pinned to 8.3.10, see: https://github.com/WordPress/wordpress-develop/pull/9602
+    image: wordpressdevelop/php@sha256:c0ba85936a9d1ac2c98bf3da2d62ceb0e5787a6b11e383630df0c5a5bf2534b5
     environment:
       WP_SQLITE_AST_DRIVER: true
     volumes:
       - ../:/var/www/src/wp-content/plugins/sqlite-database-integration
 
   cli:
-    image: wordpressdevelop/cli:8.3-fpm
+    # PHP temporarily pinned to 8.3.10, see: https://github.com/WordPress/wordpress-develop/pull/9602
+    image: wordpressdevelop/cli@sha256:85ad7d7a9c3bd9a8775fc83aea7f7dfc0aad25b2bc4f7d740696b28cd2a0ef89
     environment:
       WP_SQLITE_AST_DRIVER: true
     volumes:


### PR DESCRIPTION
Resolves https://github.com/WordPress/sqlite-database-integration/issues/228.
Closes https://github.com/WordPress/sqlite-database-integration/pull/231.