### PR TITLE
Make it work with PHP built with static-php-cli

### DIFF
--- a/activate.php
+++ b/activate.php
@@ -76,7 +76,7 @@ add_filter(
  */
 function sqlite_plugin_copy_db_file() {
 	// Bail early if the PDO SQLite extension is not loaded.
-	if ( ! extension_loaded( 'pdo_sqlite' ) ) {
+	if ( ! extension_loaded( 'pdo_sqlite' ) && ! extension_loaded( 'sqlite3' ) ) {
 		return;
 	}
 

--- a/admin-notices.php
+++ b/admin-notices.php
@@ -20,7 +20,7 @@ function sqlite_plugin_admin_notice() {
 	}
 
 	// If PDO SQLite is not loaded, bail early.
-	if ( ! extension_loaded( 'pdo_sqlite' )  && ! extension_loaded( 'sqlite3' )) {
+	if ( ! extension_loaded( 'pdo_sqlite' ) && ! extension_loaded( 'sqlite3' ) ) {
 		printf(
 			'<div class="notice notice-error"><p>%s</p></div>',
 			esc_html__( 'The SQLite Integration plugin is active, but the PDO SQLite extension is missing from your server. Please make sure that PDO SQLite is enabled in your PHP installation.', 'sqlite-database-integration' )

--- a/admin-notices.php
+++ b/admin-notices.php
@@ -20,7 +20,7 @@ function sqlite_plugin_admin_notice() {
 	}
 
 	// If PDO SQLite is not loaded, bail early.
-	if ( ! extension_loaded( 'pdo_sqlite' ) ) {
+	if ( ! extension_loaded( 'pdo_sqlite' )  && ! extension_loaded( 'sqlite3' )) {
 		printf(
 			'<div class="notice notice-error"><p>%s</p></div>',
 			esc_html__( 'The SQLite Integration plugin is active, but the PDO SQLite extension is missing from your server. Please make sure that PDO SQLite is enabled in your PHP installation.', 'sqlite-database-integration' )

--- a/admin-page.php
+++ b/admin-page.php
@@ -61,7 +61,7 @@ function sqlite_integration_admin_screen() {
 					);
 				?>
 			</p>
-		<?php elseif ( ! extension_loaded( 'pdo_sqlite' )  && ! extension_loaded( 'sqlite3' ) ) : ?>
+		<?php elseif ( ! extension_loaded( 'pdo_sqlite' ) && ! extension_loaded( 'sqlite3' ) ) : ?>
 			<div class="notice notice-error">
 				<p><?php esc_html_e( 'We detected that the PDO SQLite driver is missing from your server (the pdo_sqlite extension is not loaded). Please make sure that SQLite is enabled in your PHP installation before proceeding.', 'sqlite-database-integration' ); ?></p>
 			</div>

--- a/admin-page.php
+++ b/admin-page.php
@@ -61,7 +61,7 @@ function sqlite_integration_admin_screen() {
 					);
 				?>
 			</p>
-		<?php elseif ( ! extension_loaded( 'pdo_sqlite' ) ) : ?>
+		<?php elseif ( ! extension_loaded( 'pdo_sqlite' )  && ! extension_loaded( 'sqlite3' ) ) : ?>
 			<div class="notice notice-error">
 				<p><?php esc_html_e( 'We detected that the PDO SQLite driver is missing from your server (the pdo_sqlite extension is not loaded). Please make sure that SQLite is enabled in your PHP installation before proceeding.', 'sqlite-database-integration' ); ?></p>
 			</div>

--- a/wp-includes/sqlite/db.php
+++ b/wp-includes/sqlite/db.php
@@ -33,7 +33,7 @@ if ( ! extension_loaded( 'pdo' ) ) {
 	);
 }
 
-if ( ! extension_loaded( 'pdo_sqlite' ) ) {
+if ( ! extension_loaded( 'pdo_sqlite' ) && ! extension_loaded( 'sqlite3' ) ) {
 	wp_die(
 		new WP_Error(
 			'pdo_driver_not_loaded',


### PR DESCRIPTION
Thank you so much for the work on the plugin, it's a treat to setup and use!

The issue this PR is trying to solve surfaced while using a static build of PHP and PHP-FPM (v8.4.14) built using @crazywhalecc/static-php-cli. I'm using the "bulk" pre-built version of the PHP and PHP-FPM binaries, which contains pretty-much all of the essential PHP extensions built-in, including SQLite.

But unfortunately the wordpress setup crashes with "PDO Driver for SQLite is missing", after installing the sqlite-database-integration plugin (and following through with the necessary steps).

Checking through the code, I found that the SQLite PHP extension is detected by checking for the pdo_sqlite extension, while the SQLite extension built-into the static PHP build is called: sqlite3. 

Replacing all occurrences of "pdo_sqlite" with "sqlite3" in the extension source code fixes the problem. But instead of replacing strings, this PR changes the logic, wherever used, to crash only if neither of the PHP extensions are installed