### PR TITLE
Fix incorrect PHP polyfill implementations

### DIFF
--- a/php-polyfills.php
+++ b/php-polyfills.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * Polyfills for php 7 & 8 functions
+ * Polyfills for PHP 8.0 string functions.
+ *
+ * Implementation follows the Symfony polyfill-php80 package.
+ *
+ * @see https://github.com/symfony/polyfill-php80
  *
  * @package wp-sqlite-integration
  */
@@ -17,7 +21,7 @@ if ( ! function_exists( 'str_starts_with' ) ) {
 	 * @return bool
 	 */
 	function str_starts_with( string $haystack, string $needle ) {
-		return empty( $needle ) || 0 === strpos( $haystack, $needle );
+		return 0 === strncmp( $haystack, $needle, strlen( $needle ) );
 	}
 }
 
@@ -33,7 +37,7 @@ if ( ! function_exists( 'str_contains' ) ) {
 	 * @return bool
 	 */
 	function str_contains( string $haystack, string $needle ) {
-		return empty( $needle ) || false !== strpos( $haystack, $needle );
+		return '' === $needle || false !== strpos( $haystack, $needle );
 	}
 }
 
@@ -49,6 +53,16 @@ if ( ! function_exists( 'str_ends_with' ) ) {
 	 * @return bool
 	 */
 	function str_ends_with( string $haystack, string $needle ) {
-		return empty( $needle ) || substr( $haystack, -strlen( $needle ) === $needle );
+		if ( '' === $needle || $needle === $haystack ) {
+			return true;
+		}
+
+		if ( '' === $haystack ) {
+			return false;
+		}
+
+		$needle_length = strlen( $needle );
+
+		return $needle_length <= strlen( $haystack ) && 0 === substr_compare( $haystack, $needle, -$needle_length );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../php-polyfills.php';
 require_once __DIR__ . '/wp-sqlite-schema.php';
 require_once __DIR__ . '/../wp-pdo-mysql-on-sqlite.php';
 require_once __DIR__ . '/../wp-includes/sqlite/class-wp-sqlite-query-rewriter.php';
@@ -50,57 +51,6 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	}
 }
 
-/**
- * Polyfills for php 7 & 8 functions
- */
-
-if ( ! function_exists( 'str_starts_with' ) ) {
-	/**
-	 * Check if a string starts with a specific substring.
-	 *
-	 * @param string $haystack The string to search in.
-	 * @param string $needle The string to search for.
-	 *
-	 * @see https://www.php.net/manual/en/function.str-starts-with
-	 *
-	 * @return bool
-	 */
-	function str_starts_with( string $haystack, string $needle ) {
-		return empty( $needle ) || 0 === strpos( $haystack, $needle );
-	}
-}
-
-if ( ! function_exists( 'str_contains' ) ) {
-	/**
-	 * Check if a string contains a specific substring.
-	 *
-	 * @param string $haystack The string to search in.
-	 * @param string $needle The string to search for.
-	 *
-	 * @see https://www.php.net/manual/en/function.str-contains
-	 *
-	 * @return bool
-	 */
-	function str_contains( string $haystack, string $needle ) {
-		return empty( $needle ) || false !== strpos( $haystack, $needle );
-	}
-}
-
-if ( ! function_exists( 'str_ends_with' ) ) {
-	/**
-	 * Check if a string ends with a specific substring.
-	 *
-	 * @param string $haystack The string to search in.
-	 * @param string $needle The string to search for.
-	 *
-	 * @see https://www.php.net/manual/en/function.str-ends-with
-	 *
-	 * @return bool
-	 */
-	function str_ends_with( string $haystack, string $needle ) {
-		return empty( $needle ) || substr( $haystack, -strlen( $needle ) ) === $needle;
-	}
-}
 if ( extension_loaded( 'mbstring' ) ) {
 
 	if ( ! function_exists( 'mb_str_starts_with' ) ) {


### PR DESCRIPTION
## Summary

The polyfills for `str_starts_with`, `str_contains`, and `str_ends_with` had incorrect implementations ever since they were added in https://github.com/WordPress/sqlite-database-integration/commit/4b0dab50d559bb3c43e1b90310193691430e66b9:

- **`str_ends_with` broken parentheses**: The original `substr($haystack, -strlen($needle) === $needle)` had the `=== $needle` comparison inside the `substr()` call as the length argument, instead of comparing the `substr()` result. The function never worked correctly.
- **`empty()` vs `'' ===`**: All three functions used `empty($needle)` to check for an empty needle. Since `empty("0")` returns `true` in PHP, this caused wrong results for strings like `"0"` — e.g., `str_contains("abc", "0")` would incorrectly return `true`.
- **`str_starts_with` improvement**: Now uses `strncmp` instead of `strpos` for correctness and performance.

The implementations now follow the [Symfony polyfill-php80](https://github.com/symfony/polyfill-php80) package.

Also removes the duplicate (buggy) polyfill definitions from the test bootstrap file, which already includes `php-polyfills.php`.

## Test plan

- [ ] Verify `str_starts_with`, `str_contains`, and `str_ends_with` behave correctly with empty strings, `"0"` strings, and regular inputs.
- [ ] Run `composer run test` to confirm no regressions.