### PR TITLE
Improve identifier and string escaping in the legacy driver

### DIFF
--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -3602,6 +3602,7 @@ QUERY
 		foreach ( $this->engine->executed_sqlite_queries as $q ) {
 			if ( stripos( $q['sql'], 'INSERT' ) !== false && stripos( $q['sql'], '_options' ) !== false ) {
 				$insert_query = $q;
+				break;
 			}
 		}
 		$this->assertNotNull( $insert_query );
@@ -3635,6 +3636,7 @@ QUERY
 		foreach ( $this->engine->executed_sqlite_queries as $q ) {
 			if ( stripos( $q['sql'], 'INSERT' ) !== false && stripos( $q['sql'], '_options' ) !== false ) {
 				$insert_query = $q;
+				break;
 			}
 		}
 		$this->assertNotNull( $insert_query );

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -1170,14 +1170,14 @@ class WP_SQLite_Translator_Tests extends TestCase {
 					'name'     => '___tmp_table_created_at_on_update__',
 					'tbl_name' => '_tmp_table',
 					'rootpage' => '0',
-					'sql'      => "CREATE TRIGGER \"___tmp_table_created_at_on_update__\"\n\t\t\tAFTER UPDATE ON \"_tmp_table\"\n\t\t\tFOR EACH ROW\n\t\t\tBEGIN\n\t\t\t  UPDATE \"_tmp_table\" SET \"created_at\" = CURRENT_TIMESTAMP WHERE rowid = NEW.rowid;\n\t\t\tEND",
+					'sql'      => "CREATE TRIGGER `___tmp_table_created_at_on_update__`\n\t\t\tAFTER UPDATE ON `_tmp_table`\n\t\t\tFOR EACH ROW\n\t\t\tBEGIN\n\t\t\t  UPDATE `_tmp_table` SET `created_at` = CURRENT_TIMESTAMP WHERE rowid = NEW.rowid;\n\t\t\tEND",
 				),
 				(object) array(
 					'type'     => 'trigger',
 					'name'     => '___tmp_table_updated_at_on_update__',
 					'tbl_name' => '_tmp_table',
 					'rootpage' => '0',
-					'sql'      => "CREATE TRIGGER \"___tmp_table_updated_at_on_update__\"\n\t\t\tAFTER UPDATE ON \"_tmp_table\"\n\t\t\tFOR EACH ROW\n\t\t\tBEGIN\n\t\t\t  UPDATE \"_tmp_table\" SET \"updated_at\" = CURRENT_TIMESTAMP WHERE rowid = NEW.rowid;\n\t\t\tEND",
+					'sql'      => "CREATE TRIGGER `___tmp_table_updated_at_on_update__`\n\t\t\tAFTER UPDATE ON `_tmp_table`\n\t\t\tFOR EACH ROW\n\t\t\tBEGIN\n\t\t\t  UPDATE `_tmp_table` SET `updated_at` = CURRENT_TIMESTAMP WHERE rowid = NEW.rowid;\n\t\t\tEND",
 				),
 			),
 			$results
@@ -3556,5 +3556,41 @@ QUERY
 		$this->assertQuery( 'UPDATE test_now_default SET id = 2 WHERE id = 1' );
 		$result = $this->assertQuery( 'SELECT * FROM test_now_default WHERE id = 2' );
 		$this->assertRegExp( '/\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d/', $result[0]->updated );
+	}
+
+	public function testQuoteIdentifierEscapesBackticks() {
+		// Create a table with a backtick in the column name using double-quote
+		// quoting (MySQL syntax). The translator must properly escape the
+		// backtick when generating SQLite DDL with backtick-quoted identifiers.
+		$this->assertQuery(
+			'CREATE TABLE _tmp_backtick_test (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				"col`name" varchar(50) NOT NULL
+			);'
+		);
+
+		$this->assertQuery( "INSERT INTO _tmp_backtick_test (ID, \"col`name\") VALUES (1, 'value1')" );
+
+		$result = $this->assertQuery( 'SELECT * FROM _tmp_backtick_test WHERE ID = 1' );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'value1', $result[0]->{'col`name'} );
+
+		// Verify the column appears in DESCRIBE output.
+		$description  = $this->assertQuery( 'DESCRIBE _tmp_backtick_test' );
+		$column_names = array_map(
+			function ( $row ) {
+				return $row->Field;
+			},
+			$description
+		);
+		$this->assertContains( 'col`name', $column_names );
+
+		// Verify SHOW CREATE TABLE produces valid, parseable output.
+		$create     = $this->assertQuery( 'SHOW CREATE TABLE _tmp_backtick_test' );
+		$create_sql = $create[0]->{'Create Table'};
+		$this->assertStringContainsString( '`col``name`', $create_sql );
+
+		// Verify autoincrement detection works with backtick-quoted identifiers.
+		$this->assertStringContainsString( 'AUTO_INCREMENT', $create_sql );
 	}
 }

