### PR TITLE
Support `LIKE`/`WHERE` clauses in all `SHOW` statements

### DIFF
--- a/tests/WP_SQLite_Driver_Metadata_Tests.php
+++ b/tests/WP_SQLite_Driver_Metadata_Tests.php
@@ -468,6 +468,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 	}
 
 	public function testShowCollation(): void {
+		// Simple.
 		$this->assertQuery( 'SHOW COLLATION' );
 		$actual = $this->engine->get_query_results();
 		$this->assertCount( 7, $actual );
@@ -478,6 +479,21 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals( 'utf8mb4_bin', $actual[4]->Collation );
 		$this->assertEquals( 'utf8mb4_unicode_ci', $actual[5]->Collation );
 		$this->assertEquals( 'utf8mb4_0900_ai_ci', $actual[6]->Collation );
+
+		// With LIKE clause.
+		$this->assertQuery( "SHOW COLLATION LIKE 'utf8%'" );
+		$actual = $this->engine->get_query_results();
+		$this->assertCount( 6, $actual );
+		$this->assertEquals( 'utf8_bin', $actual[0]->Collation );
+		$this->assertEquals( 'utf8_general_ci', $actual[1]->Collation );
+		$this->assertEquals( 'utf8_unicode_ci', $actual[2]->Collation );
+		$this->assertEquals( 'utf8mb4_bin', $actual[3]->Collation );
+
+		// With WHERE clause.
+		$this->assertQuery( "SHOW COLLATION WHERE Collation = 'utf8_bin'" );
+		$actual = $this->engine->get_query_results();
+		$this->assertCount( 1, $actual );
+		$this->assertEquals( 'utf8_bin', $actual[0]->Collation );
 	}
 
 	public function testShowDatabases(): void {

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -3018,6 +3018,19 @@ class WP_SQLite_Driver_Tests extends TestCase {
 			),
 			$this->engine->get_query_results()
 		);
+
+		// With WHERE clause.
+		$this->assertQuery( "SHOW INDEX FROM wptests_term_relationships WHERE Key_name = 'PRIMARY'" );
+		$actual = $this->engine->get_query_results();
+		$this->assertCount( 2, $actual );
+
+		$this->assertQuery( 'SHOW INDEX FROM wptests_term_relationships WHERE Non_unique = 0' );
+		$actual = $this->engine->get_query_results();
+		$this->assertCount( 2, $actual );
+
+		$this->assertQuery( "SHOW INDEX FROM wptests_term_relationships WHERE Index_type = 'FULLTEXT'" );
+		$actual = $this->engine->get_query_results();
+		$this->assertCount( 2, $actual );
 	}
 
 	public function testShowVarianles(): void {

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2444,7 +2444,14 @@ class WP_SQLite_Driver {
 		}
 		$table_name = $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
 
-		// TODO: WHERE
+		// WHERE clause.
+		$where = $node->get_first_child_node( 'whereClause' );
+		if ( null !== $where ) {
+			$value     = $this->translate( $where->get_first_child_node( 'expr' ) );
+			$condition = sprintf( 'AND %s', $value );
+		} else {
+			$condition = '';
+		}
 
 		$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table_name );
 
@@ -2488,6 +2495,7 @@ class WP_SQLite_Driver {
 				FROM ' . $this->quote_sqlite_identifier( $statistics_table ) . "
 				WHERE table_schema = ?
 				AND table_name = ?
+				$condition
 				ORDER BY
 					INDEX_NAME = 'PRIMARY' DESC,
 					NON_UNIQUE = '0' DESC,

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2230,7 +2230,7 @@ class WP_SQLite_Driver {
 
 		switch ( $keyword1->id ) {
 			case WP_MySQL_Lexer::COLLATION_SYMBOL:
-				$this->execute_show_collation_statement();
+				$this->execute_show_collation_statement( $node );
 				return;
 			case WP_MySQL_Lexer::DATABASES_SYMBOL:
 				$this->execute_show_databases_statement( $node );
@@ -2359,12 +2359,18 @@ class WP_SQLite_Driver {
 
 	/**
 	 * Translate and execute a MySQL SHOW COLLATION statement in SQLite.
+	 *
+	 * @param  WP_Parser_Node $node The "showStatement" AST node.
 	 */
-	private function execute_show_collation_statement(): void {
+	private function execute_show_collation_statement( WP_Parser_Node $node ): void {
 		$definition = $this->information_schema_builder
 			->get_computed_information_schema_table_definition( 'collations' );
 
-		// TODO: LIKE and WHERE clauses.
+		// LIKE and WHERE clauses.
+		$like_or_where = $node->get_first_child_node( 'likeOrWhere' );
+		if ( $like_or_where ) {
+			$condition = $this->translate_show_like_or_where_condition( $like_or_where, 'collation_name' );
+		}
 
 		$stmt = $this->execute_sqlite_query(
 			sprintf(
@@ -2376,8 +2382,10 @@ class WP_SQLite_Driver {
 					IS_COMPILED AS `Compiled`,
 					SORTLEN AS `Sortlen`,
 					PAD_ATTRIBUTE AS `Pad_attribute`
-				FROM (%s)',
-				$definition
+				FROM (%s)
+				WHERE TRUE %s',
+				$definition,
+				$condition ?? ''
 			)
 		);
 		$this->store_last_column_meta_from_statement( $stmt );

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2402,10 +2402,9 @@ class WP_SQLite_Driver {
 
 		// LIKE and WHERE clauses.
 		$like_or_where = $node->get_first_child_node( 'likeOrWhere' );
-		if ( null !== $like_or_where ) {
+		if ( $like_or_where ) {
 			$condition = $this->translate_show_like_or_where_condition( $like_or_where, 'schema_name' );
 		}
-
 		$stmt = $this->execute_sqlite_query(
 			sprintf(
 				'SELECT SCHEMA_NAME AS Database
@@ -2432,10 +2431,9 @@ class WP_SQLite_Driver {
 	 * @param WP_Parser_Node $node The "showStatement" AST node.
 	 */
 	private function execute_show_index_statement( WP_Parser_Node $node ): void {
+		// Get database and table name.
 		$table_ref = $node->get_first_child_node( 'tableRef' );
 		$in_db     = $node->get_first_child_node( 'inDb' );
-
-		// Get database and table name.
 		if ( $in_db ) {
 			// FROM/IN database.
 			$database = $this->get_database_name( $in_db );
@@ -2640,10 +2638,10 @@ class WP_SQLite_Driver {
 	 */
 	private function execute_show_columns_statement( WP_Parser_Node $node ): void {
 		// TODO: EXTENDED, FULL
-		$table_ref = $node->get_first_child_node( 'tableRef' );
-		$in_db     = $node->get_first_child_node( 'inDb' );
 
 		// Get database and table name.
+		$table_ref = $node->get_first_child_node( 'tableRef' );
+		$in_db     = $node->get_first_child_node( 'inDb' );
 		if ( $in_db ) {
 			// FROM/IN database.
 			$database = $this->get_database_name( $in_db );


### PR DESCRIPTION
Adds support for `WHERE` and `LIKE` conditions to `SHOW`, where it was missing:
- Add support for `LIKE` and `WHERE` clauses in `SHOW COLLATION`.
- Add support for `WHERE` clause in `SHOW INDEX`.

This fixes some failures in the activation of the top 100 plugins.