### PR TITLE
Implement `DATABASE()` function

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -3705,6 +3705,19 @@ QUERY
 		$this->assertQuery( 'DELETE FROM _dates WHERE option_value = CURRENT_TIMESTAMP()' );
 	}
 
+	public function testDatabaseFunction(): void {
+		$this->assertQuery( "SELECT DATABASE(), CONCAT('test-', (SELECT DATABASE()))" );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'DATABASE()'                           => 'wp',
+					"CONCAT('test-', (SELECT DATABASE()))" => 'test-wp',
+				),
+			),
+			$this->engine->get_query_results()
+		);
+	}
+
 	public function testGroupByHaving() {
 		$this->assertQuery(
 			'CREATE TABLE _tmp_table (

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3354,6 +3354,8 @@ class WP_SQLite_Driver {
 		}
 
 		switch ( $child->id ) {
+			case WP_MySQL_Lexer::DATABASE_SYMBOL:
+				return $this->connection->quote( $this->db_name );
 			case WP_MySQL_Lexer::CURRENT_TIMESTAMP_SYMBOL:
 			case WP_MySQL_Lexer::NOW_SYMBOL:
 				/*


### PR DESCRIPTION
Implements the `DATABASE()` function.

This is needed for admin tools like Adminer, phpMyAdmin, and others.