### PR TITLE
Add support for `INSERT INTO ... SET ...` syntax

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -9439,4 +9439,40 @@ END;
 			$result
 		);
 	}
+
+	public function testInsertIntoSetSyntax(): void {
+		$this->assertQuery(
+			'CREATE TABLE t (
+			  id INT PRIMARY KEY AUTO_INCREMENT,
+			  name VARCHAR(255) NOT NULL,
+			  value TEXT
+			)'
+		);
+
+		$this->assertQuery( "INSERT INTO t SET name = 'one'" );
+		$this->assertQuery( "INSERT INTO t SET name = 'two', value = 'two-value'" );
+		$this->assertQuery( "INSERT INTO t SET value = 'three-value', name = 'three'" );
+
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'id'    => '1',
+					'name'  => 'one',
+					'value' => null,
+				),
+				(object) array(
+					'id'    => '2',
+					'name'  => 'two',
+					'value' => 'two-value',
+				),
+				(object) array(
+					'id'    => '3',
+					'name'  => 'three',
+					'value' => 'three-value',
+				),
+			),
+			$result
+		);
+	}
 }

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -9475,4 +9475,50 @@ END;
 			$result
 		);
 	}
+
+	public function testInsertIntoSetSyntaxInNonStrictMode(): void {
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+
+		$this->assertQuery(
+			'CREATE TABLE t (
+			  id INT PRIMARY KEY AUTO_INCREMENT,
+			  created_at DATETIME NOT NULL,
+			  name VARCHAR(255) NOT NULL,
+			  value TEXT,
+			  score INT NOT NULL
+			)'
+		);
+
+		$this->assertQuery( "INSERT INTO t SET name = 'one'" );
+		$this->assertQuery( "INSERT INTO t SET name = 'two', value = 'two-value'" );
+		$this->assertQuery( "INSERT INTO t SET value = 'three-value', name = 'three'" );
+
+		$result = $this->assertQuery( 'SELECT * FROM t' );
+		$this->assertEquals(
+			array(
+				(object) array(
+					'id'         => '1',
+					'created_at' => '0000-00-00 00:00:00',
+					'name'       => 'one',
+					'value'      => null,
+					'score'      => '0',
+				),
+				(object) array(
+					'id'         => '2',
+					'created_at' => '0000-00-00 00:00:00',
+					'name'       => 'two',
+					'value'      => 'two-value',
+					'score'      => '0',
+				),
+				(object) array(
+					'id'         => '3',
+					'created_at' => '0000-00-00 00:00:00',
+					'name'       => 'three',
+					'value'      => 'three-value',
+					'score'      => '0',
+				),
+			),
+			$result
+		);
+	}
 }

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1529,7 +1529,15 @@ class WP_SQLite_Driver {
 
 		$parts = array();
 		foreach ( $node->get_children() as $child ) {
-			if ( $child instanceof WP_MySQL_Token && WP_MySQL_Lexer::IGNORE_SYMBOL === $child->id ) {
+			$is_token = $child instanceof WP_MySQL_Token;
+			$is_node  = $child instanceof WP_Parser_Node;
+
+			// Skip the SET keyword in "INSERT INTO ... SET ..." syntax.
+			if ( $is_token && WP_MySQL_Lexer::SET_SYMBOL === $child->id ) {
+				continue;
+			}
+
+			if ( $is_token && WP_MySQL_Lexer::IGNORE_SYMBOL === $child->id ) {
 				// Translate "UPDATE IGNORE" to "UPDATE OR IGNORE".
 				$parts[] = 'OR IGNORE';
 			} elseif (
@@ -1540,6 +1548,16 @@ class WP_SQLite_Driver {
 				$table_ref  = $node->get_first_child_node( 'tableRef' );
 				$table_name = $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
 				$parts[]    = $this->translate_insert_or_replace_body_in_non_strict_mode( $table_name, $child );
+			} elseif ( $is_node && 'updateList' === $child->rule_name ) {
+				// Convert "SET c1 = v1, c2 = v2, ... to "(c1, c2, ...) VALUES (v1, v2, ...)".
+				$columns = array();
+				$values  = array();
+				foreach ( $child->get_child_nodes( 'updateElement' ) as $update_element ) {
+					$column_ref = $update_element->get_first_child_node( 'columnRef' );
+					$columns[]  = $this->translate( $column_ref );
+					$values[]   = $this->translate( $update_element->get_first_child_node( 'expr' ) );
+				}
+				$parts[] = '(' . implode( ', ', $columns ) . ') VALUES (' . implode( ', ', $values ) . ')';
 			} else {
 				$parts[] = $this->translate( $child );
 			}

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1542,8 +1542,12 @@ class WP_SQLite_Driver {
 				$parts[] = 'OR IGNORE';
 			} elseif (
 				$is_non_strict_mode
-				&& $child instanceof WP_Parser_Node
-				&& ( 'insertFromConstructor' === $child->rule_name || 'insertQueryExpression' === $child->rule_name )
+				&& $is_node
+				&& (
+					'insertFromConstructor' === $child->rule_name
+					|| 'insertQueryExpression' === $child->rule_name
+					|| 'updateList' === $child->rule_name
+				)
 			) {
 				$table_ref  = $node->get_first_child_node( 'tableRef' );
 				$table_name = $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
@@ -4322,6 +4326,12 @@ class WP_SQLite_Driver {
 			foreach ( $fields_node->get_child_nodes() as $field ) {
 				$insert_list[] = $this->unquote_sqlite_identifier( $this->translate( $field ) );
 			}
+		} elseif ( 'updateList' === $node->rule_name ) {
+			// This is the "INSERT INTO ... SET c1 = v1, c2 = v2, ... " syntax.
+			foreach ( $node->get_child_nodes( 'updateElement' ) as $update_element ) {
+				$column_ref    = $update_element->get_first_child_node( 'columnRef' );
+				$insert_list[] = $this->unquote_sqlite_identifier( $this->translate( $column_ref ) );
+			}
 		} else {
 			// When no explicit field list is provided, all columns are required.
 			foreach ( array_column( $columns, 'COLUMN_NAME' ) as $column_name ) {
@@ -4402,10 +4412,25 @@ class WP_SQLite_Driver {
 			}
 		}
 
-		// 6. Wrap the original insert VALUES or SELECT expression in a FROM clause.
-		$values = 'insertFromConstructor' === $node->rule_name
-			? $node->get_first_child_node( 'insertValues' )
-			: $node->get_first_child_node( 'queryExpressionOrParens' );
+		// 6. Wrap the original insert VALUES, SELECT, or SET list in a FROM clause.
+		if ( 'insertFromConstructor' === $node->rule_name ) {
+			// VALUES (...)
+			$from = $this->translate(
+				$node->get_first_child_node( 'insertValues' )
+			);
+		} elseif ( 'insertQueryExpression' === $node->rule_name ) {
+			// SELECT ...
+			$from = $this->translate(
+				$node->get_first_child_node( 'queryExpressionOrParens' )
+			);
+		} else {
+			// SET c1 = v1, c2 = v2, ...
+			$values = array();
+			foreach ( $node->get_child_nodes( 'updateElement' ) as $update_element ) {
+				$values[] = $this->translate( $update_element->get_first_child_node( 'expr' ) );
+			}
+			$from = 'VALUES (' . implode( ', ', $values ) . ')';
+		}
 
 		/*
 		 * The "WHERE true" suffix is used to avoid parsing ambiguity in SQLite.
@@ -4414,7 +4439,7 @@ class WP_SQLite_Driver {
 		 *
 		 * See: https://www.sqlite.org/lang_insert.html
 		 */
-		$fragment .= ' FROM (' . $this->translate( $values ) . ') WHERE true';
+		$fragment .= ' FROM (' . $from . ') WHERE true';
 
 		return $fragment;
 	}


### PR DESCRIPTION
Some popular plugins use the `INSERT INTO … SET …` syntax that is specific to MySQL.

In SQLite, this needs to be translated into the standard `INSERT INTO ( … ) VALUES ( … )` syntax.