### PR TITLE
Add support for `DELETE` with `LIMIT` and `ORDER BY`

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -2308,6 +2308,38 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			throw $this->new_access_denied_to_information_schema_exception();
 		}
 
+		/*
+		 * SQLite doesn't support DELETE with ORDER BY/LIMIT.
+		 * We need to use a subquery to emulate this behavior.
+		 *
+		 * For instance, the following query:
+		 *   DELETE FROM t WHERE c = 2 LIMIT 1;
+		 * Will be rewritten to:
+		 *   DELETE FROM t WHERE rowid IN ( SELECT rowid FROM t WHERE c = 2 LIMIT 1 );
+		 */
+		$has_order = $node->has_child_node( 'orderClause' );
+		$has_limit = $node->has_child_node( 'simpleLimitClause' );
+		if ( $has_order || $has_limit ) {
+			$where_subquery = 'SELECT rowid FROM ' . $this->translate_sequence(
+				array(
+					$table_ref,
+					$node->get_first_child_node( 'tableAlias' ),
+					$node->get_first_child_node( 'whereClause' ),
+					$node->get_first_child_node( 'orderClause' ),
+					$node->get_first_child_node( 'simpleLimitClause' ),
+				)
+			);
+
+			$query = sprintf(
+				'DELETE FROM %s WHERE rowid IN ( %s )',
+				$this->translate( $table_ref ),
+				$where_subquery
+			);
+
+			$this->last_result_statement = $this->execute_sqlite_query( $query );
+			return;
+		}
+
 		$query                       = $this->translate( $node );
 		$this->last_result_statement = $this->execute_sqlite_query( $query );
 	}

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -222,6 +222,64 @@ class WP_SQLite_Driver_Tests extends TestCase {
 		$this->assertEquals( '2003-05-27 10:08:48', $result2[0]->option_value );
 	}
 
+	public function testDeleteWithLimit() {
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('first', '2003-05-27 00:00:45')"
+		);
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('second', '2003-05-28 00:00:45')"
+		);
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('third', '2003-05-29 00:00:45')"
+		);
+
+		// LIMIT only: only one row is removed even though WHERE matches every row.
+		$result = $this->assertQuery( "DELETE FROM _dates WHERE option_name LIKE '%' LIMIT 1" );
+		$this->assertSame( 1, $result );
+
+		$rows = $this->engine->query( 'SELECT option_name FROM _dates ORDER BY option_name' );
+		$this->assertCount( 2, $rows );
+
+		// ORDER BY + LIMIT: deletes the lexicographically-first remaining row.
+		$result = $this->assertQuery( 'DELETE FROM _dates ORDER BY option_name ASC LIMIT 1' );
+		$this->assertSame( 1, $result );
+
+		$rows = $this->engine->query( 'SELECT option_name FROM _dates' );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'third', $rows[0]->option_name );
+	}
+
+	public function testDeleteWithoutWhereButWithLimit() {
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('first', '2003-05-27 10:08:48')"
+		);
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('second', '2003-05-27 10:08:48')"
+		);
+
+		$result = $this->assertQuery( 'DELETE FROM _dates LIMIT 1' );
+		$this->assertSame( 1, $result );
+
+		$rows = $this->engine->query( 'SELECT option_name FROM _dates' );
+		$this->assertCount( 1, $rows );
+	}
+
+	public function testDeleteWithAliasAndLimit() {
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('a', '2003-05-27 00:00:45')"
+		);
+		$this->assertQuery(
+			"INSERT INTO _dates (option_name, option_value) VALUES ('b', '2003-05-28 00:00:45')"
+		);
+
+		$result = $this->assertQuery( "DELETE FROM _dates AS d WHERE d.option_name = 'a' LIMIT 1" );
+		$this->assertSame( 1, $result );
+
+		$rows = $this->engine->query( 'SELECT option_name FROM _dates' );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'b', $rows[0]->option_name );
+	}
+
 	public function testCastAsBinary() {
 		$this->assertQuery(
 			// Use a confusing alias to make sure it replaces only the correct token

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -382,6 +382,36 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 			'DELETE FROM `t` WHERE `c` = 1',
 			'DELETE FROM t WHERE c = 1'
 		);
+
+		// DELETE with LIMIT.
+		$this->assertQuery(
+			'DELETE FROM `t` WHERE rowid IN ( SELECT rowid FROM `t` LIMIT 1 )',
+			'DELETE FROM t LIMIT 1'
+		);
+
+		// DELETE with WHERE and LIMIT.
+		$this->assertQuery(
+			'DELETE FROM `t` WHERE rowid IN ( SELECT rowid FROM `t` WHERE `c` = 1 LIMIT 5 )',
+			'DELETE FROM t WHERE c = 1 LIMIT 5'
+		);
+
+		// DELETE with ORDER BY and LIMIT.
+		$this->assertQuery(
+			'DELETE FROM `t` WHERE rowid IN ( SELECT rowid FROM `t` ORDER BY `c` ASC LIMIT 1 )',
+			'DELETE FROM t ORDER BY c ASC LIMIT 1'
+		);
+
+		// DELETE with WHERE, ORDER BY, and LIMIT.
+		$this->assertQuery(
+			'DELETE FROM `t` WHERE rowid IN ( SELECT rowid FROM `t` WHERE `c` = 1 ORDER BY `c` ASC LIMIT 1 )',
+			'DELETE FROM t WHERE c = 1 ORDER BY c ASC LIMIT 1'
+		);
+
+		// DELETE with a table alias and LIMIT.
+		$this->assertQuery(
+			'DELETE FROM `t` WHERE rowid IN ( SELECT rowid FROM `t` AS `a` WHERE `a`.`c` = 1 LIMIT 1 )',
+			'DELETE FROM t AS a WHERE a.c = 1 LIMIT 1'
+		);
 	}
 
 	public function testCreateTable(): void {


### PR DESCRIPTION
## Summary

Adds support for single-table `DELETE` statements with `ORDER BY` and/or `LIMIT` clauses, which SQLite rejects as a syntax error unless it was compiled with `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` (not the case for standard builds, including the one bundled with WordPress Playground).

The fix mirrors the existing `UPDATE` LIMIT rewrite: when `ORDER BY` or `LIMIT` is present, the statement is translated to drive deletion off a `rowid` subquery.

```sql
-- MySQL
DELETE FROM t WHERE c = 1 ORDER BY c LIMIT 10

-- Translated SQLite
DELETE FROM `t` WHERE rowid IN (
    SELECT rowid FROM `t` WHERE `c` = 1 ORDER BY `c` ASC LIMIT 10
)
```

The subquery forwards `tableRef`, `tableAlias`, `whereClause`, `orderClause`, and `simpleLimitClause`, so queries that reference an aliased table keep the alias in scope inside the subquery (e.g. `DELETE FROM t AS a WHERE a.c = 1 LIMIT 1` works).

## Scope

- **In scope:** single-table `DELETE` with `ORDER BY`, `LIMIT`, or both — with or without `WHERE` and alias.
- **Out of scope:** multi-table `DELETE` — MySQL's grammar disallows `ORDER BY`/`LIMIT` there, so there's nothing to add.

## Tests

- Translation tests covering plain `LIMIT`, `WHERE` + `LIMIT`, `ORDER BY` + `LIMIT`, `WHERE` + `ORDER BY` + `LIMIT`, and alias + `WHERE` + `LIMIT`.
- Runtime tests that insert rows, run `DELETE ... LIMIT` through the driver, and assert on the surviving rows — including a case that matches multiple rows to verify `LIMIT` is actually enforced, and an alias case.

Fixes #100