--- a/tests/WP_SQLite_Translator_Tests.php
+++ b/tests/WP_SQLite_Translator_Tests.php
@@ -3593,4 +3593,113 @@ QUERY
 		// Verify autoincrement detection works with backtick-quoted identifiers.
 		$this->assertStringContainsString( 'AUTO_INCREMENT', $create_sql );
 	}
+
+	public function testDoubleQuotedStringsAreParameterized() {
+		$this->assertQuery( 'INSERT INTO _options (option_name, option_value) VALUES ("dq_name", "dq_value")' );
+
+		// The double-quoted strings should be bound as parameters, not inlined.
+		$insert_query = null;
+		foreach ( $this->engine->executed_sqlite_queries as $q ) {
+			if ( stripos( $q['sql'], 'INSERT' ) !== false && stripos( $q['sql'], '_options' ) !== false ) {
+				$insert_query = $q;
+			}
+		}
+		$this->assertNotNull( $insert_query );
+		$this->assertNotEmpty( $insert_query['params'], 'Double-quoted strings should be bound as parameters' );
+		$this->assertStringNotContainsString( 'dq_name', $insert_query['sql'], 'Value should not appear in SQL' );
+		$this->assertStringNotContainsString( 'dq_value', $insert_query['sql'], 'Value should not appear in SQL' );
+		$this->assertContains( 'dq_name', $insert_query['params'] );
+		$this->assertContains( 'dq_value', $insert_query['params'] );
+
+		// Verify the data was inserted correctly.
+		$result = $this->assertQuery( 'SELECT * FROM _options WHERE option_name = "dq_name"' );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'dq_value', $result[0]->option_value );
+	}
+
+	public function testDoubleQuotedStringWithBackslashEscapeDoesNotCauseInjection() {
+		// In MySQL, \" inside double-quoted strings is an escaped double quote.
+		// The MySQL lexer produces a single token: "admin\" OR 1=1--"
+		// with value: admin" OR 1=1--
+		//
+		// Without parameterization, passing the raw token to SQLite would be:
+		//   "admin\" OR 1=1--" (SQLite sees "admin\" as identifier + SQL)
+		//
+		// With parameterization, the value is safely bound as a parameter.
+		$this->assertQuery(
+			'INSERT INTO _options (option_name, option_value) VALUES ("safe_key", "admin\" OR 1=1--")'
+		);
+
+		// Verify the injection payload is not present in the SQL sent to SQLite.
+		$insert_query = null;
+		foreach ( $this->engine->executed_sqlite_queries as $q ) {
+			if ( stripos( $q['sql'], 'INSERT' ) !== false && stripos( $q['sql'], '_options' ) !== false ) {
+				$insert_query = $q;
+			}
+		}
+		$this->assertNotNull( $insert_query );
+		$this->assertStringNotContainsString( 'OR 1=1', $insert_query['sql'], 'Injection payload should not appear in SQL' );
+		$this->assertNotEmpty( $insert_query['params'], 'Values should be bound as parameters' );
+
+		$result = $this->assertQuery( 'SELECT * FROM _options WHERE option_name = "safe_key"' );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'admin" OR 1=1--', $result[0]->option_value );
+	}
+
+	public function testDateFormatWithSingleQuotesInFormat() {
+		$this->assertQuery(
+			'CREATE TABLE _tmp_dates (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				created_at DATETIME NOT NULL
+			);'
+		);
+		$this->assertQuery( "INSERT INTO _tmp_dates (created_at) VALUES ('2024-01-15 10:30:00')" );
+
+		// DATE_FORMAT with a format that produces a value — verify it works.
+		$result = $this->assertQuery(
+			"SELECT DATE_FORMAT(created_at, '%Y-%m-%d') as formatted FROM _tmp_dates"
+		);
+		$this->assertCount( 1, $result );
+		$this->assertEquals( '2024-01-15', $result[0]->formatted );
+	}
+
+	public function testIntervalExpression() {
+		$this->assertQuery(
+			'CREATE TABLE _tmp_dates (
+				ID INTEGER PRIMARY KEY AUTO_INCREMENT NOT NULL,
+				created_at DATETIME NOT NULL
+			);'
+		);
+		$this->assertQuery( 'INSERT INTO _tmp_dates (created_at) VALUES (\'2024-01-15 10:30:00\')' );
+
+		$result = $this->assertQuery(
+			'SELECT DATE_ADD(created_at, INTERVAL 1 DAY) as future_date FROM _tmp_dates'
+		);
+		$this->assertCount( 1, $result );
+		$this->assertEquals( '2024-01-16 10:30:00', $result[0]->future_date );
+
+		$result = $this->assertQuery(
+			'SELECT DATE_SUB(created_at, INTERVAL 1 DAY) as past_date FROM _tmp_dates'
+		);
+		$this->assertCount( 1, $result );
+		$this->assertEquals( '2024-01-14 10:30:00', $result[0]->past_date );
+	}
+
+	public function testLikeBinaryWithSingleQuoteInPattern() {
+		$this->assertQuery(
+			"CREATE TABLE _tmp_table (
+				ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+				name varchar(50) NOT NULL default ''
+			);"
+		);
+
+		$this->assertQuery( "INSERT INTO _tmp_table (name) VALUES ('it''s a test')" );
+		$this->assertQuery( "INSERT INTO _tmp_table (name) VALUES ('no quote here')" );
+
+		$result = $this->assertQuery(
+			"SELECT * FROM _tmp_table WHERE name LIKE BINARY 'it''s%'"
+		);
+		$this->assertCount( 1, $result );
+		$this->assertEquals( "it's a test", $result[0]->name );
+	}
 }

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -916,12 +916,12 @@ class WP_SQLite_Translator {
 		}
 
 		if ( count( $table->primary_key ) > 1 ) {
-			$definitions[] = 'PRIMARY KEY ("' . implode( '", "', $table->primary_key ) . '")';
+			$definitions[] = 'PRIMARY KEY (' . implode( ', ', array_map( array( $this, 'quote_identifier' ), $table->primary_key ) ) . ')';
 		}
 
 		$create_query = (
 			$table->create_table .
-			'"' . $table->name . '" (' . "\n" .
+			$this->quote_identifier( $table->name ) . ' (' . "\n" .
 			implode( ",\n", $definitions ) .
 			')'
 		);
