### PR TITLE
Pad binary string literals to full bytes as required by SQLite HEX notation

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6883,6 +6883,22 @@ END;
 
 		$result = $this->assertQuery( "SELECT B'0100000101111010'" );
 		$this->assertEquals( array( (object) array( "B'0100000101111010'" => 'Az' ) ), $result );
+
+		// Verify correct padding (0b1 === 0b01 === 0b001 ... === 0x00000001).
+		$result = $this->assertQuery( 'SELECT 0b1' );
+		$this->assertEquals( array( (object) array( '0b1' => pack( 'H*', '01' ) ) ), $result );
+
+		$result = $this->assertQuery( 'SELECT 0b01' );
+		$this->assertEquals( array( (object) array( '0b01' => pack( 'H*', '01' ) ) ), $result );
+
+		$result = $this->assertQuery( 'SELECT 0b001' );
+		$this->assertEquals( array( (object) array( '0b001' => pack( 'H*', '01' ) ) ), $result );
+
+		$result = $this->assertQuery( 'SELECT 0b00000001' );
+		$this->assertEquals( array( (object) array( '0b00000001' => pack( 'H*', '01' ) ) ), $result );
+
+		$result = $this->assertQuery( 'SELECT 0b000000001' );
+		$this->assertEquals( array( (object) array( '0b000000001' => pack( 'H*', '0001' ) ) ), $result );
 	}
 
 	public function testHexadecimalLiterals(): void {

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2873,7 +2873,18 @@ class WP_SQLite_Driver {
 					// b'...' or B'...'
 					$value = substr( $value, 2, -1 );
 				}
-				return sprintf( "x'%s'", base_convert( $value, 2, 16 ) );
+
+				// Convert the binary string to HEX.
+				$hex = base_convert( $value, 2, 16 );
+
+				/*
+				 * The "base_convert()" function doesn't add or preserve padding.
+				 * Let's compute how many bytes we expect and pad the HEX value
+				 * to full bytes (SQLite requires HEX strings of even length).
+				 */
+				$byte_count = (int) ceil( strlen( $value ) / 8 );
+				$hex        = str_pad( $hex, $byte_count * 2, '0', STR_PAD_LEFT );
+				return sprintf( "x'%s'", $hex );
 			case WP_MySQL_Lexer::HEX_NUMBER:
 				/*
 				 * In MySQL, "0x" prefixed values represent binary literal values,


### PR DESCRIPTION
This fixes the following error:
```bash
SQLSTATE[HY000]: General error: 1 unrecognized token: "x'1'"
```

For queries like the following:
```sql
SELECT 0b1;
SELECT 0b01;
SELECT 0b001;
...
```

SQLite doesn't have binary string literals, so [we need to convert them to HEX string literals](https://github.com/WordPress/sqlite-database-integration/pull/245). However, HEX string literals in SQLite must be aligned to full bytes (their length needs to be even) — `x'01'` is valid, while `x'1'` is invalid.

In MySQL, binary strings don't require such alignment, and `0b1` is valid (and `SELECT 0b1 = 0b01` returns `true`).

Additionally, the `base_convert()` function used in the [original implementation](https://github.com/WordPress/sqlite-database-integration/pull/245) doesn't preserve existing leading `0` padding.

To solve both of these issues, this PR implements the following:
1. Count how many full bytes the original binary string requires.
2. Make sure the resulting HEX string has that number of bytes, using leading `0` padding.

For HEX strings, this fix is not needed, as those require to be byte-aligned also in MySQL, so throwing an error for `x'1'` is actually correct.