### PR TITLE
Handle incorrectly stored MySQL metadata in the legacy-to-AST driver migrator

### DIFF
--- a/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
+++ b/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
@@ -310,6 +310,88 @@ class WP_SQLite_Information_Schema_Reconstructor_Tests extends TestCase {
 		);
 	}
 
+	public function testInvalidDataTypeCacheDataForDecimalDefinition(): void {
+		// Recreate the invalid database state before the following fix:
+		//   https://github.com/WordPress/sqlite-database-integration/pull/126
+		$connection = $this->engine->get_connection();
+		$connection->query( self::CREATE_DATA_TYPES_CACHE_TABLE_SQL );
+		$connection->query( 'CREATE TABLE t ( dec_col REAL )' );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('t', 'decimal', 'decimal(26,')" );
+
+		// Ensure the information schema is reconstructed correctly.
+		$this->reconstructor->ensure_correct_information_schema();
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertSame(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					'  `dec_col` float DEFAULT NULL',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
+
+	public function testInvalidDataTypeCacheDataForDecimalDefinitionOnWooCommerceTable(): void {
+		// Recreate the invalid database state before the following fix:
+		//   https://github.com/WordPress/sqlite-database-integration/pull/126
+		$connection = $this->engine->get_connection();
+		$connection->query( self::CREATE_DATA_TYPES_CACHE_TABLE_SQL );
+		$connection->query( 'CREATE TABLE wc_testing_table ( col1 REAL, col2 REAL, col3 REAL, col4 REAL )' );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('wc_testing_table', 'col1', 'decimal(26,')" );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('wc_testing_table', 'col2', 'decimal(19,')" );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('wc_testing_table', 'col3', 'decimal(3,')" );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('wc_testing_table', 'col4', 'decimal(5,')" );
+
+		// Ensure the information schema is reconstructed correctly.
+		$this->reconstructor->ensure_correct_information_schema();
+		$result = $this->assertQuery( 'SHOW CREATE TABLE wc_testing_table' );
+		$this->assertSame(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `wc_testing_table` (',
+					'  `col1` decimal(26,8) DEFAULT NULL,',
+					'  `col2` decimal(19,4) DEFAULT NULL,',
+					'  `col3` decimal(3,2) DEFAULT NULL,',
+					'  `col4` float DEFAULT NULL',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
+
+	public function testInvalidDataTypeCacheDataForIndexDefinition(): void {
+		$connection = $this->engine->get_connection();
+
+		// Recreate the invalid database state before the following fix:
+		//   https://github.com/WordPress/sqlite-database-integration/commit/b5a9fbaed4d0d843f792aaa959e3d00f193ff1ee
+		//   https://github.com/Automattic/sqlite-database-integration/pull/2
+		$connection->query( self::CREATE_DATA_TYPES_CACHE_TABLE_SQL );
+		$connection->query( 'CREATE TABLE t ( `timestamp` TEXT, `KEY` TEXT)' );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('t', 'timestamp', 'datetime')" );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('t', 'KEY', 'timestamp(timestamp)')" );
+
+		// Ensure the information schema is reconstructed correctly.
+		$this->reconstructor->ensure_correct_information_schema();
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertSame(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					'  `timestamp` datetime DEFAULT NULL,',
+					'  `KEY` text DEFAULT NULL',
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
+
 	private function assertQuery( $sql ) {
 		$retval = $this->engine->query( $sql );
 		$this->assertNotFalse( $retval );


### PR DESCRIPTION
When migrating from the legacy SQLite driver to the new AST-based driver, the information schema reconstructor reads MySQL column type metadata from the `_mysql_data_types_cache` table. Some older versions of the legacy driver stored invalid type definitions in this table, causing migration failures.

This PR detects and handles two types of invalid data:

**1. Truncated decimal definitions** — Before [PR #126](https://github.com/WordPress/sqlite-database-integration/pull/126), columns with multiple type arguments like `decimal(26, 8)` were incorrectly stored as `decimal(26,` (missing the second argument and closing parenthesis). For WooCommerce tables, the fix restores the correct decimal precision based on known WooCommerce column patterns. For other tables, these invalid definitions are discarded and the column type is inferred from SQLite.

**2. Index definitions mistaken for columns** — Before [commit b5a9fba](https://github.com/WordPress/sqlite-database-integration/commit/b5a9fbaed4d0d843f792aaa959e3d00f193ff1ee), index definitions like `KEY timestamp (timestamp)` were incorrectly parsed and stored as column `KEY` with type `timestamp(timestamp)`. The fix validates that type arguments are numeric, rejecting these malformed entries and falling back to the SQLite type inference.

Fixes https://github.com/WordPress/wordpress-playground/issues/3050.