### PR TITLE
Add WP_SQLITE_DB_NAME constant to take precedence over DB_NAME

### DIFF
--- a/wp-includes/sqlite/db.php
+++ b/wp-includes/sqlite/db.php
@@ -64,8 +64,8 @@ require_once __DIR__ . '/install-functions.php';
  *
  * TODO: For version 3.0, enforce the DB_NAME constant and remove the fallback.
  */
-if ( defined( 'SQLITE_DB_NAME' ) && '' !== SQLITE_DB_NAME ) {
-	$db_name = SQLITE_DB_NAME;
+if ( defined( 'WP_SQLITE_DB_NAME' ) && '' !== WP_SQLITE_DB_NAME ) {
+	$db_name = WP_SQLITE_DB_NAME;
 } elseif ( defined( 'DB_NAME' ) && '' !== DB_NAME ) {
 	$db_name = DB_NAME;
 } else {

--- a/wp-includes/sqlite/db.php
+++ b/wp-includes/sqlite/db.php
@@ -64,11 +64,15 @@ require_once __DIR__ . '/install-functions.php';
  *
  * TODO: For version 3.0, enforce the DB_NAME constant and remove the fallback.
  */
-if ( defined( 'DB_NAME' ) && '' !== DB_NAME ) {
+if ( defined( 'SQLITE_DB_NAME' ) && '' !== SQLITE_DB_NAME ) {
+	$db_name = SQLITE_DB_NAME;
+} elseif ( defined( 'DB_NAME' ) && '' !== DB_NAME ) {
 	$db_name = DB_NAME;
 } else {
-	$db_name = apply_filters( 'wp_sqlite_default_db_name', 'database_name_here' );
+	$db_name = 'database_name_here';
 }
+
+$db_name = apply_filters( 'wp_sqlite_default_db_name', $db_name );
 
 /*
  * Debug: Cross-check with MySQL.

--- a/wp-includes/sqlite/db.php
+++ b/wp-includes/sqlite/db.php
@@ -72,8 +72,6 @@ if ( defined( 'SQLITE_DB_NAME' ) && '' !== SQLITE_DB_NAME ) {
 	$db_name = 'database_name_here';
 }
 
-$db_name = apply_filters( 'wp_sqlite_default_db_name', $db_name );
-
 /*
  * Debug: Cross-check with MySQL.
  * This is for debugging purpose only and requires files


### PR DESCRIPTION
- Related to https://github.com/Automattic/studio/pull/1839

Because [filters actually don’t work in db.php](https://github.com/WordPress/sqlite-database-integration/pull/260), I suggest removing the `wp_sqlite_default_db_name` filter and introducing a new constant `WP_SQLITE_DB_NAME` to take precedence over DB_NAME.

* Break your database connection:
  * Edit your wp-config.php
  * Copy the value of your DB_NAME
  * Change it to any value to break your database connection
  * Access the homepage of your site and observe the error: `Error establishing a database connection`
* Fix your database connection using the new constant:
  * Edit your wp-config.php
  * Add the new constant WP_SQLITE_DB_NAME with the value you copied before. Example `define( 'WP_SQLITE_DB_NAME', 'database_name_here' );`
  * Access your site and observe it loads correctly


Credit to @wojtekn for the code. I just [removed the filter](https://github.com/WordPress/sqlite-database-integration/pull/261/commits/8f5de999c950ad4ed76244489613be3b29c1c56c) as it seemed misleading.