### PR TITLE
Emulate the `VERSION()` function in the SQLite driver

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -11134,4 +11134,9 @@ END;
 			"SQLSTATE[42S22]: Column not found: 1054 Unknown column 'missing_column' in 'field list'"
 		);
 	}
+
+	public function testVersionFunction(): void {
+		$result = $this->engine->query( 'SELECT VERSION()' );
+		$this->assertSame( '8.0.38', $result[0]->{'VERSION()'} );
+	}
 }

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -3963,6 +3963,15 @@ class WP_SQLite_Driver {
 					$found_rows = count( $this->last_result );
 				}
 				return $found_rows;
+			case 'VERSION':
+				$version = (string) $this->mysql_version;
+				$value   = sprintf(
+					'%d.%d.%d',
+					$version[0],
+					substr( $version, 1, 2 ),
+					substr( $version, 3, 2 )
+				);
+				return $this->connection->quote( $value );
 			default:
 				return $this->translate_sequence( $node->get_children() );
 		}


### PR DESCRIPTION
Emulate the `VERSION()` function in the SQLite driver

This replaces the old implementation from the legacy SQLite translator that's defined in `WP_SQLite_PDO_User_Defined_Functions` and returns `5.5`.

Emulating it directly in the driver should also be faster than calling a PHP function from SQLite.

This function is used in WordPress core and causes outdated database warning on the Site Health screen.