### PR TITLE
Support INSERT without INTO keyword

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -1835,6 +1835,11 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			$is_node  = $child instanceof WP_Parser_Node;
 
 			if ( $child instanceof WP_Parser_Node && 'tableRef' === $child->rule_name ) {
+				// MySQL supports INSERT without the INTO keyword; SQLite requires it.
+				if ( ! $node->has_child_token( WP_MySQL_Lexer::INTO_SYMBOL ) ) {
+					$parts[] = 'INTO';
+				}
+
 				$database = $this->get_database_name( $child );
 				if ( 'information_schema' === strtolower( $database ) ) {
 					throw $this->new_access_denied_to_information_schema_exception();

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -9986,6 +9986,34 @@ END;
 		);
 	}
 
+	public function testInsertWithoutInto(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT PRIMARY KEY, name VARCHAR(255))' );
+
+		// INSERT ... VALUES
+		$this->assertQuery( "INSERT t (id, name) VALUES (1, 'a')" );
+
+		// INSERT IGNORE
+		$this->assertQuery( "INSERT IGNORE t (id, name) VALUES (1, 'a')" );
+
+		// INSERT ... SET
+		$this->assertQuery( "INSERT t SET id = 2, name = 'b'" );
+
+		// INSERT IGNORE ... SET
+		$this->assertQuery( "INSERT IGNORE t SET id = 2, name = 'b'" );
+
+		// INSERT ... SELECT
+		$this->assertQuery( "INSERT t (id, name) SELECT 3, 'c'" );
+
+		// INSERT IGNORE ... SELECT
+		$this->assertQuery( "INSERT IGNORE t (id, name) SELECT 3, 'c'" );
+
+		$res = $this->assertQuery( 'SELECT * FROM t ORDER BY id' );
+		$this->assertCount( 3, $res );
+		$this->assertEquals( 'a', $res[0]->name );
+		$this->assertEquals( 'b', $res[1]->name );
+		$this->assertEquals( 'c', $res[2]->name );
+	}
+
 	public function testInsertIntoSetSyntax(): void {
 		$this->assertQuery(
 			'CREATE TABLE t (


### PR DESCRIPTION
## Summary

MySQL supports omitting the `INTO` keyword in `INSERT` statements (e.g., `INSERT t (id) VALUES (1)`), but SQLite requires it. This adds the missing `INTO` keyword during query translation.

This is a simpler alternative to #343, focusing only on the `INTO` keyword injection. It also adds tests covering `INSERT` without `INTO` across multiple syntaxes: `VALUES`, `SET`, `SELECT`, and their `IGNORE` variants.

Closes #343. Thanks @wp-fuse for reporting this!

## Test plan

- [x] `INSERT t (id, name) VALUES (1, 'a')` — VALUES syntax without INTO.
- [x] `INSERT IGNORE t (id, name) VALUES (1, 'a')` — IGNORE without INTO.
- [x] `INSERT t SET id = 2, name = 'b'` — SET syntax without INTO.
- [x] `INSERT IGNORE t SET id = 2, name = 'b'` — IGNORE + SET without INTO.
- [x] `INSERT t (id, name) SELECT 3, 'c'` — SELECT syntax without INTO.
- [x] `INSERT IGNORE t (id, name) SELECT 3, 'c'` — IGNORE + SELECT without INTO.