### PR TITLE
Fix deprecation warnings, report them in tests

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6276,6 +6276,33 @@ END;
 		$this->assertEquals( 3, $result[0]->{'@my_var'} );
 	}
 
+	public function testVariableBackupAndRestoreForDumps(): void {
+		// Set and backup variables.
+		$this->assertQuery( '/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;' );
+		$this->assertQuery( '/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;' );
+		$this->assertQuery( '/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;' );
+		$this->assertQuery( '/*!50503 SET NAMES utf8mb4 */;' );
+		$this->assertQuery( '/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;' );
+		$this->assertQuery( "/*!40103 SET TIME_ZONE='+00:00' */;" );
+		$this->assertQuery( '/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;' );
+		$this->assertQuery( '/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;' );
+		$this->assertQuery( "/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;" );
+		$this->assertQuery( '/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;' );
+		$this->assertQuery( '/*!40101 SET @saved_cs_client = @@character_set_client */; ' );
+		$this->assertQuery( '/*!50503 SET character_set_client = utf8mb4 */;' );
+
+		// Restore variables.
+		$this->assertQuery( '/*!40101 SET character_set_client = @saved_cs_client */;' );
+		$this->assertQuery( '/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;' );
+		$this->assertQuery( '/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;' );
+		$this->assertQuery( '/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;' );
+		$this->assertQuery( '/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;' );
+		$this->assertQuery( '/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;' );
+		$this->assertQuery( '/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;' );
+		$this->assertQuery( '/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;' );
+		$this->assertQuery( '/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;' );
+	}
+
 	public function testLockingStatements(): void {
 		$this->assertQuery( 'CREATE TABLE t (id INT)' );
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,7 +23,7 @@ require_once __DIR__ . '/../wp-includes/sqlite-ast/class-wp-sqlite-information-s
 require_once __DIR__ . '/../wp-includes/sqlite-ast/class-wp-sqlite-information-schema-reconstructor.php';
 
 // Configure the test environment.
-error_reporting( E_ALL & ~E_DEPRECATED );
+error_reporting( E_ALL );
 define( 'FQDB', ':memory:' );
 define( 'FQDBDIR', __DIR__ . '/../testdb' );
 

--- a/tests/mysql/WP_MySQL_Server_Suite_Lexer_Tests.php
+++ b/tests/mysql/WP_MySQL_Server_Suite_Lexer_Tests.php
@@ -21,7 +21,7 @@ class WP_MySQL_Server_Suite_Lexer_Tests extends TestCase {
 		}
 
 		try {
-			while ( ( $record = fgetcsv( $handle ) ) !== false ) {
+			while ( ( $record = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
 				$query  = $record[0];
 				$lexer  = new WP_MySQL_Lexer( $query );
 				$tokens = $lexer->remaining_tokens();

--- a/tests/mysql/WP_MySQL_Server_Suite_Parser_Tests.php
+++ b/tests/mysql/WP_MySQL_Server_Suite_Parser_Tests.php
@@ -75,7 +75,7 @@ class WP_MySQL_Server_Suite_Parser_Tests extends TestCase {
 		try {
 			$data  = array();
 			$batch = 1;
-			while ( ( $record = fgetcsv( $handle ) ) !== false ) {
+			while ( ( $record = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
 				$data[] = $record;
 				if ( count( $data ) === 1000 ) {
 					yield "batch-$batch" => array( $data );

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -1598,7 +1598,7 @@ class WP_SQLite_Driver {
 		 *         UPDATE t, information_schema.columns c SET t.column = c.column ...
 		 */
 		foreach ( $table_alias_map as $alias => $data ) {
-			if ( 'information_schema' === strtolower( $data['database'] ) ) {
+			if ( 'information_schema' === strtolower( $data['database'] ?? '' ) ) {
 				throw $this->new_access_denied_to_information_schema_exception();
 			}
 		}
@@ -2281,7 +2281,7 @@ class WP_SQLite_Driver {
 							'flags'       => array( 'not_null' ),
 							'table'       => '',
 							'name'        => 'Create Table',
-							'len'         => strlen( $sql ),
+							'len'         => strlen( $sql ?? '' ),
 							'precision'   => 31,
 						),
 					);

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2925,7 +2925,7 @@ class WP_SQLite_Driver {
 		 *          SET updatable_views_with_limit = OFF;   ERROR 1231 (42000)
 		 *          SET updatable_views_with_limit = false; SELECT @@updatable_views_with_limit; -> NO
 		 */
-		$lowercase_value = strtolower( $value );
+		$lowercase_value = null === $value ? null : strtolower( $value );
 		if ( 'on' === $lowercase_value || 'off' === $lowercase_value ) {
 			$value = 'on' === $lowercase_value ? 1 : 0;
 		}


### PR DESCRIPTION
It turns out that `E_DEPRECATED` was excluded in the test bootstrap.

When enabling it, I found a few small issues, plus fixed this one:

```
PHP Deprecated:  strtolower():
Passing null to parameter #1 ($string) of type string is deprecated
in .../sqlite-database-integration/wp-includes/sqlite-ast/class-wp-sqlite-driver.php on line 2868
```

This deprecation warning occurs on PHP >= 8.4 when a SQL variable with a `null` value is read.