### PR TITLE
Add constant for SQLite driver loader path

### DIFF
--- a/wp-pdo-mysql-on-sqlite.php
+++ b/wp-pdo-mysql-on-sqlite.php
@@ -1,5 +1,7 @@
 <?php
 
+define( 'WP_MYSQL_ON_SQLITE_LOADER_PATH', __FILE__ );
+
 /**
  * Load the PDO MySQL-on-SQLite driver and its dependencies.
  */


### PR DESCRIPTION
## Summary
Define `WP_MYSQL_ON_SQLITE_PATH` constant in `wp-pdo-mysql-on-sqlite.php` so that dependent projects can reliably determine the path to the SQLite driver loader file.