### PR TITLE
Implement FROM_BASE64() and TO_BASE64() MySQL functions

### DIFF
--- a/tests/WP_SQLite_Driver_Tests.php
+++ b/tests/WP_SQLite_Driver_Tests.php
@@ -11363,6 +11363,42 @@ END;
 		$this->assertSame( '8.0.38', $result[0]->{'VERSION()'} );
 	}
 
+	public function testFromBase64Function(): void {
+		// Basic decoding.
+		$result = $this->assertQuery( "SELECT FROM_BASE64('SGVsbG8gV29ybGQ=') AS decoded" );
+		$this->assertSame( 'Hello World', $result[0]->decoded );
+
+		// Empty string.
+		$result = $this->assertQuery( "SELECT FROM_BASE64('') AS decoded" );
+		$this->assertSame( '', $result[0]->decoded );
+
+		// NULL input returns NULL.
+		$result = $this->assertQuery( 'SELECT FROM_BASE64(NULL) AS decoded' );
+		$this->assertNull( $result[0]->decoded );
+
+		// Binary data round-trip.
+		$result = $this->assertQuery( "SELECT FROM_BASE64(TO_BASE64('binary\\0data')) AS decoded" );
+		$this->assertSame( "binary\0data", $result[0]->decoded );
+	}
+
+	public function testToBase64Function(): void {
+		// Basic encoding.
+		$result = $this->assertQuery( "SELECT TO_BASE64('Hello World') AS encoded" );
+		$this->assertSame( 'SGVsbG8gV29ybGQ=', $result[0]->encoded );
+
+		// Empty string.
+		$result = $this->assertQuery( "SELECT TO_BASE64('') AS encoded" );
+		$this->assertSame( '', $result[0]->encoded );
+
+		// NULL input returns NULL.
+		$result = $this->assertQuery( 'SELECT TO_BASE64(NULL) AS encoded' );
+		$this->assertNull( $result[0]->encoded );
+
+		// Round-trip: TO_BASE64(FROM_BASE64(x)) = x.
+		$result = $this->assertQuery( "SELECT TO_BASE64(FROM_BASE64('dGVzdA==')) AS encoded" );
+		$this->assertSame( 'dGVzdA==', $result[0]->encoded );
+	}
+
 	public function testSubstringFunction(): void {
 		$result = $this->assertQuery( "SELECT SUBSTRING('abcdef', 1, 3) AS s" );
 		$this->assertSame( 'abc', $result[0]->s );

--- a/wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/wp-includes/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -80,6 +80,8 @@ class WP_SQLite_PDO_User_Defined_Functions {
 		'ucase'                        => 'ucase',
 		'lcase'                        => 'lcase',
 		'unhex'                        => 'unhex',
+		'from_base64'                  => 'from_base64',
+		'to_base64'                    => 'to_base64',
 		'inet_ntoa'                    => 'inet_ntoa',
 		'inet_aton'                    => 'inet_aton',
 		'datediff'                     => 'datediff',
@@ -665,6 +667,44 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	 */
 	public function unhex( $number ) {
 		return pack( 'H*', $number );
+	}
+
+	/**
+	 * Method to emulate MySQL FROM_BASE64() function.
+	 *
+	 * Takes a base64-encoded string and returns the decoded result as a binary
+	 * string. Returns NULL if the argument is NULL or is not a valid base64 string.
+	 *
+	 * @param string|null $str The base64-encoded string.
+	 *
+	 * @return string|null Decoded binary string, or NULL.
+	 */
+	public function from_base64( $str ) {
+		if ( null === $str ) {
+			return null;
+		}
+		$decoded = base64_decode( $str, true );
+		if ( false === $decoded ) {
+			return null;
+		}
+		return $decoded;
+	}
+
+	/**
+	 * Method to emulate MySQL TO_BASE64() function.
+	 *
+	 * Takes a string and returns a base64-encoded result.
+	 * Returns NULL if the argument is NULL.
+	 *
+	 * @param string|null $str The string to encode.
+	 *
+	 * @return string|null Base64-encoded string, or NULL.
+	 */
+	public function to_base64( $str ) {
+		if ( null === $str ) {
+			return null;
+		}
+		return base64_encode( $str );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

This adds support for MySQL's `FROM_BASE64()` and `TO_BASE64()` functions, allowing SQL queries to encode and decode base64 data.

Both functions are implemented as SQLite user-defined functions backed by PHP's `base64_encode()` and `base64_decode()`. Because they're registered through `WP_SQLite_PDO_User_Defined_Functions::register_for()`, they work with both the legacy and AST-based drivers automatically.

`FROM_BASE64()` returns `NULL` for `NULL` or invalid base64 input. `TO_BASE64()` returns `NULL` for `NULL` input.

## Test plan

- Run `composer run test -- --filter 'testFromBase64|testToBase64'`
- Verify basic encoding/decoding, NULL handling, empty string handling, and round-trip correctness