### PR TITLE
Release 2.2.23

### DIFF
--- a/packages/mysql-on-sqlite/src/version.php
+++ b/packages/mysql-on-sqlite/src/version.php
@@ -5,4 +5,4 @@
  *
  * This constant needs to be updated on plugin release!
  */
-define( 'SQLITE_DRIVER_VERSION', '2.2.22' );
+define( 'SQLITE_DRIVER_VERSION', '2.2.23' );

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: SQLite Database Integration
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
- * Version: 2.2.22
+ * Version: 2.2.23
  * Requires PHP: 7.2
  * Textdomain: sqlite-database-integration
  *

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgic
 Requires at least: 6.4
 Tested up to:      6.9
 Requires PHP:      7.2
-Stable tag:        2.2.22
+Stable tag:        2.2.23
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, database
@@ -45,6 +45,11 @@ the wpdb API, while queries are internally adapted to be compatible
 with SQLite syntax and behavior.
 
 == Changelog ==
+
+= 2.2.23 =
+
+* Add Query Monitor 4.0 support ([#357](https://github.com/WordPress/sqlite-database-integration/pull/357))
+* Translate MySQL CONVERT() expressions to SQLite ([#356](https://github.com/WordPress/sqlite-database-integration/pull/356))
 
 = 2.2.22 =
 


### PR DESCRIPTION
## Release `2.2.23`

Version bump and changelog update for release `2.2.23`.

**Changelog draft:**
* Add Query Monitor 4.0 support ([#357](https://github.com/WordPress/sqlite-database-integration/pull/357))
* Translate MySQL CONVERT() expressions to SQLite ([#356](https://github.com/WordPress/sqlite-database-integration/pull/356))

**Full changelog:** https://github.com/WordPress/sqlite-database-integration/compare/v2.2.22...release/v2.2.23

## Next steps

1. **Review** the changes in this pull request.
2. **Push** any additional edits to this branch (`release/v2.2.23`).
3. **Merge** this pull request to complete the release.

Merging will automatically build the plugin ZIP, create a [GitHub release](https://github.com/WordPress/sqlite-database-integration/releases), and deploy to [WordPress.org](https://wordpress.org/plugins/sqlite-database-integration/).