### PR TITLE
Add support for all binary and hexadecimal literal syntaxes

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6873,4 +6873,26 @@ END;
 			SET claim_id = 37, last_attempt_gmt = '2025-09-03 12:23:55', last_attempt_local = '2025-09-03 12:23:55'"
 		);
 	}
+
+	public function testBinaryLiterals(): void {
+		$result = $this->assertQuery( 'SELECT 0b0100000101111010' );
+		$this->assertEquals( array( (object) array( '0b0100000101111010' => 'Az' ) ), $result );
+
+		$result = $this->assertQuery( "SELECT b'0100000101111010'" );
+		$this->assertEquals( array( (object) array( "b'0100000101111010'" => 'Az' ) ), $result );
+
+		$result = $this->assertQuery( "SELECT B'0100000101111010'" );
+		$this->assertEquals( array( (object) array( "B'0100000101111010'" => 'Az' ) ), $result );
+	}
+
+	public function testHexadecimalLiterals(): void {
+		$result = $this->assertQuery( 'SELECT 0x417a' );
+		$this->assertEquals( array( (object) array( '0x417a' => 'Az' ) ), $result );
+
+		$result = $this->assertQuery( "SELECT x'417a'" );
+		$this->assertEquals( array( (object) array( "x'417a'" => 'Az' ) ), $result );
+
+		$result = $this->assertQuery( "SELECT X'417a'" );
+		$this->assertEquals( array( (object) array( "X'417a'" => 'Az' ) ), $result );
+	}
 }

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -1328,6 +1328,40 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 		);
 	}
 
+	public function testBinaryLiterals(): void {
+		// All binary literal syntaxes need to be converted to HEX strings.
+		$this->assertQuery(
+			"SELECT x'417a' AS `b'0100000101111010'`",
+			"SELECT b'0100000101111010'"
+		);
+		$this->assertQuery(
+			"SELECT x'417a' AS `B'0100000101111010'`",
+			"SELECT B'0100000101111010'"
+		);
+		$this->assertQuery(
+			"SELECT x'417a' AS `0b0100000101111010`",
+			'SELECT 0b0100000101111010'
+		);
+	}
+
+	public function testHexadecimalLiterals(): void {
+		// The x'...' and X'...' syntax should be preserved as is.
+		$this->assertQuery(
+			"SELECT x'417a'",
+			"SELECT x'417a'"
+		);
+		$this->assertQuery(
+			"SELECT X'417a'",
+			"SELECT X'417a'"
+		);
+
+		// The 0x... syntax needs to be translated to x'...'.
+		$this->assertQuery(
+			"SELECT x'417a' AS `0x417a`",
+			'SELECT 0x417a'
+		);
+	}
+
 	public function testSystemVariables(): void {
 		$this->assertQuery(
 			"SELECT 'ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION,NO_ZERO_DATE,NO_ZERO_IN_DATE,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES' AS `@@sql_mode`",


### PR DESCRIPTION
Add support for all binary and hexadecimal literal syntaxes. The differences are:
1. In MySQL, `0x…` is a binary literal, while in SQLite it’s a numeric one.
2. In MySQL, `0b...`, `b'...'`, and `B'...'` syntaxes can be used to represent binary literals. SQLite only supports HEX literals (`x'...'`).

This PR implements the following conversions:
1. Convert `0x...` to `x'...'`.
2. Convert `0b...`, `b'...'`, and `B'...'` to `x'...'` with binary to hexadecimal conversion.