### PR TITLE
Add support for `CHECK` constraints

### DIFF
--- a/tests/WP_SQLite_Driver_Metadata_Tests.php
+++ b/tests/WP_SQLite_Driver_Metadata_Tests.php
@@ -1878,4 +1878,221 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->expectExceptionCode( 'HY000' );
 		$this->assertQuery( 'ALTER TABLE t2 DROP CONSTRAINT cnst' );
 	}
+
+	public function testInformationSchemaCheckConstraints(): void {
+		$this->assertQuery(
+			"CREATE TABLE t (
+				id INT NOT NULL CHECK (id > 0),
+				name VARCHAR(255) NOT NULL CHECK (name != ''),
+				score DOUBLE NOT NULL CHECK (score > 0 AND score < 100),
+				data JSON CHECK (json_valid(data)),
+				start_timestamp TIMESTAMP NOT NULL,
+				end_timestamp TIMESTAMP NOT NULL,
+				CONSTRAINT c1 CHECK (id < 10),
+				CONSTRAINT c2 CHECK (start_timestamp < end_timestamp),
+				CONSTRAINT c3 CHECK (length(data) < 20)
+			)"
+		);
+
+		// INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+		$result = $this->assertQuery( "SELECT * FROM information_schema.table_constraints WHERE table_name = 't' ORDER BY CONSTRAINT_NAME" );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c1',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c2',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c3',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_1',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_2',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_3',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_4',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+			),
+			$result
+		);
+
+		// INFORMATION_SCHEMA.CHECK_CONSTRAINTS
+		$result = $this->assertQuery( 'SELECT * FROM information_schema.check_constraints ORDER BY CONSTRAINT_NAME' );
+		$this->assertCount( 7, $result );
+
+		$this->assertEquals(
+			array(
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c1',
+					'CHECK_CLAUSE'       => '( id < 10 )',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c2',
+					'CHECK_CLAUSE'       => '( start_timestamp < end_timestamp )',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c3',
+					'CHECK_CLAUSE'       => '( length ( data ) < 20 )',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_1',
+					'CHECK_CLAUSE'       => '( id > 0 )',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_2',
+					'CHECK_CLAUSE'       => "( name != '' )",
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_3',
+					'CHECK_CLAUSE'       => '( score > 0 AND score < 100 )',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_4',
+					'CHECK_CLAUSE'       => '( json_valid ( data ) )',
+				),
+			),
+			$result
+		);
+	}
+
+	public function testInformationSchemaAlterTableAddCheckConstraint(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT)' );
+
+		// ADD CONSTRAINT syntax.
+		$this->assertQuery( 'ALTER TABLE t ADD CONSTRAINT c CHECK (id > 0)' );
+
+		// ADD CHECK syntax.
+		$this->assertQuery( 'ALTER TABLE t ADD CHECK (id < 10)' );
+
+		// INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+		$result = $this->assertQuery( "SELECT * FROM information_schema.table_constraints WHERE table_name = 't' ORDER BY CONSTRAINT_NAME" );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_1',
+					'TABLE_SCHEMA'       => 'wp',
+					'TABLE_NAME'         => 't',
+					'CONSTRAINT_TYPE'    => 'CHECK',
+					'ENFORCED'           => 'YES',
+				),
+			),
+			$result
+		);
+
+		// INFORMATION_SCHEMA.CHECK_CONSTRAINTS
+		$result = $this->assertQuery( 'SELECT * FROM information_schema.check_constraints ORDER BY CONSTRAINT_NAME' );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 'c',
+					'CHECK_CLAUSE'       => '( id > 0 )',
+				),
+				(object) array(
+					'CONSTRAINT_CATALOG' => 'def',
+					'CONSTRAINT_SCHEMA'  => 'wp',
+					'CONSTRAINT_NAME'    => 't_chk_1',
+					'CHECK_CLAUSE'       => '( id < 10 )',
+				),
+			),
+			$result
+		);
+	}
+
+	public function testInformationSchemaAlterTableDropCheckConstraint(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT, CONSTRAINT c1 CHECK (id > 0), CONSTRAINT c2 CHECK (id < 10))' );
+
+		$result = $this->assertQuery( "SELECT * FROM information_schema.table_constraints WHERE table_name = 't'" );
+		$this->assertCount( 2, $result );
+
+		$result = $this->assertQuery( 'SELECT * FROM information_schema.check_constraints' );
+		$this->assertCount( 2, $result );
+
+		// DROP CONSTRAINT syntax.
+		$this->assertQuery( 'ALTER TABLE t DROP CONSTRAINT c1' );
+
+		// DROP CHECK syntax.
+		$this->assertQuery( 'ALTER TABLE t DROP CHECK c2' );
+
+		$result = $this->assertQuery( "SELECT * FROM information_schema.table_constraints WHERE table_name = 't'" );
+		$this->assertCount( 0, $result );
+
+		$result = $this->assertQuery( 'SELECT * FROM information_schema.check_constraints' );
+		$this->assertCount( 0, $result );
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -9178,6 +9178,9 @@ END;
 		// Insert valid data.
 		$this->assertQuery( 'INSERT INTO t (id) VALUES (1)' );
 
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+
 		// Insert invalid data.
 		$this->expectException( WP_SQLite_Driver_Exception::class );
 		$this->expectExceptionMessage( 'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: c' );
