### PR TITLE
Improve concurrent database access

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -883,10 +883,32 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				null === $child_node
 				|| 'beginWork' === $child_node->rule_name
 				|| $child_node->has_child_node( 'transactionOrLockingStatement' )
+				|| $child_node->has_child_node( 'selectStatement' )
 			) {
 				$wrap_in_transaction = false;
 			} else {
 				$wrap_in_transaction = true;
+			}
+
+			/*
+			 * Detect read-only statements before opening the wrapper transaction.
+			 *
+			 * [GRAMMAR]
+			 * simpleStatement: selectStatement | showStatement | utilityStatement | ...
+			 */
+			$statement_node = $child_node->get_first_child_node();
+			if ( null !== $statement_node ) {
+				if (
+					'selectStatement' === $statement_node->rule_name
+					|| 'showStatement' === $statement_node->rule_name
+				) {
+					$this->is_readonly = true;
+				} elseif ( 'utilityStatement' === $statement_node->rule_name ) {
+					$utility_subnode = $statement_node->get_first_child_node();
+					if ( null !== $utility_subnode && 'describeStatement' === $utility_subnode->rule_name ) {
+						$this->is_readonly = true;
+					}
+				}
 			}
 
 			if ( $wrap_in_transaction ) {
@@ -1366,7 +1388,6 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				$this->execute_transaction_or_locking_statement( $node );
 				break;
 			case 'selectStatement':
-				$this->is_readonly = true;
 				$this->execute_select_statement( $node );
 				break;
 			case 'insertStatement':
@@ -1444,14 +1465,12 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				$this->execute_set_statement( $node );
 				break;
 			case 'showStatement':
-				$this->is_readonly = true;
 				$this->execute_show_statement( $node );
 				break;
 			case 'utilityStatement':
 				$subtree = $node->get_first_child_node();
 				switch ( $subtree->rule_name ) {
 					case 'describeStatement':
-						$this->is_readonly = true;
 						$this->execute_describe_statement( $subtree );
 						break;
 					case 'useCommand':

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -896,8 +896,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			 * [GRAMMAR]
 			 * simpleStatement: selectStatement | showStatement | utilityStatement | ...
 			 */
-			$statement_node = $child_node->get_first_child_node();
-			if ( null !== $statement_node ) {
+			if ( null !== $child_node && $child_node->has_child_node() ) {
+				$statement_node = $child_node->get_first_child_node();
 				if (
 					'selectStatement' === $statement_node->rule_name
 					|| 'showStatement' === $statement_node->rule_name

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
@@ -32,84 +32,72 @@ class WP_SQLite_Driver_Concurrency_Tests extends TestCase {
 		$this->db_path = null;
 	}
 
-	/**
-	 * A SELECT should not be wrapped in a transaction — no BEGIN at all.
-	 */
 	public function testSelectQueryIsNotWrappedInTransaction(): void {
-		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
-		$pdo       = new $pdo_class( 'sqlite::memory:' );
-
-		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
-		$driver     = new WP_SQLite_Driver( $connection, 'wp' );
+		$driver = $this->create_in_memory_driver();
 		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
-
-		// Capture SQLite queries. The logger must be set on the driver's
-		// internal connection, not the original one passed to the constructor.
-		$logged_queries = array();
-		$driver->get_connection()->set_query_logger(
-			function ( string $sql, array $params ) use ( &$logged_queries ): void {
-				$logged_queries[] = $sql;
-			}
-		);
 
 		$driver->query( 'SELECT * FROM t' );
 
-		$this->assertStringStartsNotWith( 'BEGIN', $logged_queries[0] );
+		$this->assertStringStartsNotWith( 'BEGIN', $driver->get_last_sqlite_queries()[0]['sql'] );
 	}
 
-	/**
-	 * A SHOW statement should use a deferred BEGIN (SHARED lock), not
-	 * BEGIN IMMEDIATE (RESERVED/write lock).
-	 */
 	public function testShowQueryOpensReadOnlyTransaction(): void {
-		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
-		$pdo       = new $pdo_class( 'sqlite::memory:' );
-
-		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
-		$driver     = new WP_SQLite_Driver( $connection, 'wp' );
+		$driver = $this->create_in_memory_driver();
 		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
-
-		$logged_queries = array();
-		$driver->get_connection()->set_query_logger(
-			function ( string $sql, array $params ) use ( &$logged_queries ): void {
-				$logged_queries[] = $sql;
-			}
-		);
 
 		$driver->query( 'SHOW TABLES' );
 
-		$this->assertSame( 'BEGIN', $logged_queries[0] );
+		$this->assertSame( 'BEGIN', $driver->get_last_sqlite_queries()[0]['sql'] );
 	}
 
-	/**
-	 * A DESCRIBE statement should use a deferred BEGIN (SHARED lock), not
-	 * BEGIN IMMEDIATE (RESERVED/write lock).
-	 */
 	public function testDescribeQueryOpensReadOnlyTransaction(): void {
-		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
-		$pdo       = new $pdo_class( 'sqlite::memory:' );
-
-		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
-		$driver     = new WP_SQLite_Driver( $connection, 'wp' );
+		$driver = $this->create_in_memory_driver();
 		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
-
-		$logged_queries = array();
-		$driver->get_connection()->set_query_logger(
-			function ( string $sql, array $params ) use ( &$logged_queries ): void {
-				$logged_queries[] = $sql;
-			}
-		);
 
 		$driver->query( 'DESCRIBE t' );
 
-		$this->assertSame( 'BEGIN', $logged_queries[0] );
+		$this->assertSame( 'BEGIN', $driver->get_last_sqlite_queries()[0]['sql'] );
 	}
 
 	/**
-	 * A SELECT on one connection should succeed even when another connection
-	 * holds an open write transaction (RESERVED lock).
+	 * @dataProvider provideWriteStatements
 	 */
+	public function testWriteQueryOpensWriteTransaction( string $query ): void {
+		$driver = $this->create_in_memory_driver();
+		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+		$driver->query( "INSERT INTO t VALUES (1, 'Alice')" );
+
+		$driver->query( $query );
+
+		$this->assertSame( 'BEGIN IMMEDIATE', $driver->get_last_sqlite_queries()[0]['sql'] );
+	}
+
+	public function provideWriteStatements(): array {
+		return array(
+			'INSERT'         => array( "INSERT INTO t VALUES (2, 'Bob')" ),
+			'UPDATE'         => array( "UPDATE t SET name = 'Carol' WHERE id = 1" ),
+			'DELETE'         => array( 'DELETE FROM t WHERE id = 1' ),
+			'REPLACE'        => array( "REPLACE INTO t VALUES (1, 'Dan')" ),
+			'CREATE TABLE'   => array( 'CREATE TABLE u (id INT)' ),
+			'ALTER TABLE'    => array( 'ALTER TABLE t ADD COLUMN x INT' ),
+			'DROP TABLE'     => array( 'DROP TABLE t' ),
+			'TRUNCATE TABLE' => array( 'TRUNCATE TABLE t' ),
+		);
+	}
+
 	public function testSelectQuerySucceedsWhileAnotherConnectionHoldsWriteLock(): void {
+		$this->assertReadOnlyQuerySucceedsUnderWriteLock( 'SELECT * FROM t' );
+	}
+
+	public function testShowQuerySucceedsWhileAnotherConnectionHoldsWriteLock(): void {
+		$this->assertReadOnlyQuerySucceedsUnderWriteLock( 'SHOW TABLES' );
+	}
+
+	public function testDescribeQuerySucceedsWhileAnotherConnectionHoldsWriteLock(): void {
+		$this->assertReadOnlyQuerySucceedsUnderWriteLock( 'DESCRIBE t' );
+	}
+
+	private function assertReadOnlyQuerySucceedsUnderWriteLock( string $query ): void {
 		// Connection A: set up the database.
 		$conn_a   = new WP_SQLite_Connection( array( 'path' => $this->db_path ) );
 		$driver_a = new WP_SQLite_Driver( $conn_a, 'wp' );
@@ -130,13 +118,19 @@ class WP_SQLite_Driver_Concurrency_Tests extends TestCase {
 			$driver_b = new WP_SQLite_Driver( $conn_b, 'wp' );
 			$conn_b->get_pdo()->setAttribute( PDO::ATTR_TIMEOUT, 0 );
 
-			$result = $driver_b->query( 'SELECT * FROM t' );
+			$result = $driver_b->query( $query );
 
-			$this->assertCount( 1, $result );
-			$this->assertSame( '1', $result[0]->id );
-			$this->assertSame( 'Alice', $result[0]->name );
+			$this->assertIsArray( $result );
+			$this->assertNotEmpty( $result );
 		} finally {
 			$conn_a->get_pdo()->exec( 'ROLLBACK' );
 		}
+	}
+
+	private function create_in_memory_driver(): WP_SQLite_Driver {
+		$pdo_class  = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
+		$pdo        = new $pdo_class( 'sqlite::memory:' );
+		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
+		return new WP_SQLite_Driver( $connection, 'wp' );
 	}
 }

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
@@ -58,6 +58,54 @@ class WP_SQLite_Driver_Concurrency_Tests extends TestCase {
 	}
 
 	/**
+	 * A SHOW statement should use a deferred BEGIN (SHARED lock), not
+	 * BEGIN IMMEDIATE (RESERVED/write lock).
+	 */
+	public function testShowQueryOpensReadOnlyTransaction(): void {
+		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
+		$pdo       = new $pdo_class( 'sqlite::memory:' );
+
+		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
+		$driver     = new WP_SQLite_Driver( $connection, 'wp' );
+		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+
+		$logged_queries = array();
+		$driver->get_connection()->set_query_logger(
+			function ( string $sql, array $params ) use ( &$logged_queries ): void {
+				$logged_queries[] = $sql;
+			}
+		);
+
+		$driver->query( 'SHOW TABLES' );
+
+		$this->assertSame( 'BEGIN', $logged_queries[0] );
+	}
+
+	/**
+	 * A DESCRIBE statement should use a deferred BEGIN (SHARED lock), not
+	 * BEGIN IMMEDIATE (RESERVED/write lock).
+	 */
+	public function testDescribeQueryOpensReadOnlyTransaction(): void {
+		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
+		$pdo       = new $pdo_class( 'sqlite::memory:' );
+
+		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
+		$driver     = new WP_SQLite_Driver( $connection, 'wp' );
+		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+
+		$logged_queries = array();
+		$driver->get_connection()->set_query_logger(
+			function ( string $sql, array $params ) use ( &$logged_queries ): void {
+				$logged_queries[] = $sql;
+			}
+		);
+
+		$driver->query( 'DESCRIBE t' );
+
+		$this->assertSame( 'BEGIN', $logged_queries[0] );
+	}
+
+	/**
 	 * A SELECT on one connection should succeed even when another connection
 	 * holds an open write transaction (RESERVED lock).
 	 */

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
@@ -1,0 +1,94 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for concurrent access to the same SQLite database file.
+ */
+class WP_SQLite_Driver_Concurrency_Tests extends TestCase {
+	/**
+	 * Path to the temporary SQLite database file used in file-based tests.
+	 *
+	 * @var string|null
+	 */
+	private $db_path;
+
+	public function setUp(): void {
+		$this->db_path = tempnam( sys_get_temp_dir(), 'wp_sqlite_' );
+		unlink( $this->db_path ); // Remove so SQLite creates a fresh database.
+	}
+
+	public function tearDown(): void {
+		foreach ( array(
+			$this->db_path,
+			$this->db_path . '-wal',
+			$this->db_path . '-shm',
+			$this->db_path . '-journal',
+		) as $path ) {
+			if ( is_string( $path ) && file_exists( $path ) ) {
+				unlink( $path );
+			}
+		}
+		$this->db_path = null;
+	}
+
+	/**
+	 * A SELECT should not be wrapped in a transaction — no BEGIN at all.
+	 */
+	public function testSelectQueryIsNotWrappedInTransaction(): void {
+		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
+		$pdo       = new $pdo_class( 'sqlite::memory:' );
+
+		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
+		$driver     = new WP_SQLite_Driver( $connection, 'wp' );
+		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+
+		// Capture SQLite queries. The logger must be set on the driver's
+		// internal connection, not the original one passed to the constructor.
+		$logged_queries = array();
+		$driver->get_connection()->set_query_logger(
+			function ( string $sql, array $params ) use ( &$logged_queries ): void {
+				$logged_queries[] = $sql;
+			}
+		);
+
+		$driver->query( 'SELECT * FROM t' );
+
+		$this->assertStringStartsNotWith( 'BEGIN', $logged_queries[0] );
+	}
+
+	/**
+	 * A SELECT on one connection should succeed even when another connection
+	 * holds an open write transaction (RESERVED lock).
+	 */
+	public function testSelectQuerySucceedsWhileAnotherConnectionHoldsWriteLock(): void {
+		// Connection A: set up the database.
+		$conn_a   = new WP_SQLite_Connection( array( 'path' => $this->db_path ) );
+		$driver_a = new WP_SQLite_Driver( $conn_a, 'wp' );
+		$driver_a->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+		$driver_a->query( "INSERT INTO t VALUES (1, 'Alice')" );
+
+		// Simulate another PHP process holding a write transaction.
+		$conn_a->get_pdo()->exec( 'BEGIN IMMEDIATE' );
+
+		try {
+			// Connection B with zero timeout — any lock conflict fails immediately.
+			$conn_b   = new WP_SQLite_Connection(
+				array(
+					'path'    => $this->db_path,
+					'timeout' => 0,
+				)
+			);
+			$driver_b = new WP_SQLite_Driver( $conn_b, 'wp' );
+			$conn_b->get_pdo()->setAttribute( PDO::ATTR_TIMEOUT, 0 );
+
+			$result = $driver_b->query( 'SELECT * FROM t' );
+
+			$this->assertCount( 1, $result );
+			$this->assertSame( '1', $result[0]->id );
+			$this->assertSame( 'Alice', $result[0]->name );
+		} finally {
+			$conn_a->get_pdo()->exec( 'ROLLBACK' );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Reduces lock contention under concurrent access by avoiding unnecessary write locks for read-only queries.

1. **Skip the wrapper transaction for SELECT statements.** A standalone SELECT translates to a single SQLite query, so the implicit autocommit transaction provides sufficient consistency — no explicit `BEGIN`/`COMMIT` needed.
2. **Use deferred `BEGIN` for other read-only wrapper transactions.** SHOW and DESCRIBE queries still use a wrapper transaction (they may translate to multiple SQLite queries), but now use a deferred `BEGIN` (SHARED lock) instead of `BEGIN IMMEDIATE` (RESERVED lock).

### Background

The wrapper transaction previously used `BEGIN IMMEDIATE` for all queries, including read-only SELECTs. This acquired a RESERVED (write) lock on every query — but SQLite only allows one RESERVED lock at a time. Under concurrent load (e.g., multiple PHP-FPM workers handling requests simultaneously), all processes competed for the single write lock. When the 10-second busy timeout was exceeded, SQLite returned `SQLITE_BUSY` ("database is locked", error 5).

SHARED locks, acquired by a deferred `BEGIN`, are compatible with RESERVED locks — multiple readers can proceed concurrently alongside an active writer.

Fixes #318