### PR TITLE
Add support for derived tables in `UPDATE` with `JOIN` queries, fix special cases

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6840,4 +6840,36 @@ END;
 			$result
 		);
 	}
+
+	public function testUpdateWithJoinComplexQuery(): void {
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+
+		$default_date = '0000-00-00 00:00:00';
+		$this->assertQuery(
+			"CREATE TABLE wp_actionscheduler_actions (
+				action_id bigint(20) unsigned NOT NULL auto_increment,
+				status varchar(20) NOT NULL,
+				scheduled_date_gmt datetime NULL default '{$default_date}',
+				scheduled_date_local datetime NULL default '{$default_date}',
+				priority tinyint unsigned NOT NULL default '10',
+				attempts int(11) NOT NULL default '0',
+				last_attempt_gmt datetime NULL default '{$default_date}',
+				last_attempt_local datetime NULL default '{$default_date}',
+				claim_id bigint(20) unsigned NOT NULL default '0',
+				PRIMARY KEY  (action_id)
+			)"
+		);
+
+		$this->assertQuery(
+			"UPDATE wp_actionscheduler_actions t1
+			JOIN (
+				SELECT action_id
+				FROM wp_actionscheduler_actions
+				WHERE claim_id = 0 AND scheduled_date_gmt <= '2025-09-03 12:23:55' AND status = 'pending'
+				ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC
+				LIMIT 25
+			) t2 ON t1.action_id = t2.action_id
+			SET claim_id = 37, last_attempt_gmt = '2025-09-03 12:23:55', last_attempt_local = '2025-09-03 12:23:55'"
+		);
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6868,6 +6868,7 @@ END;
 				WHERE claim_id = 0 AND scheduled_date_gmt <= '2025-09-03 12:23:55' AND status = 'pending'
 				ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC
 				LIMIT 25
+				FOR UPDATE
 			) t2 ON t1.action_id = t2.action_id
 			SET claim_id = 37, last_attempt_gmt = '2025-09-03 12:23:55', last_attempt_local = '2025-09-03 12:23:55'"
 		);

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -168,6 +168,17 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'UPDATE t SET c = 1 WHERE c = 2'
 		);
 
