### PR TITLE
Fix missing table name column in `SHOW CREATE TABLE` statement

### DIFF
--- a/tests/WP_SQLite_Driver_Metadata_Tests.php
+++ b/tests/WP_SQLite_Driver_Metadata_Tests.php
@@ -1319,6 +1319,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1451,6 +1452,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1558,6 +1560,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1681,6 +1684,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1725,6 +1729,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1764,6 +1769,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1799,6 +1805,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1830,6 +1837,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't2',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1852,6 +1860,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1882,6 +1891,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't',
 					'Create Table' => implode(
 						"\n",
 						array(
@@ -1913,6 +1923,7 @@ class WP_SQLite_Driver_Metadata_Tests extends TestCase {
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't',
 					'Create Table' => implode(
 						"\n",
 						array(

--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -9664,6 +9664,7 @@ END;
 		$this->assertEquals(
 			array(
 				(object) array(
+					'Table'        => 't',
 					'Create Table' => implode(
 						"\n",
 						array(

--- a/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
+++ b/wp-includes/sqlite-ast/class-wp-sqlite-driver.php
@@ -2263,6 +2263,7 @@ class WP_SQLite_Driver {
 						$this->set_results_from_fetched_data(
 							array(
 								(object) array(
+									'Table'        => $table_name,
 									'Create Table' => $sql,
 								),
 							)


### PR DESCRIPTION
Extracting smaller chunks from https://github.com/WordPress/sqlite-database-integration/pull/291 so we can review and merge them independently.

This PR adds `Table` column to `SHOW CREATE TABLE` statements, [as per MySQL behavior](https://onecompiler.com/mysql/447x6gea7).