### PR TITLE
Fix implicit result column name/alias for `SELECT` item literals with `NULL` bytes

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -6138,6 +6138,14 @@ END;
 		$this->assertQuery( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
 		$this->assertQuery( 'INSERT INTO t (id, name) VALUES (1, "John"), (2, "Jane")' );
 
+		// Literal with a NULL byte (no explicit alias).
+		$result = $this->assertQuery( "SELECT 'abc\0def'" );
+		$this->assertSame( array( 'abc' ), array_keys( (array) $result[0] ) );
+
+		// Literal with a NULL byte (with an explicit alias).
+		$result = $this->assertQuery( "SELECT 'abc\0def' AS `col1`" );
+		$this->assertSame( array( 'col1' ), array_keys( (array) $result[0] ) );
+
 		// Columns (no explicit alias).
 		$result = $this->assertQuery( 'SELECT id, name FROM t' );
 		$this->assertSame( array( 'id', 'name' ), array_keys( (array) $result[0] ) );

--- a/wp-includes/sqlite-ast/class-wp-pdo-mysql-on-sqlite.php
+++ b/wp-includes/sqlite-ast/class-wp-pdo-mysql-on-sqlite.php
@@ -4566,6 +4566,13 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		$is_text_string_literal = $text_string_literal && $item === $this->translate( $text_string_literal );
 		if ( $is_text_string_literal ) {
 			$alias = $text_string_literal->get_first_child_token()->get_value();
+
+			// When the literal value contains a NULL byte, MySQL truncates the
+			// resulting identifier at the position of the first one of them.
+			$fist_null_byte_pos = strpos( $alias, "\0" );
+			if ( false !== $fist_null_byte_pos ) {
+				$alias = substr( $alias, 0, $fist_null_byte_pos );
+			}
 			return sprintf( '%s AS %s', $item, $this->quote_sqlite_identifier( $alias ) );
 		}
 


### PR DESCRIPTION
Fixes `SELECT` queries that have string literals with `NULL` bytes in them and no column alias.

E.g.:
```sql
SELECT `a<null-byte>b`;

-- result column name should be: 'a'
```

This is because in MySQL:
- There can’t be `\0` bytes in identifiers (like column names). The lexer will reject that.
- But string literals can have them.
- And there is a way to make a string literal “identifier-like” (implicit alias = the result “column name”): `SELECT 'abc\0xyz'` The result column name will be: `abc`