@@ -9207,5 +9210,12 @@ END;
 			),
 			$result[0]->{'Create Table'}
 		);
+
+		// Insert data that would violate the constraints.
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (0)' );
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (100)' );
+
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 2, $result );
 	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -9218,4 +9218,30 @@ END;
 		$result = $this->assertQuery( 'SELECT * FROM t' );
 		$this->assertCount( 2, $result );
 	}
+
+	public function testCheckConstraintNotEnforced(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT, CONSTRAINT c CHECK (id > 0) NOT ENFORCED)' );
+
+		// Insert data that would violate the constraints.
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (0)' );
+
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertCount( 1, $result );
+
+		// SHOW CREATE TABLE
+		$this->assertQuery( 'SHOW CREATE TABLE t' );
+		$result = $this->engine->get_query_results();
+		$this->assertEquals(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					'  `id` int DEFAULT NULL,',
+					'  CONSTRAINT `c` CHECK ( id > 0 ) /*!80016 NOT ENFORCED */',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -8976,4 +8976,211 @@ END;
 			$column_info[0]
 		);
 	}
+
+	public function testCheckConstraints(): void {
+		$this->assertQuery(
+			"CREATE TABLE t (
+				id INT NOT NULL CHECK (id > 0),
+				name VARCHAR(255) NOT NULL CHECK (name != ''),
+				score DOUBLE NOT NULL CHECK (score > 0 AND score < 100),
+				data JSON CHECK (json_valid(data)),
+				start_timestamp TIMESTAMP NOT NULL,
+				end_timestamp TIMESTAMP NOT NULL,
+				CONSTRAINT c1 CHECK (id < 10),
+				CONSTRAINT c2 CHECK (start_timestamp < end_timestamp),
+				CONSTRAINT c3 CHECK (length(data) < 20)
+			)"
+		);
+
+		// Valid data.
+		$this->assertQuery(
+			"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+			VALUES (1, 'test', 50, '2025-01-01 12:00:00', '2025-01-02 12:00:00', '{\"key\":\"value\"}')
+		"
+		);
+
+		// Invalid ID.
+		$exception = null;
+		try {
+			$this->assertQuery(
+				"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+				VALUES (0, 'test', 50, '2025-01-01 12:00:00', '2025-01-02 12:00:00', '{\"key\":\"value\"}')
+			"
+			);
+		} catch ( WP_SQLite_Driver_Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertNotNull( $exception );
+		$this->assertSame(
+			'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: t_chk_1',
+			$exception->getMessage()
+		);
+
+		// Invalid name.
+		$exception = null;
+		try {
+			$this->assertQuery(
+				"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+				VALUES (1, '', 50, '2025-01-01 12:00:00', '2025-01-02 12:00:00', '{\"key\":\"value\"}')
+			"
+			);
+		} catch ( WP_SQLite_Driver_Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertNotNull( $exception );
+		$this->assertSame(
+			'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: t_chk_2',
+			$exception->getMessage()
+		);
+
+		// Invalid score.
+		$exception = null;
+		try {
+			$this->assertQuery(
+				"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+				VALUES (1, 'test', 100, '2025-01-01 12:00:00', '2025-01-02 12:00:00', '{\"key\":\"value\"}')
+			"
+			);
+		} catch ( WP_SQLite_Driver_Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertNotNull( $exception );
+		$this->assertSame(
+			'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: t_chk_3',
+			$exception->getMessage()
+		);
+
+		// Invalid data.
+		$exception = null;
+		try {
+			$this->assertQuery(
+				"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+				VALUES (1, 'test', 50, '2025-01-01 12:00:00', '2025-01-02 12:00:00', 'invalid JSON')
+			"
+			);
+		} catch ( WP_SQLite_Driver_Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertNotNull( $exception );
+		$this->assertSame(
+			'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: t_chk_4',
+			$exception->getMessage()
+		);
+
+		// Invalid c1.
+		$exception = null;
+		try {
+			$this->assertQuery(
+				"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+				VALUES (11, 'test', 50, '2025-01-01 12:00:00', '2025-01-02 12:00:00', '{\"key\":\"value\"}')
+			"
+			);
+		} catch ( WP_SQLite_Driver_Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertNotNull( $exception );
+		$this->assertSame(
+			'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: c1',
+			$exception->getMessage()
+		);
+
+		// Invalid c2.
+		$exception = null;
+		try {
+			$this->assertQuery(
+				"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+				VALUES (1, 'test', 50, '2025-01-02 12:00:00', '2025-01-01 12:00:00', '{\"key\":\"value\"}')
+			"
+			);
+		} catch ( WP_SQLite_Driver_Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertNotNull( $exception );
+		$this->assertSame(
+			'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: c2',
+			$exception->getMessage()
+		);
+
+		// Invalid c3.
+		$exception = null;
+		try {
+			$this->assertQuery(
+				"INSERT INTO t (id, name, score, start_timestamp, end_timestamp, data)
+				VALUES (1, 'test', 50, '2025-01-01 12:00:00', '2025-01-02 12:00:00', '{\"key\":\"a-very-long-value\"}')
+			"
+			);
+		} catch ( WP_SQLite_Driver_Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertNotNull( $exception );
+		$this->assertSame(
+			'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: c3',
+			$exception->getMessage()
+		);
+
+		// SHOW CREATE TABLE
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertCount( 1, $result );
+		$this->assertEquals(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					'  `id` int NOT NULL,',
+					'  `name` varchar(255) NOT NULL,',
+					'  `score` double NOT NULL,',
+					'  `data` json DEFAULT NULL,',
+					'  `start_timestamp` timestamp NOT NULL,',
+					'  `end_timestamp` timestamp NOT NULL,',
+
+					// The of the check expressions below is not 100% matching MySQL,
+					// because in MySQL the expressions are parsed and normalized.
+					'  CONSTRAINT `c1` CHECK ( id < 10 ),',
+					'  CONSTRAINT `c2` CHECK ( start_timestamp < end_timestamp ),',
+					'  CONSTRAINT `c3` CHECK ( length ( data ) < 20 ),',
+					'  CONSTRAINT `t_chk_1` CHECK ( id > 0 ),',
+					"  CONSTRAINT `t_chk_2` CHECK ( name != '' ),",
+					'  CONSTRAINT `t_chk_3` CHECK ( score > 0 AND score < 100 ),',
+					'  CONSTRAINT `t_chk_4` CHECK ( json_valid ( data ) )',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
+
+	public function testAlterTableAddCheckConstraint(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT)' );
+
+		// ADD CONSTRAINT syntax.
+		$this->assertQuery( 'ALTER TABLE t ADD CONSTRAINT c CHECK (id > 0)' );
+
+		// ADD CHECK syntax.
+		$this->assertQuery( 'ALTER TABLE t ADD CHECK (id < 10)' );
+
+		// SHOW CREATE TABLE
+		$this->assertQuery( 'SHOW CREATE TABLE t' );
+		$result = $this->engine->get_query_results();
+		$this->assertEquals(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					'  `id` int DEFAULT NULL,',
+					'  CONSTRAINT `c` CHECK ( id > 0 ),',
+					'  CONSTRAINT `t_chk_1` CHECK ( id < 10 )',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+
+		// Insert valid data.
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (1)' );
+
+		// Insert invalid data.
+		$this->expectException( WP_SQLite_Driver_Exception::class );
+		$this->expectExceptionMessage( 'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: c' );
+		$this->assertQuery( 'INSERT INTO t (id) VALUES (0)' );
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -9183,4 +9183,24 @@ END;
 		$this->expectExceptionMessage( 'SQLSTATE[23000]: Integrity constraint violation: 19 CHECK constraint failed: c' );
 		$this->assertQuery( 'INSERT INTO t (id) VALUES (0)' );
 	}
+
+	public function testAlterTableDropCheckConstraint(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT, CONSTRAINT c CHECK (id > 0))' );
+		$this->assertQuery( 'ALTER TABLE t DROP CONSTRAINT c' );
+
+		// SHOW CREATE TABLE
+		$this->assertQuery( 'SHOW CREATE TABLE t' );
+		$result = $this->engine->get_query_results();
+		$this->assertEquals(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					'  `id` int DEFAULT NULL',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -9185,8 +9185,13 @@ END;
 	}
 
 	public function testAlterTableDropCheckConstraint(): void {
-		$this->assertQuery( 'CREATE TABLE t (id INT, CONSTRAINT c CHECK (id > 0))' );
-		$this->assertQuery( 'ALTER TABLE t DROP CONSTRAINT c' );
+		$this->assertQuery( 'CREATE TABLE t (id INT, CONSTRAINT c1 CHECK (id > 0), CONSTRAINT c2 CHECK (id < 10))' );
+
+		// DROP CONSTRAINT syntax.
+		$this->assertQuery( 'ALTER TABLE t DROP CONSTRAINT c1' );
+
+		// DROP CHECK syntax.
+		$this->assertQuery( 'ALTER TABLE t DROP CHECK c2' );
 
 		// SHOW CREATE TABLE
 		$this->assertQuery( 'SHOW CREATE TABLE t' );

--- a/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -243,6 +243,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -267,6 +268,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -285,14 +287,15 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 					. " VALUES ('wp', 't', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't', 0, 'wp', 'PRIMARY', 1, 'id', 'A', 0, null, null, '', 'BTREE', '', '', 'YES', null)",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't', 'wp', 'PRIMARY', 'PRIMARY KEY')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't', 'wp', 'PRIMARY', 'PRIMARY KEY', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'PRIMARY', 'wp', 't', 'id', 1, null, null, null, null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -314,6 +317,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -335,6 +339,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -362,14 +367,15 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 					. " VALUES ('wp', 't', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't', 0, 'wp', 'PRIMARY', 1, 'id', 'A', 0, null, null, '', 'BTREE', '', '', 'YES', null)",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't', 'wp', 'PRIMARY', 'PRIMARY KEY')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't', 'wp', 'PRIMARY', 'PRIMARY KEY', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'PRIMARY', 'wp', 't', 'id', 1, null, null, null, null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -389,14 +395,15 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 					. " VALUES ('wp', 't1', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't1', 0, 'wp', 'PRIMARY', 1, 'id', 'A', 0, null, null, '', 'BTREE', '', '', 'YES', null)",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't1', 'wp', 'PRIMARY', 'PRIMARY KEY')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't1', 'wp', 'PRIMARY', 'PRIMARY KEY', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'PRIMARY', 'wp', 't1', 'id', 1, null, null, null, null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't1'",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't1' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't1' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't1' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't1' ORDER BY tc.constraint_name",
 			)
 		);
 
@@ -414,14 +421,15 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 					. " VALUES ('wp', 't2', 'id', 1, null, 'NO', 'int', null, null, 10, 0, null, null, null, 'int', 'PRI', 'auto_increment', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't2', 0, 'wp', 'PRIMARY', 1, 'id', 'A', 0, null, null, '', 'BTREE', '', '', 'YES', null)",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't2', 'wp', 'PRIMARY', 'PRIMARY KEY')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't2', 'wp', 'PRIMARY', 'PRIMARY KEY', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'PRIMARY', 'wp', 't2', 'id', 1, null, null, null, null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't2'",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't2' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't2' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't2' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't2' ORDER BY tc.constraint_name",
 			)
 		);
 
@@ -441,14 +449,15 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't3', 0, 'wp', 'PRIMARY', 1, 'id', 'A', 0, null, null, '', 'BTREE', '', '', 'YES', null)",
 				"UPDATE `_wp_sqlite_mysql_information_schema_columns` AS c SET (column_key, is_nullable) = ( SELECT CASE WHEN MAX(s.index_name = 'PRIMARY') THEN 'PRI' WHEN MAX(s.non_unique = 0 AND s.seq_in_index = 1) THEN 'UNI' WHEN MAX(s.seq_in_index = 1) THEN 'MUL' ELSE '' END, CASE WHEN MAX(s.index_name = 'PRIMARY') THEN 'NO' ELSE c.is_nullable END FROM `_wp_sqlite_mysql_information_schema_statistics` AS s WHERE s.table_schema = c.table_schema AND s.table_name = c.table_name AND s.column_name = c.column_name ) WHERE c.table_schema = 'wp' AND c.table_name = 't3'",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't3', 'wp', 'PRIMARY', 'PRIMARY KEY')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't3', 'wp', 'PRIMARY', 'PRIMARY KEY', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'PRIMARY', 'wp', 't3', 'id', 1, null, null, null, null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't3'",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't3' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't3' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't3' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't3' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -471,22 +480,23 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 					. " VALUES ('wp', 't', 'id', 1, null, 'YES', 'int', null, null, 10, 0, null, null, null, 'int', 'UNI', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't', 0, 'wp', 'id', 1, 'id', 'A', 0, null, null, 'YES', 'BTREE', '', '', 'YES', null)",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't', 'wp', 'id', 'UNIQUE')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't', 'wp', 'id', 'UNIQUE', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'id', 'wp', 't', 'id', 1, null, null, null, null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_columns` (`table_schema`, `table_name`, `column_name`, `ordinal_position`, `column_default`, `is_nullable`, `data_type`, `character_maximum_length`, `character_octet_length`, `numeric_precision`, `numeric_scale`, `datetime_precision`, `character_set_name`, `collation_name`, `column_type`, `column_key`, `extra`, `privileges`, `column_comment`, `generation_expression`, `srs_id`)'
 					. " VALUES ('wp', 't', 'name', 2, null, 'YES', 'text', 65535, 65535, null, null, null, 'utf8mb4', 'utf8mb4_0900_ai_ci', 'text', 'UNI', '', 'select,insert,update,references', '', '', null)",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't', 0, 'wp', 'name', 1, 'name', 'A', 0, null, null, 'YES', 'BTREE', '', '', 'YES', null)",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't', 'wp', 'name', 'UNIQUE')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't', 'wp', 'name', 'UNIQUE', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'name', 'wp', 't', 'name', 1, null, null, null, null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -514,8 +524,8 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't', 0, 'wp', 'id', 1, 'id', 'A', 0, null, null, 'YES', 'BTREE', '', '', 'YES', null)",
 				"UPDATE `_wp_sqlite_mysql_information_schema_columns` AS c SET (column_key, is_nullable) = ( SELECT CASE WHEN MAX(s.index_name = 'PRIMARY') THEN 'PRI' WHEN MAX(s.non_unique = 0 AND s.seq_in_index = 1) THEN 'UNI' WHEN MAX(s.seq_in_index = 1) THEN 'MUL' ELSE '' END, CASE WHEN MAX(s.index_name = 'PRIMARY') THEN 'NO' ELSE c.is_nullable END FROM `_wp_sqlite_mysql_information_schema_statistics` AS s WHERE s.table_schema = c.table_schema AND s.table_name = c.table_name AND s.column_name = c.column_name ) WHERE c.table_schema = 'wp' AND c.table_name = 't'",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't', 'wp', 'id', 'UNIQUE')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't', 'wp', 'id', 'UNIQUE', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'id', 'wp', 't', 'id', 1, null, null, null, null)",
 				"SELECT column_name, data_type, is_nullable, character_maximum_length FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' AND column_name IN ('name')",
