### PR TITLE
Ingore `FOREIGN KEY` constraint definitions

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6581,4 +6581,24 @@ END;
 		$this->expectExceptionMessage( 'no such savepoint: sp1' );
 		$this->assertQuery( 'ROLLBACK TO SAVEPOINT sp1' );
 	}
+
+	public function testForeignKeyConstraintAreIgnored(): void {
+		/*
+		 * FOREIGN KEY constraints are not supported yet, they will be ignored.
+		 * The following query will work, although it references a missing table.
+		 */
+		$this->assertQuery( 'CREATE TABLE t (id INT, CONSTRAINT c FOREIGN KEY (id) REFERENCES tt (id))' );
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertEquals(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					'  `id` int DEFAULT NULL',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
 }

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -1100,12 +1100,13 @@ class WP_SQLite_Information_Schema_Builder {
 			$keyword = $keyword->get_first_child_token();
 		}
 
-		// FOREIGN KEY and CHECK constraints are not supported yet.
-		if (
-			WP_MySQL_Lexer::FOREIGN_SYMBOL === $keyword->id
-			|| WP_MySQL_Lexer::CHECK_SYMBOL === $keyword->id
-		) {
-			throw new \Exception( 'FOREIGN KEY and CHECK constraints are not supported yet.' );
+		// FOREIGN KEY constraints are not supported yet; they will be ignored.
+		// @TODO: Implement support for FOREIGN KEY constraints.
+
+		// CHECK constraints are not supported yet.
+		// @TODO: Implement support for CHECK constraints.
+		if ( WP_MySQL_Lexer::CHECK_SYMBOL === $keyword->id ) {
+			throw new \Exception( 'CHECK constraints are not supported yet.' );
 		}
 
 		// PRIMARY KEY and UNIQUE require an index.


### PR DESCRIPTION
This is a hotifx where we just let `FOREIGN KEY` constraint definitions pass through, even though we don't save them to the information schema. As a result, they won't be created in SQLite either (the SQLite `CREATE TABLE` statement is generated from the information schema).

A proper fix will follow; it shouldn't be hard to support them.

Fixes https://github.com/WordPress/sqlite-database-integration/issues/229.