### PR TITLE
Introduce an unsafe flag for using the new driver with SQLite < `3.37.0`

### DIFF
--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -483,13 +483,35 @@ class WP_SQLite_Driver {
 		// Check the SQLite version.
 		$sqlite_version = $this->get_sqlite_version();
 		if ( version_compare( $sqlite_version, self::MINIMUM_SQLITE_VERSION, '<' ) ) {
-			throw $this->new_driver_exception(
-				sprintf(
-					'The SQLite version %s is not supported. Minimum required version is %s.',
-					$sqlite_version,
-					self::MINIMUM_SQLITE_VERSION
-				)
-			);
+			if ( defined( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS' ) && WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS ) {
+				/*
+				 * SQLite versions prior to 3.37.0 do not support STRICT tables.
+				 *
+				 * However, a database created with SQLite >= 3.37.0 can be used
+				 * with SQLite versions < 3.37.0 when "PRAGMA writable_schema" is
+				 * set to "ON", which also enables error-tolerant schema parsing.
+				 *
+				 * This is an unsafe opt-in feature for special back compatibility
+				 * use cases, as it can corrupt the database by allowing incorrect
+				 * types into STRICT tables. Additionally, depending on the legacy
+				 * SQLite version used, there is no guarantee that all features of
+				 * the SQLite driver will work as expected. Use this with caution.
+				 *
+				 * See: https://www.sqlite.org/stricttables.html#accessing_strict_tables_in_earlier_versions_of_sqlite
+				 *
+				 * TODO: Remove this flag when we drop support for PHP 8.0.
+				 *       From PHP 8.1, SQLite 3.46.1 is used by default.
+				 */
+				$this->execute_sqlite_query( 'PRAGMA writable_schema=ON' );
+			} else {
+				throw $this->new_driver_exception(
+					sprintf(
+						'The SQLite version %s is not supported. Minimum required version is %s.',
+						$sqlite_version,
+						self::MINIMUM_SQLITE_VERSION
+					)
+				);
+			}
 		}
 
 		// Load SQLite version to a property used by WordPress health info.

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -484,6 +484,19 @@ class WP_SQLite_Driver {
 		$sqlite_version = $this->get_sqlite_version();
 		if ( version_compare( $sqlite_version, self::MINIMUM_SQLITE_VERSION, '<' ) ) {
 			if ( defined( 'WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS' ) && WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS ) {
+				// When "WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS" is enabled,
+				// allow using legacy SQLite versions, but not older than 3.27.0.
+				if ( version_compare( $sqlite_version, '3.27.0', '<' ) ) {
+					throw $this->new_driver_exception(
+						sprintf(
+							'The SQLite version %s is not supported. Minimum required version is %s.'
+								. ' With "WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS" enabled, you must use 3.27.0 or newer.',
+							$sqlite_version,
+							self::MINIMUM_SQLITE_VERSION
+						)
+					);
+				}
+
 				/*
 				 * SQLite versions prior to 3.37.0 do not support STRICT tables.
 				 *


### PR DESCRIPTION
Adds a `WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS` flag for use with older versions of SQLite.

I came to the conclusion that a special flag with the word `UNSAFE` might be the best solution here.

By default, the new driver would still throw the following error:

> The SQLite version 3.27.2 is not supported. Minimum required version is 3.37.0.

But with the new flag, it could enable accessing a database created with 3.37.0 on older SQLite versions.

**An important consideration or TODO:**
In this form, it would serve a basic use case, which is opening an existing database on an older SQLite for previews, including writing data to the database.

However, any new `CREATE TABLE` statement would fail because of the use of the `STRICT` keyword (`General error: 1 near "STRICT": syntax error`). We could address that by omitting that keyword in this mode, but maybe let's first determine whether there are use cases for it.

Resolves https://github.com/WordPress/sqlite-database-integration/issues/252.