@@ -523,14 +533,15 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_statistics` (`table_schema`, `table_name`, `non_unique`, `index_schema`, `index_name`, `seq_in_index`, `column_name`, `collation`, `cardinality`, `sub_part`, `packed`, `nullable`, `index_type`, `comment`, `index_comment`, `is_visible`, `expression`)'
 					. " VALUES ('wp', 't', 0, 'wp', 'name', 1, 'name', 'A', 0, null, null, 'YES', 'BTREE', '', '', 'YES', null)",
 				"UPDATE `_wp_sqlite_mysql_information_schema_columns` AS c SET (column_key, is_nullable) = ( SELECT CASE WHEN MAX(s.index_name = 'PRIMARY') THEN 'PRI' WHEN MAX(s.non_unique = 0 AND s.seq_in_index = 1) THEN 'UNI' WHEN MAX(s.seq_in_index = 1) THEN 'MUL' ELSE '' END, CASE WHEN MAX(s.index_name = 'PRIMARY') THEN 'NO' ELSE c.is_nullable END FROM `_wp_sqlite_mysql_information_schema_statistics` AS s WHERE s.table_schema = c.table_schema AND s.table_name = c.table_name AND s.column_name = c.column_name ) WHERE c.table_schema = 'wp' AND c.table_name = 't'",
-				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`)'
-					. " VALUES ('wp', 't', 'wp', 'name', 'UNIQUE')",
+				'INSERT INTO `_wp_sqlite_mysql_information_schema_table_constraints` (`table_schema`, `table_name`, `constraint_schema`, `constraint_name`, `constraint_type`, `enforced`)'
+					. " VALUES ('wp', 't', 'wp', 'name', 'UNIQUE', 'YES')",
 				'INSERT INTO `_wp_sqlite_mysql_information_schema_key_column_usage` (`constraint_schema`, `constraint_name`, `table_schema`, `table_name`, `column_name`, `ordinal_position`, `position_in_unique_constraint`, `referenced_table_schema`, `referenced_table_name`, `referenced_column_name`)'
 					. " VALUES ('wp', 'name', 'wp', 't', 'name', 1, null, null, null, null)",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_tables` WHERE table_type = 'BASE TABLE' AND table_schema = 'wp' AND table_name = 't'",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -600,6 +611,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -630,6 +642,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -660,6 +673,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -690,6 +704,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -726,6 +741,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -758,6 +774,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);  }
 
@@ -794,6 +811,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -829,6 +847,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -864,6 +883,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -886,6 +906,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -908,6 +929,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -938,6 +960,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -964,6 +987,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -990,6 +1014,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1012,6 +1037,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1036,6 +1062,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1062,6 +1089,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1086,6 +1114,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1110,6 +1139,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1136,6 +1166,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1156,6 +1187,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1184,6 +1216,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1206,6 +1239,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1232,6 +1266,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1258,6 +1293,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1282,6 +1318,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1304,6 +1341,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}
@@ -1324,6 +1362,7 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_columns` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY ordinal_position",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_statistics` WHERE table_schema = 'wp' AND table_name = 't' ORDER BY INDEX_NAME = 'PRIMARY' DESC, NON_UNIQUE = '0' DESC, INDEX_TYPE = 'SPATIAL' DESC, INDEX_TYPE = 'BTREE' DESC, INDEX_TYPE = 'FULLTEXT' DESC, ROWID, SEQ_IN_INDEX",
 				"SELECT * FROM `_wp_sqlite_mysql_information_schema_referential_constraints` WHERE constraint_schema = 'wp' AND table_name = 't' ORDER BY constraint_name",
