### PR TITLE
Always apply wp_sqlite_default_db_name filter to DB_NAME

### DIFF
--- a/wp-includes/sqlite/db.php
+++ b/wp-includes/sqlite/db.php
@@ -67,8 +67,10 @@ require_once __DIR__ . '/install-functions.php';
 if ( defined( 'DB_NAME' ) && '' !== DB_NAME ) {
 	$db_name = DB_NAME;
 } else {
-	$db_name = apply_filters( 'wp_sqlite_default_db_name', 'database_name_here' );
+	$db_name = 'database_name_here';
 }
+
+$db_name = apply_filters( 'wp_sqlite_default_db_name', $db_name );
 
 /*
  * Debug: Cross-check with MySQL.


### PR DESCRIPTION
- Related to https://github.com/Automattic/studio/pull/1839

This PR applies the `wp_sqlite_default_db_name` filter in all cases, even if DB_NAME was defined, so we can override the database name, and fix the behaviour in remote servers where DB_NAME is already defined.

## Testing instructions:

> [!WARNING]  
These steps are not currently working, but they represent the desired behavior.

* Break your database connection:
  * Go to your wp-config.php
  * Copy the value of your DB_NAME
  * Change it to any value to break your database connection
  * Access the homepage of your site and observe the error: `Error establishing a database connection`
* Fix your database connection using the filter:
  * Create a new mu-plugin with the code below these instructions.
  * Access your homepage
  * Observe the site loads correctly

```php
<?php

add_filter( 'wp_sqlite_default_db_name', function( $db_name ) {
	return 'database_name_here'; // Or any other value that you copied from your wp-config.php
} );
```