+		// UPDATE with a table alias.
+		$this->assertQuery(
+			'UPDATE `t` AS `a` SET `c` = 1 WHERE `a`.`c` = 2',
+			'UPDATE t AS a SET c = 1 WHERE a.c = 2'
+		);
+
+		$this->assertQuery(
+			'UPDATE `t` AS `a` SET `c` = 1 WHERE `a`.`c` = 2',
+			'UPDATE t AS a SET a.c = 1 WHERE a.c = 2'
+		);
+
 		// UPDATE with LIMIT.
 		$this->assertQuery(
 			'UPDATE `t` SET `c` = 1 WHERE rowid IN ( SELECT rowid FROM `t` LIMIT 1 )',
@@ -178,6 +189,24 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		$this->assertQuery(
 			'UPDATE `t` SET `c` = 1 WHERE rowid IN ( SELECT rowid FROM `t` ORDER BY `c` ASC LIMIT 1 )',
 			'UPDATE t SET c = 1 ORDER BY c ASC LIMIT 1'
+		);
+
+		// UPDATE with multiple tables.
+		$this->assertQuery(
+			'UPDATE `t1` SET `id` = 1 FROM `t2` WHERE `t1`.`c` = `t2`.`c`',
+			'UPDATE t1, t2 SET t1.id = 1 WHERE t1.c = t2.c'
+		);
+
+		// UPDATE with JOIN.
+		$this->assertQuery(
+			'UPDATE `t1` SET `id` = 1 FROM `t2` WHERE `t1`.`c` = 2 AND `t1`.`c` = `t2`.`c`',
+			'UPDATE t1 JOIN t2 ON t1.c = t2.c SET t1.id = 1 WHERE t1.c = 2'
+		);
+
+		// UPDATE with JOIN using a derived table.
+		$this->assertQuery(
+			'UPDATE `t1` SET `id` = 1 FROM ( SELECT * FROM `t2` ) AS `t2` WHERE `t1`.`c` = 2 AND `t1`.`c` = `t2`.`c`',
+			'UPDATE t1 JOIN ( SELECT * FROM t2 ) AS t2 ON t1.c = t2.c SET t1.id = 1 WHERE t1.c = 2'
 		);
 	}
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1286,14 +1286,6 @@ class WP_SQLite_Driver {
 		 *     SET_SYMBOL updateList whereClause? orderClause? simpleLimitClause?
 		 */
 
-		// Translate WITH clause.
-		$with = $this->translate( $node->get_first_child_node( 'withClause' ) );
-
-		// Translate "UPDATE IGNORE" to "UPDATE OR IGNORE".
-		$or_ignore = $node->has_child_token( WP_MySQL_Lexer::IGNORE_SYMBOL )
-			? 'OR IGNORE'
-			: null;
-
 		// Collect all tables used in the UPDATE clause (e.g, UPDATE t1, t2 JOIN t3).
 		$table_alias_map = $this->create_table_reference_map(
 			$node->get_first_child_node( 'tableReferenceList' )
@@ -1316,7 +1308,7 @@ class WP_SQLite_Driver {
 				if ( null === $table_or_alias ) {
 					$persistent_table_names = array();
 					$temporary_table_names  = array();
-					foreach ( array_column( $table_alias_map, 'table_name' ) as $table_name ) {
+					foreach ( array_filter( array_column( $table_alias_map, 'table_name' ) ) as $table_name ) {
 						$is_temporary      = $this->information_schema_builder->temporary_table_exists( $table_name );
 						$quoted_table_name = $this->connection->quote( $table_name );
 						if ( $is_temporary ) {
@@ -1387,18 +1379,42 @@ class WP_SQLite_Driver {
 			throw $this->new_not_supported_exception( 'UPDATE statement modifying multiple tables' );
 		}
 
+		// Translate WITH clause.
+		$with = $this->translate( $node->get_first_child_node( 'withClause' ) );
+
+		// Translate "UPDATE IGNORE" to "UPDATE OR IGNORE".
+		$or_ignore = $node->has_child_token( WP_MySQL_Lexer::IGNORE_SYMBOL )
+			? 'OR IGNORE'
+			: null;
+
+		// Compose the update target clause.
+		$update_target_table  = $table_alias_map[ $update_target ]['table_name'] ?? $update_target;
+		$update_target_clause = $this->quote_sqlite_identifier( $update_target_table );
+		if ( $update_target !== $update_target_table ) {
+			$update_target_clause .= ' AS ' . $this->quote_sqlite_identifier( $update_target );
+		}
+
 		// Compose the FROM clause using all tables except the one being updated.
 		// UPDATE with FROM in SQLite is equivalent to UPDATE with JOIN in MySQL.
 		$from_items = array();
 		foreach ( $table_alias_map as $alias => $data ) {
-			$table_name = $data['table_name'];
 			if ( $alias === $update_target ) {
 				continue;
 			}
 
-			$from_item = $this->quote_sqlite_identifier( $alias );
+			$table_name = $data['table_name'];
+
+			// Derived table.
+			if ( null === $table_name ) {
+				$from_item    = $data['table_expr'] . ' AS ' . $this->quote_sqlite_identifier( $alias );
+				$from_items[] = $from_item;
+				continue;
+			}
+
+			// Regular table.
+			$from_item = $this->quote_sqlite_identifier( $table_name );
 			if ( $alias !== $table_name ) {
-				$from_item .= ' AS ' . $this->quote_sqlite_identifier( $table_name );
+				$from_item .= ' AS ' . $this->quote_sqlite_identifier( $alias );
 			}
 			$from_items[] = $from_item;
 		}
@@ -1449,7 +1465,7 @@ class WP_SQLite_Driver {
 			$with,
 			'UPDATE',
 			$or_ignore,
-			$this->quote_sqlite_identifier( $update_target ),
+			$update_target_clause,
 			'SET',
 			$update_list,
 			$from,
@@ -4107,8 +4123,9 @@ class WP_SQLite_Driver {
 	 * The returned array maps table aliases to table names and additional data:
 	 *   - key:   table alias, or name if no alias is used
 	 *   - value: an array of table data
-	 *       - table_name: the real name of the table
-	 *       - join_expr:  the join expression used for the table
+	 *       - table_name: the real name of the table (null for derived tables)
+	 *       - table_expr: the table expression for a derived table (null for regular tables)
+	 *       - join_expr:  the join expression used for the table (null when no join is used)
 	 *
 	 * MySQL has a non-stand ardsyntax extension where a comma-separated list of
 	 * table references is allowed as a table reference in itself, for instance:
@@ -4145,11 +4162,24 @@ class WP_SQLite_Driver {
 
 			if ( 'singleTable' === $child->rule_name ) {
 				// Extract data from the "singleTable" node.
-				$name  = $this->translate( $child->get_first_child_node( 'tableRef' ) );
-				$alias = $this->translate( $child->get_first_child_node( 'tableAlias' ) );
+				$name       = $this->translate( $child->get_first_child_node( 'tableRef' ) );
+				$alias_node = $child->get_first_child_node( 'tableAlias' );
+				$alias      = $alias_node ? $this->translate( $alias_node->get_first_child_node( 'identifier' ) ) : null;
 
 				$table_map[ $this->unquote_sqlite_identifier( $alias ?? $name ) ] = array(
 					'table_name' => $this->unquote_sqlite_identifier( $name ),
+					'table_expr' => null,
+					'join_expr'  => $this->translate( $join_expr ),
+				);
+			} elseif ( 'derivedTable' === $child->rule_name ) {
+				// Extract data from the "derivedTable" node.
+				$subquery   = $child->get_first_descendant_node( 'subquery' );
+				$alias_node = $child->get_first_child_node( 'tableAlias' );
+				$alias      = $alias_node ? $this->translate( $alias_node->get_first_child_node( 'identifier' ) ) : null;
+
+				$table_map[ $this->unquote_sqlite_identifier( $alias ) ] = array(
+					'table_name' => null,
+					'table_expr' => $this->translate( $subquery ),
 					'join_expr'  => $this->translate( $join_expr ),
 				);
 			} elseif ( 'tableReferenceListParens' === $child->rule_name ) {

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2841,6 +2841,10 @@ class WP_SQLite_Driver {
 			case 'indexHint':
 			case 'indexHintList':
 				return null;
+			case 'lockingClause':
+				// SQLite doesn't support locking clauses (SELECT ... FOR UPDATE).
+				// They are not needed in SQLite due to the database file locking.
+				return null;
 			default:
 				return $this->translate_sequence( $node->get_children() );
 		}


### PR DESCRIPTION
The following query from Action Scheduler was still failing:

```sql
UPDATE wp_actionscheduler_actions t1
JOIN (
  SELECT action_id from wp_actionscheduler_actions
  WHERE claim_id = 0 AND scheduled_date_gmt <= '2025-09-03 12:23:55' AND status='pending'
  ORDER BY priority ASC, attempts ASC, scheduled_date_gmt ASC, action_id ASC
  LIMIT 25
  FOR UPDATE
) t2 ON t1.action_id = t2.action_id
SET claim_id=37, last_attempt_gmt='2025-09-03 12:23:55', last_attempt_local='2025-09-03 12:23:55
```

This was due to the derived table subquery in `JOIN` and the `FOR UDPATE` clause.

This PR moves the derived subquery to the `FROM` clause, and strips away the locking clauses like `FOR UPDATE`.