### PR TITLE
Fix `RAND()` function behavior

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -4418,7 +4418,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				 * The UDF also handles RAND(NULL) as RAND(0), matching MySQL.
 				 */
 				if ( 0 === count( $args ) ) {
-					return '((RANDOM() & 0x001FFFFFFFFFFFFF) / 9007199254740992.0)';
+					return '((RANDOM() & ((1 << 53) - 1)) / ((1 << 53) * 1.0))';
 				}
 				return $this->translate_sequence( $node->get_children() );
 			case 'DATE_FORMAT':

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -437,6 +437,13 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	private $connection;
 
 	/**
+	 * User-defined functions registered on the SQLite connection.
+	 *
+	 * @var WP_SQLite_PDO_User_Defined_Functions
+	 */
+	private $user_defined_functions;
+
+	/**
 	 * A service for managing MySQL INFORMATION_SCHEMA tables in SQLite.
 	 *
 	 * @var WP_SQLite_Information_Schema_Builder
@@ -724,7 +731,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		$this->connection->query( 'PRAGMA foreign_keys = ON' );
 
 		// Register SQLite functions.
-		WP_SQLite_PDO_User_Defined_Functions::register_for( $this->connection->get_pdo() );
+		$this->user_defined_functions = WP_SQLite_PDO_User_Defined_Functions::register_for( $this->connection->get_pdo() );
 
 		// Load MySQL grammar.
 		if ( null === self::$mysql_grammar ) {
@@ -4395,6 +4402,25 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		}
 
 		switch ( $name ) {
+			case 'RAND':
+				/*
+				 * Unseeded RAND() compiles to a fast native SQLite expression.
+				 * In MySQL, unseeded RAND() uses the thread-level random state,
+				 * independent of any RAND(N) seeding, so we don't need PHP UDF.
+				 *
+				 * We map SQLite's RANDOM() to a float in [0, 1) by masking to
+				 * 53 bits (IEEE 754 double mantissa width) and dividing by 2^53.
+				 * This avoids the edge case where masking to 63 bits and dividing
+				 * by 2^63 could round to 1.0 due to loss of precision in double.
+				 *
+				 * Seeded RAND(N) falls through to the UDF, which implements
+				 * MySQL's deterministic LCG (Linear Congruential Generator).
+				 * The UDF also handles RAND(NULL) as RAND(0), matching MySQL.
+				 */
+				if ( 0 === count( $args ) ) {
+					return '((RANDOM() & 0x001FFFFFFFFFFFFF) / 9007199254740992.0)';
+				}
+				return $this->translate_sequence( $node->get_children() );
 			case 'DATE_FORMAT':
 				list ( $date, $mysql_format ) = $args;
 
@@ -6609,6 +6635,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		$this->last_column_meta         = array();
 		$this->is_readonly              = false;
 		$this->wrapper_transaction_type = null;
+		$this->user_defined_functions->flush();
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -96,6 +96,39 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	);
 
 	/**
+	 * First element of the RAND(N) LCG state (the value the output is derived from).
+	 *
+	 * @var int|null
+	 */
+	private $rand_seed1 = null;
+
+	/**
+	 * Second element of the RAND(N) LCG state (the paired value used in the recurrence).
+	 *
+	 * @var int|null
+	 */
+	private $rand_seed2 = null;
+
+	/**
+	 * Last seed value passed to RAND(N) in the current statement.
+	 *
+	 * Used to detect whether the rand sequence is advancing with the same seed
+	 * (e.g. "SELECT RAND(3) FROM t"), or reseeding (starting a new sequence).
+	 *
+	 * @var int|null
+	 */
+	private $rand_last_seed = null;
+
+	/**
+	 * Clear any per-statement state held by the UDFs.
+	 */
+	public function flush(): void {
+		$this->rand_seed1     = null;
+		$this->rand_seed2     = null;
+		$this->rand_last_seed = null;
+	}
+
+	/**
 	 * A helper function to throw an error from SQLite expressions.
 	 *
 	 * @param string $message The error message.
@@ -167,19 +200,74 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	}
 
 	/**
-	 * Method to emulate MySQL RAND() function.
+	 * Method to emulate MySQL's seeded RAND(N) function.
 	 *
-	 * SQLite does have a random generator, but it is called RANDOM() and returns random
-	 * number between -9223372036854775808 and +9223372036854775807. So we substitute it
-	 * with PHP random generator.
+	 * Implements MySQL's deterministic LCG (Linear Congruential Generator),
+	 * producing bit-exact output for a given seed.
 	 *
-	 * This function uses mt_rand() which is four times faster than rand() and returns
-	 * the random number between 0 and 1.
+	 * Known divergences from MySQL:
 	 *
-	 * @return int
+	 *  1. In MySQL, RAND(N) behaves differently depending on whether the seed
+	 *     is constant expression or varies per invocation:
+	 *      - Constant seed (e.g. "SELECT RAND(3) FROM t"):
+	 *        LCG is initialized once per statement and advanced for each row.
+	 *      - Non-constant seed (e.g. "SELECT RAND(col) FROM t"):
+	 *        LCG is initialized for every row with its seed value.
+	 *
+	 *     A SQLite UDF cannot tell whether the seed expression is constant, so
+	 *     we just compare the seed against its last value. This diverges from
+	 *     MySQL in rare cases, and we can consider improving it in the future.
+	 *
+	 *  2. The LCG state is shared across call sites in the same query, so
+	 *     "SELECT RAND(1), RAND(1)" yields different results here than in MySQL.
+	 *     This is a rare edge case that we can consider improving in the future.
+	 *
+	 * Unseeded RAND() never reaches this function. The AST driver translates it
+	 * directly to a more efficient SQLite-native expression.
+	 *
+	 * @param int|float|string|null $seed Seed value.
+	 *
+	 * @return float A value in [0, 1).
 	 */
