### PR TITLE
Skip plugin auto-activation if plugin file doesn't exist

### DIFF
--- a/db.copy
+++ b/db.copy
@@ -46,7 +46,10 @@ add_action(
 		if ( ! function_exists( 'activate_plugin' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
-		if ( is_plugin_inactive( '{SQLITE_PLUGIN}' ) ) {
+
+		$plugin_path = WP_PLUGIN_DIR . '/' . '{SQLITE_PLUGIN}';
+
+		if ( file_exists( $plugin_path ) && is_plugin_inactive( '{SQLITE_PLUGIN}' ) ) {
 			// If `activate_plugin()` returns a value other than null (like WP_Error),
 			// the plugin could not be found. Try with a hardcoded string,
 			// because that probably means the file was directly copy-pasted.


### PR DESCRIPTION
## What

I propose adding a `file_exists()` check before calling `is_plugin_inactive()` in the `admin_footer` action inside `db.copy`.

## Why

If the SQLite plugin is inactive for some reason but the `db.php` drop-in file exists, the logic automatically activates the plugin. This works only when the SQLite plugin is installed into the `plugins/` directory and throws warnings if plugin is installed into the `mu-plugins/` directory.

The new guard ensures that the plugin is installed in `plugins/` before running activation logic.

## Testing

1. Install WordPress
2. Install the SQLite plugin from the .org directory
3. Activate the plugin - confirm `db.php` drop-in is created
4. Deactivate the plugin by bypassing normal logic:
```
wp option delete active_plugins
```
6. Confirm `db.php` still exists
7. Reload WP Admin
8. Confirm the plugin is auto-activated
