### PR TITLE
Update phpunit to fix security advisory error (PKSA-z3gr-8qht-p93v)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 		"phpcompatibility/phpcompatibility-wp": "*",
 		"php-parallel-lint/php-parallel-lint": "^1.3",
 		"yoast/phpunit-polyfills": "2.0.0",
-		"phpunit/phpunit": "8.5.38"
+		"phpunit/phpunit": "8.5.52"
 	},
 	"config": {
 		"allow-plugins": {


### PR DESCRIPTION
Running `composer install` fails with the following error:

```
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires phpunit/phpunit 8.5.38 (exact version match: 8.5.38 or 8.5.38.0), found phpunit/phpunit[8.5.38] but these were not loaded, because they are affected by security advisories ("PKSA-z3gr-8qht-p93v"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
  Problem 2
    - Root composer.json requires yoast/phpunit-polyfills 2.0.0 -> satisfiable by yoast/phpunit-polyfills[2.0.0].
    - yoast/phpunit-polyfills 2.0.0 requires phpunit/phpunit ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0 -> found phpunit/phpunit[5.7.21, ..., 5.7.27, 6.0.0, ..., 6.5.14, 7.0.0, ..., 7.5.20, 8.0.0, ..., 8.5.52, 9.0.0, ..., 9.6.34, 10.0.0, ..., 10.5.63] but these were not loaded, because they are affected by security advisories ("PKSA-z3gr-8qht-p93v"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

This is due to a security advisory https://github.com/advisories/GHSA-vvj3-c3rp-c85p.

It only affects PHPUnit, updating it is an easy fix.