+				"SELECT tc.*, cc.check_clause FROM `_wp_sqlite_mysql_information_schema_table_constraints` tc JOIN `_wp_sqlite_mysql_information_schema_check_constraints` cc ON cc.constraint_name = tc.constraint_name WHERE tc.constraint_schema = 'wp' AND tc.table_name = 't' ORDER BY tc.constraint_name",
 			)
 		);
 	}

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -4739,7 +4739,26 @@ class WP_SQLite_Driver {
 			}
 		}
 
-		// 5. Generate CREATE TABLE statement columns.
+		// 5. Get CHECK constraint info.
+		$table_constraints_table = $this->information_schema_builder
+			->get_table_name( $table_is_temporary, 'table_constraints' );
+		$check_constraints_table = $this->information_schema_builder
+			->get_table_name( $table_is_temporary, 'check_constraints' );
+		$check_constraints_info  = $this->execute_sqlite_query(
+			sprintf(
+				'SELECT tc.*, cc.check_clause
+				FROM %s tc
+				JOIN %s cc ON cc.constraint_name = tc.constraint_name
+				WHERE tc.constraint_schema = ?
+				AND tc.table_name = ?
+				ORDER BY tc.constraint_name',
+				$this->quote_sqlite_identifier( $table_constraints_table ),
+				$this->quote_sqlite_identifier( $check_constraints_table )
+			),
+			array( $this->db_name, $table_name )
+		)->fetchAll( PDO::FETCH_ASSOC );
+
+		// 6. Generate CREATE TABLE statement columns.
 		$rows              = array();
 		$on_update_queries = array();
 		$has_autoincrement = false;