@@ -940,7 +940,7 @@ class WP_SQLite_Translator {
 			}
 			$index_name = $this->generate_index_name( $table->name, $constraint->name );
 			$this->execute_sqlite_query(
-				"CREATE $unique INDEX $if_not_exists \"$index_name\" ON \"{$table->name}\" (\"" . implode( '", "', $constraint->columns ) . '")'
+				'CREATE ' . $unique . 'INDEX ' . $if_not_exists . ' ' . $this->quote_identifier( $index_name ) . ' ON ' . $this->quote_identifier( $table->name ) . ' (' . implode( ', ', array_map( array( $this, 'quote_identifier' ), $constraint->columns ) ) . ')'
 			);
 			$this->update_data_type_cache(
 				$table->name,
@@ -1208,7 +1208,7 @@ class WP_SQLite_Translator {
 	 * @return string
 	 */
 	private function make_sqlite_field_definition( $field ) {
-		$definition = '"' . $field->name . '" ' . $field->sqlite_data_type;
+		$definition = $this->quote_identifier( $field->name ) . ' ' . $field->sqlite_data_type;
 		if ( $field->auto_increment ) {
 			$definition .= ' PRIMARY KEY AUTOINCREMENT';
 		} elseif ( $field->primary_key ) {
@@ -1382,8 +1382,9 @@ class WP_SQLite_Translator {
 		// @TODO: Actually rewrite the query instead of using a hardcoded workaround.
 		if ( str_contains( $updated_query, ' JOIN ' ) ) {
 			$table_prefix = isset( $GLOBALS['table_prefix'] ) ? $GLOBALS['table_prefix'] : 'wp_';
+			$quoted_table = $this->quote_identifier( $table_prefix . 'options' );
 			$this->execute_sqlite_query(
-				"DELETE FROM {$table_prefix}options WHERE option_id IN (SELECT MIN(option_id) FROM {$table_prefix}options GROUP BY option_name HAVING COUNT(*) > 1)"
+				"DELETE FROM $quoted_table WHERE option_id IN (SELECT MIN(option_id) FROM $quoted_table GROUP BY option_name HAVING COUNT(*) > 1)"
 			);
 			$this->set_result_from_affected_rows();
 			return;
@@ -1417,7 +1418,7 @@ class WP_SQLite_Translator {
 		// SELECT to fetch the IDs of the rows to delete, then delete them
 		// using a separate DELETE query.
 
-		$this->table_name = $rewriter->skip()->value;
+		$this->table_name = $this->normalize_column_name( $rewriter->skip()->value );
 		$rewriter->add( new WP_SQLite_Token( 'SELECT', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ) );
 
 		/*
@@ -1433,7 +1434,7 @@ class WP_SQLite_Translator {
 		for ( $i = $index + 1; $i < $rewriter->max; $i++ ) {
 			// Assume the table name is the first token after FROM.
 			if ( ! $rewriter->input_tokens[ $i ]->is_semantically_void() ) {
-				$this->table_name = $rewriter->input_tokens[ $i ]->value;
+				$this->table_name = $this->normalize_column_name( $rewriter->input_tokens[ $i ]->value );
 				break;
 			}
 		}
@@ -1445,7 +1446,7 @@ class WP_SQLite_Translator {
 		 * Now, let's figure out the primary key name.
 		 * This assumes that all listed table names are the same.
 		 */
-		$q       = $this->execute_sqlite_query( 'SELECT l.name FROM pragma_table_info("' . $this->table_name . '") as l WHERE l.pk = 1;' );
+		$q       = $this->execute_sqlite_query( 'SELECT l.name FROM pragma_table_info(' . $this->pdo->quote( $this->table_name ) . ') as l WHERE l.pk = 1;' );
 		$pk_name = $q->fetch()['name'];
 
 		/*
@@ -1468,7 +1469,7 @@ class WP_SQLite_Translator {
 				$rewriter->add_many(
 					array(
 						new WP_SQLite_Token( '.', WP_SQLite_Token::TYPE_OPERATOR, WP_SQLite_Token::FLAG_OPERATOR_SQL ),
-						new WP_SQLite_Token( $pk_name, WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
+						new WP_SQLite_Token( $this->quote_identifier( $pk_name ), WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 						new WP_SQLite_Token( 'AS', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
@@ -1491,10 +1492,12 @@ class WP_SQLite_Translator {
 			$ids_to_delete[] = $id['id_1'];
 		}
 
-		$query = (
+		$quoted_table = $this->quote_identifier( $this->table_name );
+		$quoted_pk    = $this->quote_identifier( $pk_name );
+		$query        = (
 		count( $ids_to_delete )
-			? "DELETE FROM {$this->table_name} WHERE {$pk_name} IN (" . implode( ',', $ids_to_delete ) . ')'
-			: "DELETE FROM {$this->table_name} WHERE 0=1"
+			? "DELETE FROM {$quoted_table} WHERE {$quoted_pk} IN (" . implode( ',', $ids_to_delete ) . ')'
+			: "DELETE FROM {$quoted_table} WHERE 0=1"
 		);
 		$this->execute_sqlite_query( $query );
 		$this->set_result_from_affected_rows(
@@ -1765,12 +1768,12 @@ class WP_SQLite_Translator {
 					ELSE 'PRI'
 					END
 				) as `Key`
-				FROM pragma_table_info(\"$table_name\") p
-				LEFT JOIN " . self::DATA_TYPES_CACHE_TABLE . " d
-				ON d.`table` = \"$table_name\"
+				FROM pragma_table_info(" . $this->pdo->quote( $table_name ) . ') p
+				LEFT JOIN ' . self::DATA_TYPES_CACHE_TABLE . ' d
+				ON d.`table` = ' . $this->pdo->quote( $table_name ) . '
 				AND d.`column_or_index` = p.`name`
 				;
-			"
+			'
 		)
 		->fetchAll( $this->pdo_fetch_mode );
 	}
@@ -1891,7 +1894,7 @@ class WP_SQLite_Translator {
 				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 				new WP_SQLite_Token( 'FROM', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
 				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
-				new WP_SQLite_Token( $this->table_name, WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
+				new WP_SQLite_Token( $this->quote_identifier( $this->table_name ), WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
 				new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 			)
 		);
@@ -2955,7 +2958,7 @@ class WP_SQLite_Translator {
 		$max = count( $conflict_columns );
 		$i   = 0;
 		foreach ( $conflict_columns as $conflict_column ) {
-			$this->rewriter->add( new WP_SQLite_Token( '"' . $conflict_column . '"', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ) );
+			$this->rewriter->add( new WP_SQLite_Token( $this->quote_identifier( $conflict_column ), WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ) );
 			if ( ++$i < $max ) {
 				$this->rewriter->add( new WP_SQLite_Token( ',', WP_SQLite_Token::TYPE_OPERATOR ) );
 				$this->rewriter->add( new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ) );
@@ -2993,12 +2996,12 @@ class WP_SQLite_Translator {
 	 * @return array
 	 */
 	private function get_keys( $table_name, $only_unique = false ) {
-		$query   = $this->execute_sqlite_query( 'SELECT * FROM pragma_index_list("' . $table_name . '") as l;' );
+		$query   = $this->execute_sqlite_query( 'SELECT * FROM pragma_index_list(' . $this->pdo->quote( $table_name ) . ') as l;' );
 		$indices = $query->fetchAll();
 		$results = array();
 		foreach ( $indices as $index ) {
 			if ( ! $only_unique || '1' === $index['unique'] ) {
-				$query     = $this->execute_sqlite_query( 'SELECT * FROM pragma_index_info("' . $index['name'] . '") as l;' );
+				$query     = $this->execute_sqlite_query( 'SELECT * FROM pragma_index_info(' . $this->pdo->quote( $index['name'] ) . ') as l;' );
 				$results[] = array(
 					'index'   => $index,
 					'columns' => $query->fetchAll(),
@@ -3049,7 +3052,7 @@ class WP_SQLite_Translator {
 					new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 					new WP_SQLite_Token( 'TABLE', WP_SQLite_Token::TYPE_KEYWORD ),
 					new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
-					new WP_SQLite_Token( $this->table_name, WP_SQLite_Token::TYPE_KEYWORD ),
+					new WP_SQLite_Token( $this->quote_identifier( $this->table_name ), WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
 				)
 			);
 			$op_type          = strtoupper( $this->rewriter->consume()->token ?? '' );
@@ -3153,7 +3156,7 @@ class WP_SQLite_Translator {
 
 				// Drop ON UPDATE trigger by the old column name.
 				$on_update_trigger_name = $this->get_column_on_update_current_timestamp_trigger_name( $this->table_name, $from_name );
-				$this->execute_sqlite_query( "DROP TRIGGER IF EXISTS \"$on_update_trigger_name\"" );
+				$this->execute_sqlite_query( 'DROP TRIGGER IF EXISTS ' . $this->quote_identifier( $on_update_trigger_name ) );
 
 				/*
 				 * In SQLite, there is no direct equivalent to the CHANGE COLUMN
@@ -3186,7 +3189,7 @@ class WP_SQLite_Translator {
 					if ( ! $token ) {
 						break;
 					}
-					if ( WP_SQLite_Token::TYPE_STRING !== $token->type
+					if ( ( WP_SQLite_Token::TYPE_STRING !== $token->type && WP_SQLite_Token::TYPE_SYMBOL !== $token->type )
 						|| $from_name !== $this->normalize_column_name( $token->value ) ) {
 						continue;
 					}
@@ -3222,30 +3225,33 @@ class WP_SQLite_Translator {
 						// Otherwise, just add the new name in place of the old name we dropped.
 						$create_table->add(
 							new WP_SQLite_Token(
-								"`$new_field->name`",
-								WP_SQLite_Token::TYPE_KEYWORD
+								$this->quote_identifier( $new_field->name ),
+								WP_SQLite_Token::TYPE_KEYWORD,
+								WP_SQLite_Token::FLAG_KEYWORD_KEY
 							)
 						);
 					}
 				}
 
 				// 3. Copy the data out of the old table
-				$cache_table_name = "_tmp__{$this->table_name}_" . rand( 10000000, 99999999 );
+				$cache_table_name   = "_tmp__{$this->table_name}_" . rand( 10000000, 99999999 );
+				$quoted_cache_table = $this->quote_identifier( $cache_table_name );
+				$quoted_table       = $this->quote_identifier( $this->table_name );
 				$this->execute_sqlite_query(
-					"CREATE TABLE `$cache_table_name` as SELECT * FROM `$this->table_name`"
+					"CREATE TABLE $quoted_cache_table as SELECT * FROM $quoted_table"
 				);
 
 				// 4. Drop the old table to free up the indexes names
-				$this->execute_sqlite_query( "DROP TABLE `$this->table_name`" );
+				$this->execute_sqlite_query( "DROP TABLE $quoted_table" );
 
 				// 5. Create a new table from the updated schema
 				$this->execute_sqlite_query( $create_table->get_updated_query() );
 
 				// 6. Copy the data from step 3 to the new table
-				$this->execute_sqlite_query( "INSERT INTO {$this->table_name} SELECT * FROM $cache_table_name" );
+				$this->execute_sqlite_query( "INSERT INTO $quoted_table SELECT * FROM $quoted_cache_table" );
 
 				// 7. Drop the old table copy
-				$this->execute_sqlite_query( "DROP TABLE `$cache_table_name`" );
+				$this->execute_sqlite_query( "DROP TABLE $quoted_cache_table" );
 
 				// 8. Restore any indexes that were dropped in step 4
 				foreach ( $old_indexes as $row ) {
@@ -3260,8 +3266,8 @@ class WP_SQLite_Translator {
 					$columns = array();
 					foreach ( $row['columns'] as $column ) {
 						$columns[] = ( $column['name'] === $from_name )
-							? '`' . $new_field->name . '`'
-							: '`' . $column['name'] . '`';
+							? $this->quote_identifier( $new_field->name )
+							: $this->quote_identifier( $column['name'] );
 					}
 
 					$unique = '1' === $row['index']['unique'] ? 'UNIQUE' : '';
@@ -3271,7 +3277,7 @@ class WP_SQLite_Translator {
 					 * a part of the CREATE TABLE statement
 					 */
 					$this->execute_sqlite_query(
-						"CREATE $unique INDEX IF NOT EXISTS `{$row['index']['name']}` ON $this->table_name (" . implode( ', ', $columns ) . ')'
+						"CREATE $unique INDEX IF NOT EXISTS " . $this->quote_identifier( $row['index']['name'] ) . " ON $quoted_table (" . implode( ', ', $columns ) . ')'
 					);
 				}
 
@@ -3300,11 +3306,11 @@ class WP_SQLite_Translator {
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 						new WP_SQLite_Token( $sqlite_index_type, WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
-						new WP_SQLite_Token( "\"$sqlite_index_name\"", WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
+						new WP_SQLite_Token( $this->quote_identifier( $sqlite_index_name ), WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 						new WP_SQLite_Token( 'ON', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
-						new WP_SQLite_Token( "\"$this->table_name\"", WP_SQLite_Token::TYPE_STRING, WP_SQLite_Token::FLAG_STRING_DOUBLE_QUOTES ),
+						new WP_SQLite_Token( $this->quote_identifier( $this->table_name ), WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 						new WP_SQLite_Token( '(', WP_SQLite_Token::TYPE_OPERATOR ),
 					)
@@ -3332,8 +3338,8 @@ class WP_SQLite_Translator {
 					}
 					// $token is field name.
 					if ( ! $token->matches( WP_SQLite_Token::TYPE_OPERATOR ) ) {
-						$token->token = '`' . $this->normalize_column_name( $token->token ) . '`';
-						$token->value = '`' . $this->normalize_column_name( $token->token ) . '`';
+						$token->token = $this->quote_identifier( $this->normalize_column_name( $token->token ) );
+						$token->value = $token->token;
 					}
 
 					/*
@@ -3358,7 +3364,7 @@ class WP_SQLite_Translator {
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
 						new WP_SQLite_Token( 'INDEX', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_RESERVED ),
 						new WP_SQLite_Token( ' ', WP_SQLite_Token::TYPE_WHITESPACE ),
-						new WP_SQLite_Token( "\"{$this->table_name}__$key_name\"", WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
+						new WP_SQLite_Token( $this->quote_identifier( $this->table_name . '__' . $key_name ), WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_KEY ),
 					)
 				);
 			} else {
@@ -3618,7 +3624,7 @@ class WP_SQLite_Translator {
 				$tables              = $this->strip_sqlite_system_tables( $stmt->fetchAll( $this->pdo_fetch_mode ) );
 				foreach ( $tables as $table ) {
 					$table_name  = $table->Name; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$stmt        = $this->execute_sqlite_query( "SELECT COUNT(1) as `Rows` FROM $table_name" );
+					$stmt        = $this->execute_sqlite_query( 'SELECT COUNT(1) as `Rows` FROM ' . $this->quote_identifier( $table_name ) );
 					$rows        = $stmt->fetchall( $this->pdo_fetch_mode );
 					$table->Rows = $rows[0]->Rows; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				}
@@ -3688,7 +3694,7 @@ class WP_SQLite_Translator {
 		}
 
 		$sql_parts = array(
-			"CREATE TABLE `$table_name` (",
+			'CREATE TABLE ' . $this->quote_identifier( $table_name ) . ' (',
 			"\t" . implode( ",\n\t", array_merge( $column_definitions, $key_definitions ) ),
 			');',
 		);
@@ -3710,7 +3716,7 @@ class WP_SQLite_Translator {
 	 * @return stdClass[]
 	 */
 	protected function get_table_columns( $table_name ) {
-		return $this->execute_sqlite_query( "PRAGMA table_info(\"$table_name\");" )
+		return $this->execute_sqlite_query( 'PRAGMA table_info(' . $this->pdo->quote( $table_name ) . ');' )
 			->fetchAll( $this->pdo_fetch_mode );
 	}
 
@@ -3729,7 +3735,7 @@ class WP_SQLite_Translator {
 			$mysql_type   = $this->get_cached_mysql_data_type( $table_name, $column->name );
 			$is_auto_incr = $auto_increment_column && strtolower( $auto_increment_column ) === strtolower( $column->name );
 			$definition   = array();
-			$definition[] = '`' . $column->name . '`';
+			$definition[] = $this->quote_identifier( $column->name );
 			$definition[] = $mysql_type ?? $column->name;
 
 			if ( '1' === $column->notnull ) {
@@ -3787,7 +3793,7 @@ class WP_SQLite_Translator {
 			// Remove the prefix from the index name if there is any. We use __ as a separator.
 			$index_name = explode( '__', $key['index']['name'], 2 )[1] ?? $key['index']['name'];
 
-			$key_definition[] = sprintf( '`%s`', $index_name );
+			$key_definition[] = $this->quote_identifier( $index_name );
 
 			$cols = array_map(
 				function ( $column ) use ( $table_name, $key_length_limit ) {
@@ -3807,9 +3813,9 @@ class WP_SQLite_Translator {
 						str_ends_with( $data_type, 'blob' ) ||
 						str_starts_with( $data_type, 'var' )
 					) {
-						return sprintf( '`%s`(%s)', $column['name'], $data_length );
+						return $this->quote_identifier( $column['name'] ) . '(' . $data_length . ')';
 					}
-					return sprintf( '`%s`', $column['name'] );
+					return $this->quote_identifier( $column['name'] );
 				},
 				$key['columns']
 			);
@@ -3842,7 +3848,7 @@ class WP_SQLite_Translator {
 
 		foreach ( $columns as $column ) {
 			if ( '0' !== $column->pk ) {
-				$primary_keys[] = sprintf( '`%s`', $column->name );
+				$primary_keys[] = $this->quote_identifier( $column->name );
 			}
 		}
 
@@ -3859,13 +3865,19 @@ class WP_SQLite_Translator {
 	 * @return string|null
 	 */
 	private function get_autoincrement_column( $table_name ) {
-		preg_match(
-			'/"([^"]+)"\s+integer\s+primary\s+key\s+autoincrement/i',
-			$this->get_sqlite_create_table( $table_name ),
-			$matches
-		);
+		$create_table = $this->get_sqlite_create_table( $table_name );
 
-		return $matches[1] ?? null;
+		// Match backtick-quoted identifiers (with escaped backticks ``).
+		if ( preg_match( '/`((?:[^`]|``)+)`\s+integer\s+primary\s+key\s+autoincrement/i', $create_table, $matches ) ) {
+			return str_replace( '``', '`', $matches[1] );
+		}
+
+		// Match double-quote-quoted identifiers (with escaped double-quotes "").
+		if ( preg_match( '/"((?:[^"]|"")+)"\s+integer\s+primary\s+key\s+autoincrement/i', $create_table, $matches ) ) {
+			return str_replace( '""', '"', $matches[1] );
+		}
+
+		return null;
 	}
 
 	/**
@@ -4047,7 +4059,36 @@ class WP_SQLite_Translator {
 	 * @return string The normalized column name.
 	 */
 	private function normalize_column_name( $column_name ) {
-		return trim( $column_name, '`\'"' );
+		$first = substr( $column_name, 0, 1 );
+		$last  = substr( $column_name, -1 );
+
+		// Strip matching surrounding quotes and unescape doubled instances.
+		if ( '`' === $first && '`' === $last && strlen( $column_name ) >= 2 ) {
+			return str_replace( '``', '`', substr( $column_name, 1, -1 ) );
+		}
+		if ( '"' === $first && '"' === $last && strlen( $column_name ) >= 2 ) {
+			return str_replace( '""', '"', substr( $column_name, 1, -1 ) );
+		}
+		if ( "'" === $first && "'" === $last && strlen( $column_name ) >= 2 ) {
+			return str_replace( "''", "'", substr( $column_name, 1, -1 ) );
+		}
+
+		return $column_name;
+	}
+
+	/**
+	 * Quotes an identifier for safe use in SQLite queries.
+	 *
+	 * Wraps the identifier in backticks and escapes any internal backticks
+	 * by doubling them. This ensures identifiers with special characters
+	 * are properly escaped in the target SQLite query context.
+	 *
+	 * @param string $identifier The unquoted identifier.
+	 *
+	 * @return string The properly quoted identifier.
+	 */
+	private function quote_identifier( $identifier ) {
+		return '`' . str_replace( '`', '``', $identifier ) . '`';
 	}
 
 	/**
@@ -4487,12 +4528,15 @@ class WP_SQLite_Translator {
 		// The trigger wouldn't work for virtual and "WITHOUT ROWID" tables,
 		// but currently that can't happen as we're not creating such tables.
 		// See: https://www.sqlite.org/rowidtable.html
+		$quoted_trigger = $this->quote_identifier( $trigger_name );
+		$quoted_table   = $this->quote_identifier( $table );
+		$quoted_column  = $this->quote_identifier( $column );
 		$this->execute_sqlite_query(
-			"CREATE TRIGGER \"$trigger_name\"
-			AFTER UPDATE ON \"$table\"
+			"CREATE TRIGGER $quoted_trigger
+			AFTER UPDATE ON $quoted_table
 			FOR EACH ROW
 			BEGIN
-			  UPDATE \"$table\" SET \"$column\" = CURRENT_TIMESTAMP WHERE rowid = NEW.rowid;
+			  UPDATE $quoted_table SET $quoted_column = CURRENT_TIMESTAMP WHERE rowid = NEW.rowid;
 			END"
 		);
 	}

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -2251,10 +2251,7 @@ class WP_SQLite_Translator {
 	 * @return bool True if the parameter was extracted successfully, false otherwise.
 	 */
 	private function extract_bound_parameter( $token, &$params ) {
-		if ( ! $token->matches(
-			WP_SQLite_Token::TYPE_STRING,
-			WP_SQLite_Token::FLAG_STRING_SINGLE_QUOTES
-		)
+		if ( ! $token->matches( WP_SQLite_Token::TYPE_STRING )
 			|| 'AS' === $this->last_reserved_keyword
 		) {
 			return false;
@@ -2539,7 +2536,7 @@ class WP_SQLite_Translator {
 
 		$this->rewriter->add( new WP_SQLite_Token( 'STRFTIME', WP_SQLite_Token::TYPE_KEYWORD, WP_SQLite_Token::FLAG_KEYWORD_FUNCTION ) );
 		$this->rewriter->add( new WP_SQLite_Token( '(', WP_SQLite_Token::TYPE_OPERATOR ) );
-		$this->rewriter->add( new WP_SQLite_Token( "'$new_format'", WP_SQLite_Token::TYPE_STRING ) );
+		$this->rewriter->add( new WP_SQLite_Token( $this->pdo->quote( $new_format ), WP_SQLite_Token::TYPE_STRING ) );
 		$this->rewriter->add( new WP_SQLite_Token( ',', WP_SQLite_Token::TYPE_OPERATOR ) );
 
 		// Add the buffered tokens back to the stream.
@@ -2614,7 +2611,7 @@ class WP_SQLite_Translator {
 			}
 		}
 
-		$this->rewriter->add( new WP_SQLite_Token( "'{$interval_op}$num $unit'", WP_SQLite_Token::TYPE_STRING ) );
+		$this->rewriter->add( new WP_SQLite_Token( $this->pdo->quote( "{$interval_op}$num $unit" ), WP_SQLite_Token::TYPE_STRING ) );
 		return true;
 	}
 
@@ -2712,16 +2709,9 @@ class WP_SQLite_Translator {
 	 * @return string The escaped GLOB pattern.
 	 */
 	private function escape_like_to_glob( $pattern ) {
-		// Remove surrounding quotes
-		$pattern = trim( $pattern, "'\"" );
-
 		$pattern = str_replace( '%', '*', $pattern );
 		$pattern = str_replace( '_', '?', $pattern );
-
-		// No need to escape special characters in this case
-		// because GLOB doesn't require escaping in the same way LIKE does
-		// Return the pattern wrapped in single quotes
-		return "'" . $pattern . "'";
+		return $this->pdo->quote( $pattern );
 	}
 
 	/**

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1494,12 +1494,13 @@ class WP_SQLite_Translator {
 
 		$quoted_table = $this->quote_identifier( $this->table_name );
 		$quoted_pk    = $this->quote_identifier( $pk_name );
-		$query        = (
-		count( $ids_to_delete )
-			? "DELETE FROM {$quoted_table} WHERE {$quoted_pk} IN (" . implode( ',', $ids_to_delete ) . ')'
-			: "DELETE FROM {$quoted_table} WHERE 0=1"
-		);
-		$this->execute_sqlite_query( $query );
+		if ( count( $ids_to_delete ) ) {
+			$placeholders = implode( ',', array_fill( 0, count( $ids_to_delete ), '?' ) );
+			$stmt         = $this->execute_sqlite_query( "DELETE FROM {$quoted_table} WHERE {$quoted_pk} IN ({$placeholders})" );
+			$stmt->execute( $ids_to_delete );
+		} else {
+			$this->execute_sqlite_query( "DELETE FROM {$quoted_table} WHERE 0=1" );
+		}
 		$this->set_result_from_affected_rows(
 			count( $ids_to_delete )
 		);

--- a/wp-includes/sqlite/class-wp-sqlite-translator.php
+++ b/wp-includes/sqlite/class-wp-sqlite-translator.php
@@ -1722,7 +1722,7 @@ class WP_SQLite_Translator {
 	 */
 	private function execute_describe() {
 		$this->rewriter->skip();
-		$this->table_name = $this->rewriter->consume()->value;
+		$this->table_name = $this->normalize_column_name( $this->rewriter->consume()->value );
 		$this->set_results_from_fetched_data(
 			$this->describe( $this->table_name )
 		);
@@ -1840,7 +1840,7 @@ class WP_SQLite_Translator {
 					WP_SQLite_Token::FLAG_KEYWORD_RESERVED
 				)
 			) {
-				$this->table_name = $token->value;
+				$this->table_name = $this->normalize_column_name( $token->value );
 			}
 
 			$this->remember_last_reserved_keyword( $token );
@@ -1919,7 +1919,7 @@ class WP_SQLite_Translator {
 		// Consume and record the table name.
 		$this->insert_columns = array();
 		$this->rewriter->consume(); // INTO.
-		$this->table_name = $this->rewriter->consume()->value; // Table name.
+		$this->table_name = $this->normalize_column_name( $this->rewriter->consume()->value ); // Table name.
 
 		/*
 		 * A list of columns is given if the opening parenthesis
@@ -2198,7 +2198,7 @@ class WP_SQLite_Translator {
 		) {
 			return false;
 		}
-		$table_name = $this->rewriter->peek_nth( 2 )->value;
+		$table_name = $this->normalize_column_name( $this->rewriter->peek_nth( 2 )->value );
 		if ( 'dual' === strtolower( $table_name ) ) {
 			return false;
 		}


### PR DESCRIPTION
Improve escaping consistency in the legacy SQLite translator:

- Use `quote_identifier()` for all identifier interpolations (table names, column names, index names, trigger names) in SQL queries, token values, and DDL reconstruction output.
- Use parameterized queries and `PDO::quote()` for all string literals processed by the translator.

See added tests for more details.