-	public function rand() {
-		return mt_rand( 0, 1 );
+	public function rand( $seed ) {
+		// Requires 64-bit PHP. Seed * 0x10000001 can exceed PHP_INT_MAX on 32-bit.
+		$max_value = 0x3FFFFFFF;
+
+		if ( null === $seed ) {
+			// MySQL treats NULL seed as 0.
+			$seed = 0;
+		} elseif ( ! is_int( $seed ) ) {
+			/*
+			 * MySQL rounds float values and numeric strings take the same path.
+			 * Reduce the value to a 32-bit range using "fmod" to avoid firing
+			 * the "out-of-range float to int" cast deprecation on PHP 8.1+.
+			 */
+			$seed = (int) fmod( round( (float) $seed, 0, PHP_ROUND_HALF_EVEN ), 0x100000000 );
+		}
+
+		// Initialize MySQL's internal 30-bit seeds.
+		if ( $seed !== $this->rand_last_seed ) {
+			/*
+			 * MySQL casts to uint32, and the intermediate results wrap at 32-bit
+			 * unsigned boundaries. We emulate this with & 0xFFFFFFFF masks.
+			 */
+			$seed_u32             = $seed & 0xFFFFFFFF;
+			$this->rand_seed1     = ( ( $seed_u32 * 0x10001 + 55555555 ) & 0xFFFFFFFF ) % $max_value;
+			$this->rand_seed2     = ( ( $seed_u32 * 0x10000001 ) & 0xFFFFFFFF ) % $max_value;
+			$this->rand_last_seed = $seed;
+		}
+
+		/*
+		 * MySQL's LCG recurrence:
+		 *   seed1 = (seed1 * 3 + seed2) % max_value
+		 *   seed2 = (seed1 + seed2 + 33) % max_value
+		 *
+		 * Note that seed1 is updated first and the new value is used for seed2.
+		 */
+		$this->rand_seed1 = ( $this->rand_seed1 * 3 + $this->rand_seed2 ) % $max_value;
+		$this->rand_seed2 = ( $this->rand_seed1 + $this->rand_seed2 + 33 ) % $max_value;
+
+		return (float) $this->rand_seed1 / (float) $max_value;
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -3742,13 +3742,292 @@ QUERY
 		$this->assertQuery( 'DELETE FROM _options' );
 	}
 
-	public function testTranslatesRandom() {
-		$this->assertIsNumeric(
-			$this->sqlite->query( 'SELECT RAND() AS rand' )->fetchColumn()
+	public function testRandUnseededReturnsFloatInRange() {
+		for ( $i = 0; $i < 100; $i++ ) {
+			$this->assertQuery( 'SELECT RAND() AS r' );
+			$results = $this->engine->get_query_results();
+			$value   = (float) $results[0]->r;
+			$this->assertGreaterThanOrEqual( 0.0, $value );
+			$this->assertLessThan( 1.0, $value );
+		}
+	}
+
+	public function testRandSeededProducesDeterministicValues() {
+		// MySQL reference values for RAND(0), RAND(1), RAND(5).
+		$seeds_and_expected = array(
+			0 => 0.15522042769494,
+			1 => 0.40540353712198,
+			5 => 0.40613597483014,
+		);
+		foreach ( $seeds_and_expected as $seed => $expected ) {
+			$this->assertQuery( "SELECT RAND($seed) AS r" );
+			$results = $this->engine->get_query_results();
+			$value   = (float) $results[0]->r;
+			$this->assertEqualsWithDelta( $expected, $value, 1e-12, "RAND($seed) mismatch" );
+		}
+	}
+
+	public function testRandSeededStateIsResetBetweenStatements() {
+		// Each statement must restart the sequence from its own seed, even when
+		// an intervening statement used a different seed. This pins down the
+		// per-statement flush contract.
+		$this->assertQuery( 'SELECT RAND(3) AS r' );
+		$first_of_3 = (float) $this->engine->get_query_results()[0]->r;
+
+		$this->assertQuery( 'SELECT RAND(5) AS r' );
+		$first_of_5 = (float) $this->engine->get_query_results()[0]->r;
+
+		$this->assertQuery( 'SELECT RAND(3) AS r' );
+		$first_of_3_again = (float) $this->engine->get_query_results()[0]->r;
+
+		$this->assertSame( $first_of_3, $first_of_3_again );
+		$this->assertNotSame( $first_of_3, $first_of_5 );
+	}
+
+	public function testRandSeededAndUnseededInSameQueryAreIndependent() {
+		// In MySQL, unseeded RAND() uses the thread-level random state and is
+		// independent of RAND(N) seeding. Running the same combined query
+		// twice must reproduce the seeded column exactly, and the unseeded
+		// columns must vary between runs (probability of collision is ~2^-53
+		// per pair, so a match would indicate a shared state bug, not luck).
+		$this->assertQuery( 'SELECT RAND(1) AS r1, RAND() AS r2, RAND() AS r3' );
+		$run1 = $this->engine->get_query_results()[0];
+
+		$this->assertQuery( 'SELECT RAND(1) AS r1, RAND() AS r2, RAND() AS r3' );
+		$run2 = $this->engine->get_query_results()[0];
+
+		// Seeded column is stable across runs.
+		$this->assertSame( (float) $run1->r1, (float) $run2->r1 );
+		$this->assertEqualsWithDelta( 0.40540353712198, (float) $run1->r1, 1e-12 );
+
+		// Unseeded columns vary.
+		$this->assertTrue(
+			(float) $run1->r2 !== (float) $run2->r2
+			|| (float) $run1->r3 !== (float) $run2->r3,
+			'Unseeded RAND() must vary between identical queries.'
 		);
 
-		$this->assertIsNumeric(
-			$this->sqlite->query( 'SELECT RAND(5) AS rand' )->fetchColumn()
+		// All unseeded values are in [0, 1).
+		foreach ( array( $run1->r2, $run1->r3, $run2->r2, $run2->r3 ) as $value ) {
+			$this->assertGreaterThanOrEqual( 0.0, (float) $value );
+			$this->assertLessThan( 1.0, (float) $value );
+		}
+	}
+
+	public function testRandMultiRowReturnsDifferentValues() {
+		$this->assertQuery( "INSERT INTO _options (option_name, option_value) VALUES ('a', '1'), ('b', '2'), ('c', '3')" );
+		$this->assertQuery( 'SELECT RAND() AS r FROM _options' );
+		$results = $this->engine->get_query_results();
+		$values  = array_map(
+			function ( $row ) {
+				return $row->r;
+			},
+			$results
+		);
+
+		// At least two distinct values among three rows.
+		$this->assertGreaterThan( 1, count( array_unique( $values ) ) );
+	}
+
+	public function testRandSeededMultiRowProducesDeterministicSequence() {
+		// Per the MySQL docs: with a constant seed, RAND(N) is initialized
+		// once per statement and advances on each row. Values below are
+		// from the MySQL 8.4 manual example "SELECT i, RAND(3) FROM t".
+		$this->assertQuery( "INSERT INTO _options (option_name, option_value) VALUES ('a', '1'), ('b', '2'), ('c', '3')" );
+		$this->assertQuery( 'SELECT RAND(3) AS r FROM _options' );
+		$results = $this->engine->get_query_results();
+		$this->assertCount( 3, $results );
+		$this->assertEqualsWithDelta( 0.90576975597606, (float) $results[0]->r, 1e-12 );
+		$this->assertEqualsWithDelta( 0.37307905813035, (float) $results[1]->r, 1e-12 );
+		$this->assertEqualsWithDelta( 0.14808605345719, (float) $results[2]->r, 1e-12 );
+
+		// A second identical query must restart the sequence from seed 3,
+		// not continue where the previous statement left off.
+		$this->assertQuery( 'SELECT RAND(3) AS r FROM _options' );
+		$results = $this->engine->get_query_results();
+		$this->assertEqualsWithDelta( 0.90576975597606, (float) $results[0]->r, 1e-12 );
+		$this->assertEqualsWithDelta( 0.37307905813035, (float) $results[1]->r, 1e-12 );
+		$this->assertEqualsWithDelta( 0.14808605345719, (float) $results[2]->r, 1e-12 );
+	}
+
+	public function testRandNonConstantSeedReinitializesPerRow() {
+		// Per the MySQL docs: with a non-constant seed (e.g. a column), the
+		// LCG is reinitialized for each row, so every row gets the first
+		// value of the sequence for its own seed. We verify this indirectly
+		// by comparing against RAND(seed) called from scalar subqueries.
+		$this->assertQuery( "INSERT INTO _options (option_name, option_value) VALUES ('a', '1'), ('b', '2'), ('c', '3')" );
+
+		$this->assertQuery( 'SELECT RAND(CAST(option_value AS SIGNED)) AS r FROM _options ORDER BY option_name' );
+		$per_row = $this->engine->get_query_results();
+
+		$this->assertQuery( 'SELECT RAND(1) AS r' );
+		$r1 = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(2) AS r' );
+		$r2 = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(3) AS r' );
+		$r3 = (float) $this->engine->get_query_results()[0]->r;
+
+		$this->assertEqualsWithDelta( $r1, (float) $per_row[0]->r, 1e-12 );
+		$this->assertEqualsWithDelta( $r2, (float) $per_row[1]->r, 1e-12 );
+		$this->assertEqualsWithDelta( $r3, (float) $per_row[2]->r, 1e-12 );
+	}
+
+	public function testRandOrderBy() {
+		$this->assertQuery(
+			'INSERT INTO _options (option_name, option_value) VALUES '
+			. "('a', '1'), ('b', '2'), ('c', '3'), ('d', '4'), ('e', '5')"
+		);
+
+		// Unseeded `ORDER BY RAND() LIMIT N` — the common "random sample" pattern.
+		$this->assertQuery( 'SELECT option_name FROM _options ORDER BY RAND() LIMIT 2' );
+		$rows = $this->engine->get_query_results();
+		$this->assertCount( 2, $rows );
+		foreach ( $rows as $row ) {
+			$this->assertContains( $row->option_name, array( 'a', 'b', 'c', 'd', 'e' ) );
+		}
+
+		// Seeded `ORDER BY RAND(N)` is a deterministic permutation: running the
+		// same query twice yields the same order, and every row appears once.
+		$extract = function ( $results ) {
+			return array_map(
+				function ( $row ) {
+					return $row->option_name;
+				},
+				$results
+			);
+		};
+		$this->assertQuery( 'SELECT option_name FROM _options ORDER BY RAND(1)' );
+		$first = $extract( $this->engine->get_query_results() );
+		$this->assertQuery( 'SELECT option_name FROM _options ORDER BY RAND(1)' );
+		$second = $extract( $this->engine->get_query_results() );
+		$this->assertSame( $first, $second );
+		$sorted = $first;
+		sort( $sorted );
+		$this->assertSame( array( 'a', 'b', 'c', 'd', 'e' ), $sorted );
+	}
+
+	public function testRandNullIsEquivalentToZeroSeed() {
+		// In MySQL, RAND(NULL) is equivalent to RAND(0) because val_int()
+		// on a NULL argument returns 0. Verified against MySQL 9.6.
+		$this->assertQuery( 'SELECT RAND(NULL) AS r' );
+		$this->assertEqualsWithDelta(
+			0.15522042769493574,
+			(float) $this->engine->get_query_results()[0]->r,
+			1e-12
+		);
+
+		// The same rule applies when the seed expression evaluates to NULL
+		// at runtime rather than being a literal NULL.
+		$this->assertQuery( 'SELECT RAND(NULLIF(1, 1)) AS r' );
+		$this->assertEqualsWithDelta(
+			0.15522042769493574,
+			(float) $this->engine->get_query_results()[0]->r,
+			1e-12
+		);
+	}
+
+	public function testRandFloatSeedRoundsToNearestInteger() {
+		// MySQL's val_int() on DOUBLE rounds to nearest, so RAND(3.9) is
+		// equivalent to RAND(4) and RAND(3.1) to RAND(3).
+		$this->assertQuery( 'SELECT RAND(3.9) AS r' );
+		$from_float = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(4) AS r' );
+		$from_int = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertSame( $from_int, $from_float );
+
+		$this->assertQuery( 'SELECT RAND(3.1) AS r' );
+		$from_float = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(3) AS r' );
+		$from_int = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertSame( $from_int, $from_float );
+	}
+
+	public function testRandStringSeedIsCoercedLikeMySQL() {
+		// Numeric strings are coerced through float-then-round; non-numeric
+		// strings fall back to 0, matching MySQL's val_int() semantics.
+		$this->assertQuery( "SELECT RAND('5') AS r" );
+		$from_string = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(5) AS r' );
+		$from_int = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertSame( $from_int, $from_string );
+
+		$this->assertQuery( "SELECT RAND('3.9') AS r" );
+		$from_string = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(4) AS r' );
+		$from_int = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertSame( $from_int, $from_string );
+
+		$this->assertQuery( "SELECT RAND('abc') AS r" );
+		$from_bad_string = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(0) AS r' );
+		$from_zero = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertSame( $from_zero, $from_bad_string );
+	}
+
+	public function testRandNegativeSeedIsDeterministicAndInRange() {
+		// Negative seeds fold into uint32 (matching MySQL's cast-to-uint32
+		// before the LCG init). The exact value is defined by the LCG; this
+		// test pins determinism and range, not a reference constant.
+		$this->assertQuery( 'SELECT RAND(-1) AS r' );
+		$v1 = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(-1) AS r' );
+		$v2 = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertSame( $v1, $v2 );
+		$this->assertGreaterThanOrEqual( 0.0, $v1 );
+		$this->assertLessThan( 1.0, $v1 );
+	}
+
+	public function testRandMultipleCallSitesShareLcgState() {
+		// Documented divergence from MySQL: each Item_func_rand in MySQL
+		// owns its own LCG state, so `SELECT RAND(1), RAND(1)` returns
+		// (v, v). This UDF keeps a single per-connection state, so the
+		// second call advances the shared stream and returns the next
+		// value. Pin the current behavior so any future change is explicit.
+		$this->assertQuery( 'SELECT RAND(1) AS a, RAND(1) AS b' );
+		$row = $this->engine->get_query_results()[0];
+		$this->assertEqualsWithDelta( 0.40540353712198, (float) $row->a, 1e-12 );
+		$this->assertNotEquals( (float) $row->a, (float) $row->b );
+		$this->assertGreaterThanOrEqual( 0.0, (float) $row->b );
+		$this->assertLessThan( 1.0, (float) $row->b );
+	}
+
+	public function testRandSeededResetsAcrossStatementsInsideTransaction() {
+		// The per-statement flush contract must hold inside a transaction.
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'SELECT RAND(1) AS r' );
+		$a = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'SELECT RAND(1) AS r' );
+		$b = (float) $this->engine->get_query_results()[0]->r;
+		$this->assertQuery( 'COMMIT' );
+		$this->assertSame( $a, $b );
+		$this->assertEqualsWithDelta( 0.40540353712198, $a, 1e-12 );
+	}
+
+	public function testRandInWhereClauseRuns() {
+		$this->assertQuery( "INSERT INTO _options (option_name, option_value) VALUES ('a', '1'), ('b', '2'), ('c', '3')" );
+		// Sanity: a predicate that is always true / always false.
+		$this->assertQuery( 'SELECT COUNT(*) AS c FROM _options WHERE RAND() < 2' );
+		$this->assertSame( 3, (int) $this->engine->get_query_results()[0]->c );
+		$this->assertQuery( 'SELECT COUNT(*) AS c FROM _options WHERE RAND() > 2' );
+		$this->assertSame( 0, (int) $this->engine->get_query_results()[0]->c );
+	}
+
+	public function testRandInUpdateAndInsert() {
+		$this->assertQuery( "INSERT INTO _options (option_name, option_value) VALUES ('a', '0')" );
+		$this->assertQuery( "UPDATE _options SET option_value = RAND(1) WHERE option_name = 'a'" );
+		$this->assertQuery( "SELECT option_value FROM _options WHERE option_name = 'a'" );
+		$this->assertEqualsWithDelta(
+			0.40540353712198,
+			(float) $this->engine->get_query_results()[0]->option_value,
+			1e-12
+		);
+
+		$this->assertQuery( "INSERT INTO _options (option_name, option_value) VALUES ('b', RAND(1))" );
+		$this->assertQuery( "SELECT option_value FROM _options WHERE option_name = 'b'" );
+		$this->assertEqualsWithDelta(
+			0.40540353712198,
+			(float) $this->engine->get_query_results()[0]->option_value,
+			1e-12
 		);
 	}
 
@@ -9093,14 +9372,13 @@ END;
 					'mysqli:type'      => 8,
 				),
 				array(
-					// TODO: Fix custom "RAND()" function to behave like in MySQL.
-					'native_type'      => 'LONGLONG',          // DOUBLE in MySQL.
-					'pdo_type'         => PDO::PARAM_INT,      // PARAM_STR in MySQL.
+					'native_type'      => 'DOUBLE',
+					'pdo_type'         => PDO::PARAM_STR,
 					'flags'            => array( 'not_null' ),
 					'table'            => '',
 					'name'             => 'col_expr_19',
-					'len'              => 21,                  // 23 in MySQL.
-					'precision'        => 0,                   // 31 in MySQL.
+					'len'              => 23,
+					'precision'        => 31,
 					'sqlite:decl_type' => '',
 
 					// Additional MySQLi metadata.
@@ -9109,7 +9387,7 @@ END;
 					'mysqli:db'        => 'wp',
 					'mysqli:charsetnr' => 63,
 					'mysqli:flags'     => 0, // 32769 in MySQL.
-					'mysqli:type'      => 8, // 5 in MySQL.
+					'mysqli:type'      => 5,
 				),
 				array(
 					'native_type'      => 'LONGLONG',


### PR DESCRIPTION
## Summary

Replaces the old `mt_rand(0, 1)` stub — which returned an integer 0 or 1, not a float in `[0, 1)` as MySQL requires — with MySQL-compatible `RAND()` behavior.

Replaces #341.

## Unseeded `RAND()`

Compiles to a native SQLite expression:

```sql
((RANDOM() & 0x001FFFFFFFFFFFFF) / 9007199254740992.0)
```

The 53-bit mask matches the IEEE 754 double mantissa, so division by 2^53 is exact and strictly less than 1.0. Matches MySQL, where unseeded `RAND()` uses a thread-level state independent of `RAND(N)`.

## Seeded `RAND(N)`

Routes through a PHP UDF implementing MySQL's exact LCG from `my_rnd_init()` / `my_rnd()` (`sql/item_func.cc`, `mysys/my_rnd.cc`), bit-exact against MySQL 9.6. Requires 64-bit PHP.

Seed handling matches `val_int()`: `NULL` becomes 0, floats round to nearest (`RAND(3.9) == RAND(4)`), numeric strings follow the same path.

## Known divergences

- MySQL distinguishes constant vs non-constant seeds at parse time (constant = init once per statement, non-constant = reinit per row). A SQLite UDF can't see the expression, so we approximate by reinitializing only when the seed value changes. This diverges when a non-constant expression yields a stable value.
- The UDF keeps one LCG state per connection, so multiple `RAND(N)` call sites in one query share a stream: `SELECT RAND(1), RAND(1)` returns `(v1, v2)` here vs `(v, v)` in MySQL.

Both are documented in the `rand()` docblock.

## Metadata

`RAND()` column metadata is now reported as `DOUBLE` / `PARAM_STR`, removing a long-standing TODO.

## Test plan
- [ ] CI green.
- [ ] Bit-exact reference values against MySQL 9.6 (seeds 0, 1, 3, 5, and multi-row sequences).
- [ ] NULL, float, numeric/non-numeric string, and negative seed handling.
- [ ] `RAND()` in `WHERE`, `UPDATE`, `INSERT`, `ORDER BY` (`LIMIT` + seeded deterministic permutation).
- [ ] Per-statement flush contract inside a transaction.