@@ -4875,7 +4894,7 @@ class WP_SQLite_Driver {
 			}
 		}
 
-		// 7. Add foreign key constraints.
+		// 8. Add foreign key constraints.
 		foreach ( $referential_constraints_info as $referential_constraint ) {
 			$column_names            = array();
 			$referenced_column_names = array();
@@ -4910,7 +4929,26 @@ class WP_SQLite_Driver {
 			$rows[] = $query;
 		}
 
-		// 8. Compose the CREATE TABLE statement.
+		// 9. Add CHECK constraints.
+		foreach ( $check_constraints_info as $check_constraint ) {
+			if ( 'NO' === $check_constraint['ENFORCED'] ) {
+				continue;
+			}
+
+			// Translate the check clause from MySQL to SQLite.
+			$ast          = $this->create_parser( 'SELECT ' . $check_constraint['CHECK_CLAUSE'] )->parse();
+			$expr         = $ast->get_first_descendant_node( 'selectItem' )->get_first_child_node();
+			$check_clause = $this->translate( $expr );
+
+			$sql    = sprintf(
+				'  CONSTRAINT %s CHECK %s',
+				$this->quote_sqlite_identifier( $check_constraint['CONSTRAINT_NAME'] ),
+				$check_clause
+			);
+			$rows[] = $sql;
+		}
+
+		// 10. Compose the CREATE TABLE statement.
 		$create_table_query  = sprintf(
 			"CREATE %sTABLE %s (\n",
 			$table_is_temporary ? 'TEMPORARY ' : '',
@@ -5028,7 +5066,26 @@ class WP_SQLite_Driver {
 			}
 		}
 
-		// 5. Generate CREATE TABLE statement columns.
+		// 5. Get CHECK constraint info.
+		$table_constraints_table = $this->information_schema_builder
+			->get_table_name( $table_is_temporary, 'table_constraints' );
+		$check_constraints_table = $this->information_schema_builder
+			->get_table_name( $table_is_temporary, 'check_constraints' );
+		$check_constraints_info  = $this->execute_sqlite_query(
+			sprintf(
+				'SELECT tc.*, cc.check_clause
+				FROM %s tc
+				JOIN %s cc ON cc.constraint_name = tc.constraint_name
+				WHERE tc.constraint_schema = ?
+				AND tc.table_name = ?
+				ORDER BY tc.constraint_name',
+				$this->quote_sqlite_identifier( $table_constraints_table ),
+				$this->quote_sqlite_identifier( $check_constraints_table )
+			),
+			array( $this->db_name, $table_name )
+		)->fetchAll( PDO::FETCH_ASSOC );
+
+		// 6. Generate CREATE TABLE statement columns.
 		$rows = array();
 		foreach ( $column_info as $column ) {
 			$sql  = '  ';
@@ -5072,7 +5129,7 @@ class WP_SQLite_Driver {
 			$rows[] = $sql;
 		}
 
-		// 6. Generate CREATE TABLE statement constraints, collect indexes.
+		// 7. Generate CREATE TABLE statement constraints, collect indexes.
 		foreach ( $grouped_constraints as $constraint ) {
 			ksort( $constraint );
 			$info = $constraint[1];
@@ -5129,7 +5186,7 @@ class WP_SQLite_Driver {
 			$rows[] = $sql;
 		}
 
-		// 7. Add foreign key constraints.
+		// 8. Add foreign key constraints.
 		foreach ( $referential_constraints_info as $referential_constraint ) {
 			$column_names            = array();
 			$referenced_column_names = array();
@@ -5153,7 +5210,18 @@ class WP_SQLite_Driver {
 			$rows[] = $sql;
 		}
 
-		// 8. Compose the CREATE TABLE statement.
+		// 9. Add CHECK constraints.
+		foreach ( $check_constraints_info as $check_constraint ) {
+			$sql    = sprintf(
+				'  CONSTRAINT %s CHECK %s%s',
+				$this->quote_mysql_identifier( $check_constraint['CONSTRAINT_NAME'] ),
+				$check_constraint['CHECK_CLAUSE'],
+				'NO' === $check_constraint['ENFORCED'] ? ' /*!80016 NOT ENFORCED */' : ''
+			);
+			$rows[] = $sql;
+		}
+
+		// 10. Compose the CREATE TABLE statement.
 		$collation = $table_info['TABLE_COLLATION'];
 		$charset   = substr( $collation, 0, strpos( $collation, '_' ) );
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -22,10 +22,10 @@ class WP_SQLite_Information_Schema_Builder {
 	 *  - COLUMNS
 	 *  - STATISTICS (indexes)
 	 *  - TABLE_CONSTRAINTS
+	 *  - CHECK_CONSTRAINTS
 	 *
 	 * TODO (not yet implemented):
 	 *  - VIEWS
-	 *  - CHECK_CONSTRAINTS
 	 *  - TRIGGERS
 	 */
 	const INFORMATION_SCHEMA_TABLE_DEFINITIONS = array(
@@ -167,6 +167,15 @@ class WP_SQLite_Information_Schema_Builder {
 			REFERENCED_TABLE_NAME TEXT COLLATE NOCASE,                     -- referenced table name
 			REFERENCED_COLUMN_NAME TEXT COLLATE NOCASE,                    -- referenced column name
 			UNIQUE (CONSTRAINT_SCHEMA, CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_SCHEMA)
+		",
+
+		// INFORMATION_SCHEMA.CHECK_CONSTRAINTS
+		'check_constraints'       => "
+			CONSTRAINT_CATALOG TEXT NOT NULL DEFAULT 'def' COLLATE NOCASE, -- always 'def'
+			CONSTRAINT_SCHEMA TEXT NOT NULL COLLATE NOCASE,                -- constraint database name
+			CONSTRAINT_NAME TEXT NOT NULL COLLATE NOCASE,                  -- constraint name
+			CHECK_CLAUSE TEXT NOT NULL COLLATE BINARY,                     -- check clause
+			PRIMARY KEY (CONSTRAINT_SCHEMA, CONSTRAINT_NAME)
 		",
 	);
 
@@ -531,6 +540,10 @@ class WP_SQLite_Information_Schema_Builder {
 				$table_name,
 				$index_data['index_name'] ?? null
 			);
+			$check_constraint_data       = $this->extract_check_constraint_data(
+				$column_node,
+				$table_name
+			);
 
 			// Save inline column constraints and indexes.
 			if ( null !== $index_data ) {
@@ -555,6 +568,12 @@ class WP_SQLite_Information_Schema_Builder {
 				$this->insert_values(
 					$this->get_table_name( $table_is_temporary, 'key_column_usage' ),
 					$key_column_usage_item
+				);
+			}
+			if ( null !== $check_constraint_data ) {
+				$this->insert_values(
+					$this->get_table_name( $table_is_temporary, 'check_constraints' ),
+					$check_constraint_data
 				);
 			}
 
@@ -1167,14 +1186,13 @@ class WP_SQLite_Information_Schema_Builder {
 	): void {
 		// Get first constraint keyword.
 		$children = $node->get_children();
-		$keyword  = $children[0] instanceof WP_MySQL_Token ? $children[0] : $children[1];
+		if ( $children[0] instanceof WP_Parser_Node && 'constraintName' === $children[0]->rule_name ) {
+			$keyword = $children[1];
+		} else {
+			$keyword = $children[0];
+		}
 		if ( ! $keyword instanceof WP_MySQL_Token ) {
 			$keyword = $keyword->get_first_child_token();
-		}
-
-		// CHECK constraints are not supported yet.
-		if ( WP_MySQL_Lexer::CHECK_SYMBOL === $keyword->id ) {
-			throw new \Exception( 'CHECK constraints are not supported yet.' );
 		}
 
 		// PRIMARY KEY and UNIQUE require an index.
@@ -1208,6 +1226,7 @@ class WP_SQLite_Information_Schema_Builder {
 		$constraint_data             = $this->extract_table_constraint_data( $node, $table_name, $index_name );
 		$referential_constraint_data = $this->extract_referential_constraint_data( $node, $table_name );
 		$key_column_usage_data       = $this->extract_key_column_usage_data( $node, $table_name, $index_name );
+		$check_constraint_data       = $this->extract_check_constraint_data( $node, $table_name );
 
 		// Save constraint data.
 		if ( null !== $constraint_data ) {
@@ -1228,6 +1247,13 @@ class WP_SQLite_Information_Schema_Builder {
 			$this->insert_values(
 				$this->get_table_name( $table_is_temporary, 'key_column_usage' ),
 				$key_column_usage_item
+			);
+		}
+
+		if ( null !== $check_constraint_data ) {
+			$this->insert_values(
+				$this->get_table_name( $table_is_temporary, 'check_constraints' ),
+				$check_constraint_data
 			);
 		}
 	}
@@ -1605,12 +1631,22 @@ class WP_SQLite_Information_Schema_Builder {
 
 		// Index name always takes precedence over constraint name.
 		$name = $index_name ?? $this->get_table_constraint_name( $node, $table_name );
+
+		// Constraint enforcement.
+		$constraint_enforcement = $node->get_first_descendant_node( 'constraintEnforcement' );
+		if ( $constraint_enforcement && $constraint_enforcement->has_child_token( WP_MySQL_Lexer::NOT_SYMBOL ) ) {
+			$enforced = 'NO';
+		} else {
+			$enforced = 'YES';
+		}
+
 		return array(
 			'table_schema'      => $this->db_name,
 			'table_name'        => $table_name,
 			'constraint_schema' => $this->db_name,
 			'constraint_name'   => $name,
 			'constraint_type'   => $type,
+			'enforced'          => $enforced,
 		);
 	}
 
@@ -1766,6 +1802,32 @@ class WP_SQLite_Information_Schema_Builder {
 			);
 		}
 		return $rows;
+	}
+
+	/**
+	 * Extract check constraint data from the "tableConstraintDef" AST node.
+	 *
+	 * @param  WP_Parser_Node $node       The "tableConstraintDef" AST node.
+	 * @param  string         $table_name The table name.
+	 * @return array|null                 The check constraint data as stored in information schema.
+	 */
+	private function extract_check_constraint_data( WP_Parser_Node $node, string $table_name ): ?array {
+		$check_constraint = $node->get_first_descendant_node( 'checkConstraint' );
+		if ( null === $check_constraint ) {
+			return null;
+		}
+
+		$expr         = $check_constraint->get_first_child_node( 'exprWithParentheses' );
+		$check_clause = '';
+		foreach ( $expr->get_descendant_tokens() as $i => $token ) {
+			$check_clause .= ( $i > 0 ? ' ' : '' ) . $token->get_bytes();
+		}
+
+		return array(
+			'constraint_schema' => $this->db_name,
+			'constraint_name'   => $this->get_table_constraint_name( $node, $table_name ),
+			'check_clause'      => $check_clause,
+		);
 	}
 
 	/**
@@ -2431,9 +2493,14 @@ class WP_SQLite_Information_Schema_Builder {
 			return $this->get_value( $name_node->get_first_child_node( 'identifier' ) );
 		}
 
-		// FOREIGN KEY constraint without a name gets a generated name.
-		if ( $node->get_first_descendant_node( 'references' ) ) {
-			// Get the highest existing name in format "<table_name>_ibfk_<number>".
+		$foreign_key      = $node->get_first_descendant_node( 'references' );
+		$check_constraint = $node->get_first_descendant_node( 'checkConstraint' );
+
+		// FOREIGN KEY and CHECK constraints without a name get a generated name.
+		if ( $foreign_key || $check_constraint ) {
+			$type = $check_constraint ? 'chk' : 'ibfk';
+
+			// Get the highest existing name in format "<table_name>_<type>_<number>".
 			$existing_names = $this->connection->query(
 				sprintf(
 					"SELECT DISTINCT constraint_name
@@ -2451,7 +2518,7 @@ class WP_SQLite_Information_Schema_Builder {
 				array(
 					$this->db_name,
 					$table_name,
-					str_replace( array( '_', '%' ), array( '\\_', '\\%' ), $table_name ) . '\\_ibfk\\_%',
+					str_replace( array( '_', '%' ), array( '\\_', '\\%' ), $table_name ) . "\\_{$type}\\_%",
 				)
 			)->fetchAll(
 				PDO::FETCH_COLUMN // phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
@@ -2465,10 +2532,9 @@ class WP_SQLite_Information_Schema_Builder {
 					$last_name_index = (int) max( $last_name_index, (int) $last_part );
 				}
 			}
-			return $table_name . '_ibfk_' . ( $last_name_index + 1 );
+			return $table_name . "_{$type}_" . ( $last_name_index + 1 );
 		}
 
-		// TODO: Handle CHECK constraints.
 		return null;
 	}
 

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -682,6 +682,13 @@ class WP_SQLite_Information_Schema_Builder {
 					continue;
 				}
 
+				// DROP CHECK
+				if ( $action->has_child_token( WP_MySQL_Lexer::CHECK_SYMBOL ) ) {
+					$name = $this->get_value( $action->get_first_child_node( 'identifier' ) );
+					$this->record_drop_check_constraint( $table_is_temporary, $table_name, $name );
+					continue;
+				}
+
 				// DROP [COLUMN]
 				$column_ref = $action->get_first_child_node( 'fieldIdentifier' );
 				if ( null !== $column_ref ) {

--- a/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-information-schema-builder.php
@@ -1301,6 +1301,8 @@ class WP_SQLite_Information_Schema_Builder {
 			$this->record_drop_key( $table_is_temporary, $table_name, $name );
 		} elseif ( 'FOREIGN KEY' === $constraint_type ) {
 			$this->record_drop_foreign_key( $table_is_temporary, $table_name, $name );
+		} elseif ( 'CHECK' === $constraint_type ) {
+			$this->record_drop_check_constraint( $table_is_temporary, $table_name, $name );
 		} else {
 			throw new \Exception(
 				"DROP CONSTRAINT for constraint type '$constraint_type' is not supported."
@@ -1394,6 +1396,37 @@ class WP_SQLite_Information_Schema_Builder {
 
 				// Remove only FOREIGN KEY records; not PRIMARY/UNIQUE KEY data.
 				'REFERENCED_TABLE_SCHEMA' => $this->db_name,
+			)
+		);
+	}
+
+	/**
+	 * Analyze DROP CHECK statement and record data in the information schema.
+	 *
+	 * @param bool   $table_is_temporary Whether the table is temporary.
+	 * @param string $table_name         The table name.
+	 * @param string $name               The check constraint name.
+	 */
+	private function record_drop_check_constraint(
+		bool $table_is_temporary,
+		string $table_name,
+		string $name
+	): void {
+		$this->delete_values(
+			$this->get_table_name( $table_is_temporary, 'table_constraints' ),
+			array(
+				'CONSTRAINT_SCHEMA' => $this->db_name,
+				'TABLE_NAME'        => $table_name,
+				'CONSTRAINT_TYPE'   => 'CHECK',
+				'CONSTRAINT_NAME'   => $name,
+			)
+		);
+
+		$this->delete_values(
+			$this->get_table_name( $table_is_temporary, 'check_constraints' ),
+			array(
+				'CONSTRAINT_SCHEMA' => $this->db_name,
+				'CONSTRAINT_NAME'   => $name,
 			)
 		);
 	}


### PR DESCRIPTION
Implements support for `CHECK` constraints:

```sql
CREATE TABLE t (
	id INT NOT NULL CHECK (id > 0),
	name VARCHAR(255) NOT NULL CHECK (name != ''),
	score DOUBLE NOT NULL CHECK (score > 0 AND score < 100),
	data JSON CHECK (json_valid(data)),
	start_timestamp TIMESTAMP NOT NULL,
	end_timestamp TIMESTAMP NOT NULL,
	CONSTRAINT c1 CHECK (id < 10),
	CONSTRAINT c2 CHECK (start_timestamp < end_timestamp),
	CONSTRAINT c3 CHECK (length(data) < 20)
)
```

This includes support for:
1. `CREATE TABLE` with inline `CHECK (...)` for column definitions.
2. `CREATE TABLE` with `CHECK (...)` and `CONSTRAINT ... CHECK (...)` definitions.
3. `ALTER TABLE ... ADD CHECK (...)` and `ALTER TABLE ... ADD CONSTRAINT ... CHECK (...)` statements.
4. `ALTER TABLE ... DROP CONSTRAINT ...` statements.
5. `ALTER TABLE ... DROP CHECK ...` statements.
6. `CHECK` constraints with the `NOT ENFORCED` clause.

Resolves https://github.com/WordPress/sqlite-database-integration/issues/251.