### PR TITLE
Bump "Tested up to" plugin header

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgicak, bpayton, zaerl
 Requires at least: 6.4
-Tested up to:      6.6.1
+Tested up to:      6.9
 Requires PHP:      7.2
 Stable tag:        2.2.15
 License:           GPLv2 or later


### PR DESCRIPTION
This is to fix the following warning:

> This plugin **hasn’t been tested with the latest 3 major releases of WordPress**. It may no longer be maintained or supported and may have compatibility issues when used with more recent versions of WordPress.

<img width="1222" height="489" alt="Screenshot 2026-01-08 at 17 29 18" src="https://github.com/user-attachments/assets/c374eac4-b3a4-48b8-a22b-662cc0aa2493" />