### PR TITLE
[codex] Speed up MySQL lexing and parsing

### DIFF
--- a/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-lexer.php
+++ b/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-lexer.php
@@ -2112,6 +2112,13 @@ class WP_MySQL_Lexer {
 	private $sql;
 
 	/**
+	 * Byte length of the SQL payload.
+	 *
+	 * @var int
+	 */
+	private $sql_length;
+
+	/**
 	 * The version of the MySQL server that the SQL payload is intended for.
 	 *
 	 * This is used to determine which tokens are valid for the given MySQL
@@ -2189,6 +2196,7 @@ class WP_MySQL_Lexer {
 		array $sql_modes = array()
 	) {
 		$this->sql           = $sql;
+		$this->sql_length    = strlen( $sql );
 		$this->mysql_version = $mysql_version;
 
 		foreach ( $sql_modes as $sql_mode ) {
@@ -2284,10 +2292,46 @@ class WP_MySQL_Lexer {
 	 * @return WP_MySQL_Token[] An array of token objects representing the remaining tokens.
 	 */
 	public function remaining_tokens(): array {
-		$tokens = array();
-		while ( true === $this->next_token() ) {
-			$token    = $this->get_token();
-			$tokens[] = $token;
+		$tokens                            = array();
+		$no_backslash_escapes_sql_mode_set = $this->is_sql_mode_active(
+			self::SQL_MODE_NO_BACKSLASH_ESCAPES
+		);
+
+		while ( true ) {
+			if (
+				self::EOF === $this->token_type
+				|| ( null === $this->token_type && $this->bytes_already_read > 0 )
+			) {
+				$this->token_type = null;
+				break;
+			}
+
+			do {
+				$this->token_starts_at = $this->bytes_already_read;
+				$this->token_type      = $this->read_next_token();
+			} while (
+				self::WHITESPACE === $this->token_type
+				|| self::COMMENT === $this->token_type
+				|| self::MYSQL_COMMENT_START === $this->token_type
+				|| self::MYSQL_COMMENT_END === $this->token_type
+			);
+
+			if ( null === $this->token_type ) {
+				break;
+			}
+
+			$tokens[] = new WP_MySQL_Token(
+				$this->token_type,
+				$this->token_starts_at,
+				$this->bytes_already_read - $this->token_starts_at,
+				$this->sql,
+				$no_backslash_escapes_sql_mode_set
+			);
+
+			if ( self::EOF === $this->token_type ) {
+				$this->token_type = null;
+				break;
+			}
 		}
 		return $tokens;
 	}
@@ -2356,10 +2400,10 @@ class WP_MySQL_Lexer {
 
 		if ( "'" === $byte || '"' === $byte || '`' === $byte ) {
 			$type = $this->read_quoted_text();
-		} elseif ( null !== $byte && strspn( $byte, self::DIGIT_MASK ) > 0 ) {
+		} elseif ( null !== $byte && $byte >= '0' && $byte <= '9' ) {
 			$type = $this->read_number();
 		} elseif ( '.' === $byte ) {
-			if ( null !== $next_byte && strspn( $next_byte, self::DIGIT_MASK ) > 0 ) {
+			if ( null !== $next_byte && $next_byte >= '0' && $next_byte <= '9' ) {
 				$type = $this->read_number();
 			} else {
 				$this->bytes_already_read += 1;
@@ -2420,8 +2464,8 @@ class WP_MySQL_Lexer {
 		} elseif ( '-' === $byte ) {
 			if (
 				'-' === $next_byte
-				&& $this->bytes_already_read + 2 < strlen( $this->sql )
-				&& strspn( $this->sql[ $this->bytes_already_read + 2 ], self::WHITESPACE_MASK ) > 0
+				&& $this->bytes_already_read + 2 < $this->sql_length
+				&& false !== strpos( self::WHITESPACE_MASK, $this->sql[ $this->bytes_already_read + 2 ] )
 			) {
 				$type = $this->read_line_comment();
 			} elseif ( '>' === $next_byte ) {
@@ -2547,7 +2591,13 @@ class WP_MySQL_Lexer {
 			}
 		} elseif ( '#' === $byte ) {
 			$type = $this->read_line_comment();
-		} elseif ( null !== $byte && strspn( $byte, self::WHITESPACE_MASK ) > 0 ) {
+		} elseif (
+			' ' === $byte
+			|| "\t" === $byte
+			|| "\n" === $byte
+			|| "\r" === $byte
+			|| "\f" === $byte
+		) {
 			$this->bytes_already_read += strspn( $this->sql, self::WHITESPACE_MASK, $this->bytes_already_read );
 			$type                      = self::WHITESPACE;
 		} elseif ( ( 'x' === $byte || 'X' === $byte || 'b' === $byte || 'B' === $byte ) && "'" === $next_byte ) {
@@ -2675,7 +2725,7 @@ class WP_MySQL_Lexer {
 				'0' === $byte
 				&& 'x' === $next_byte
 				&& null !== $third_byte
-				&& strspn( $third_byte, self::HEX_DIGIT_MASK ) > 0
+				&& false !== strpos( self::HEX_DIGIT_MASK, $third_byte )
 			)
 			// HEX number in the form of x'N' or X'N'.
 			|| ( ( 'x' === $byte || 'X' === $byte ) && "'" === $next_byte )
@@ -2685,7 +2735,7 @@ class WP_MySQL_Lexer {
 			$this->bytes_already_read += strspn( $this->sql, self::HEX_DIGIT_MASK, $this->bytes_already_read );
 			if ( $is_quoted ) {
 				if (
-					$this->bytes_already_read >= strlen( $this->sql )
+					$this->bytes_already_read >= $this->sql_length
 					|| "'" !== $this->sql[ $this->bytes_already_read ]
 				) {
 					return null; // Invalid input.
@@ -2708,7 +2758,7 @@ class WP_MySQL_Lexer {
 			$this->bytes_already_read += strspn( $this->sql, '01', $this->bytes_already_read );
 			if ( $is_quoted ) {
 				if (
-					$this->bytes_already_read >= strlen( $this->sql )
+					$this->bytes_already_read >= $this->sql_length
 					|| "'" !== $this->sql[ $this->bytes_already_read ]
 				) {
 					return null; // Invalid input.
@@ -2737,11 +2787,12 @@ class WP_MySQL_Lexer {
 				( 'e' === $byte || 'E' === $byte )
 				&& null !== $next_byte
 				&& (
-					strspn( $next_byte, self::DIGIT_MASK ) > 0
+					( $next_byte >= '0' && $next_byte <= '9' )
 					|| (
 						( '+' === $next_byte || '-' === $next_byte )
-						&& $this->bytes_already_read + 2 < strlen( $this->sql )
-						&& strspn( $this->sql[ $this->bytes_already_read + 2 ], self::DIGIT_MASK ) > 0
+						&& $this->bytes_already_read + 2 < $this->sql_length
+						&& $this->sql[ $this->bytes_already_read + 2 ] >= '0'
+						&& $this->sql[ $this->bytes_already_read + 2 ] <= '9'
 					)
 				);
 			if ( $has_exponent ) {
@@ -2840,7 +2891,11 @@ class WP_MySQL_Lexer {
 		// in which case the escape sequence is consumed and the loop continues.
 		$at = $this->bytes_already_read;
 		while ( true ) {
-			$at += strcspn( $this->sql, $quote, $at );
+			$quote_at = strpos( $this->sql, $quote, $at );
+			if ( false === $quote_at ) {
+				return null; // Invalid input.
+			}
+			$at = $quote_at;
 
 			/*
 			 * By default, quotes can be escaped with a "\".
@@ -2852,16 +2907,14 @@ class WP_MySQL_Lexer {
 			 * "\\\" is an escaped backslash and an escape sequence, and so on.
 			 */
 			if ( ! $no_backslash_escapes ) {
-				for ($i = 0; '\\' === $this->sql[ $at - $i - 1 ]; $i += 1);
+				$i = 0;
+				while ( '\\' === ( $this->sql[ $at - $i - 1 ] ?? null ) ) {
+					$i += 1;
+				}
 				if ( 1 === $i % 2 ) {
 					$at += 1;
 					continue;
 				}
-			}
-
-			// Unclosed string - unexpected EOF.
-			if ( ( $this->sql[ $at ] ?? null ) !== $quote ) {
-				return null; // Invalid input.
 			}
 
 			// Check if the quote is doubled.
@@ -2922,17 +2975,11 @@ class WP_MySQL_Lexer {
 	}
 
 	private function read_comment_content(): void {
-		while ( true ) {
-			$this->bytes_already_read += strcspn( $this->sql, '*', $this->bytes_already_read );
-			$this->bytes_already_read += 1; // Consume the '*'.
-			$byte                      = $this->sql[ $this->bytes_already_read ] ?? null;
-			if ( null === $byte ) {
-				break;
-			}
-			if ( '/' === $byte ) {
-				$this->bytes_already_read += 1; // Consume the '/'.
-				break;
-			}
+		$comment_end = strpos( $this->sql, '*/', $this->bytes_already_read );
+		if ( false === $comment_end ) {
+			$this->bytes_already_read = $this->sql_length;
+		} else {
+			$this->bytes_already_read = $comment_end + 2;
 		}
 	}
 

--- a/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-token.php
+++ b/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-token.php
@@ -30,7 +30,10 @@ class WP_MySQL_Token extends WP_Parser_Token {
 		string $input,
 		bool $sql_mode_no_backslash_escapes_enabled
 	) {
-		parent::__construct( $id, $start, $length, $input );
+		$this->id     = $id;
+		$this->start  = $start;
+		$this->length = $length;
+		$this->input  = $input;
 		$this->sql_mode_no_backslash_escapes_enabled = $sql_mode_no_backslash_escapes_enabled;
 	}
 

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
@@ -29,11 +29,11 @@ class WP_Parser_Grammar {
 	public $rules;
 	public $rule_names;
 	public $fragment_ids;
-	public $lookahead_is_match_possible = array();
 	public $branch_candidates           = array();
 	public $lowest_non_terminal_id;
 	public $highest_terminal_id;
 	private $rule_ids_by_name = array();
+	private static $lookahead_table_cache = array();
 
 	public function __construct( array $rules ) {
 		$this->inflate( $rules );
@@ -88,13 +88,41 @@ class WP_Parser_Grammar {
 			$this->rules[ $rule_id ] = $branches;
 		}
 
-		$this->compute_lookahead_tables();
+		$lookahead_cache_key = $this->get_lookahead_cache_key( $grammar );
+		if ( isset( self::$lookahead_table_cache[ $lookahead_cache_key ] ) ) {
+			$this->branch_candidates = self::$lookahead_table_cache[ $lookahead_cache_key ];
+		} else {
+			$this->branch_candidates = $this->compute_branch_candidates();
+			self::$lookahead_table_cache[ $lookahead_cache_key ] = $this->branch_candidates;
+		}
 	}
 
 	/**
-	 * Compute FIRST-set lookahead tables for rules and individual branches.
+	 * Get a stable cache key for the compressed grammar.
 	 */
-	private function compute_lookahead_tables(): void {
+	private function get_lookahead_cache_key( array $grammar ): string {
+		$hash = hash_init( 'md5' );
+
+		hash_update( $hash, (string) $grammar['rules_offset'] );
+
+		foreach ( $grammar['rules_names'] as $rule_name ) {
+			hash_update( $hash, "\0n" . $rule_name );
+		}
+
+		foreach ( $grammar['grammar'] as $branches ) {
+			hash_update( $hash, "\0r" );
+			foreach ( $branches as $branch ) {
+				hash_update( $hash, "\0b" . implode( ',', $branch ) );
+			}
+		}
+
+		return hash_final( $hash );
+	}
+
+	/**
+	 * Compute FIRST-set branch candidates.
+	 */
+	private function compute_branch_candidates(): array {
 		$first_sets = array();
 		foreach ( $this->rules as $rule_id => $_branches ) {
 			$first_sets[ $rule_id ] = array();
@@ -115,32 +143,36 @@ class WP_Parser_Grammar {
 			}
 		} while ( $changed );
 
-		$this->lookahead_is_match_possible = $first_sets;
-
+		$branch_candidates = array();
 		foreach ( $this->rules as $rule_id => $branches ) {
-			$this->branch_candidates[ $rule_id ] = array();
+			$branch_candidates[ $rule_id ] = array();
 			foreach ( $branches as $branch_index => $branch ) {
 				$branch_first = $this->get_branch_first_set(
 					$branch,
 					$first_sets
 				);
 				foreach ( $branch_first as $token_id => $_ ) {
-					$this->branch_candidates[ $rule_id ][ $token_id ][] = $branch_index;
+					$branch_candidates[ $rule_id ][ $token_id ][] = $branch_index;
 				}
 			}
-			if ( isset( $this->branch_candidates[ $rule_id ][ self::EMPTY_RULE_ID ] ) ) {
-				$empty_branches = $this->branch_candidates[ $rule_id ][ self::EMPTY_RULE_ID ];
-				foreach ( $this->branch_candidates[ $rule_id ] as $token_id => $branch_indexes ) {
+			if ( isset( $branch_candidates[ $rule_id ][ self::EMPTY_RULE_ID ] ) ) {
+				$empty_branches = $branch_candidates[ $rule_id ][ self::EMPTY_RULE_ID ];
+				foreach ( $branch_candidates[ $rule_id ] as $token_id => $branch_indexes ) {
 					if ( self::EMPTY_RULE_ID === $token_id ) {
 						continue;
 					}
-					$this->branch_candidates[ $rule_id ][ $token_id ] = $this->merge_branch_indexes(
+					$branch_candidates[ $rule_id ][ $token_id ] = $this->merge_branch_indexes(
 						$branch_indexes,
 						$empty_branches
 					);
 				}
 			}
+			foreach ( $branch_candidates[ $rule_id ] as $token_id => $branch_indexes ) {
+				$branch_candidates[ $rule_id ][ $token_id ] = $this->compact_branch_indexes( $branch_indexes );
+			}
 		}
+
+		return $branch_candidates;
 	}
 
 	/**
@@ -185,6 +217,19 @@ class WP_Parser_Grammar {
 		}
 
 		return $branch_first;
+	}
+
+	/**
+	 * Compact branch indexes when there is only one candidate.
+	 *
+	 * @param int[] $branch_indexes Branch indexes to pack.
+	 * @return int|int[] Branch index, or branch indexes when there are multiple candidates.
+	 */
+	private function compact_branch_indexes( array $branch_indexes ) {
+		if ( 1 === count( $branch_indexes ) ) {
+			return $branch_indexes[0];
+		}
+		return $branch_indexes;
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
@@ -30,8 +30,10 @@ class WP_Parser_Grammar {
 	public $rule_names;
 	public $fragment_ids;
 	public $lookahead_is_match_possible = array();
+	public $branch_candidates           = array();
 	public $lowest_non_terminal_id;
 	public $highest_terminal_id;
+	private $rule_ids_by_name = array();
 
 	public function __construct( array $rules ) {
 		$this->inflate( $rules );
@@ -42,7 +44,7 @@ class WP_Parser_Grammar {
 	}
 
 	public function get_rule_id( $rule_name ) {
-		return array_search( $rule_name, $this->rule_names, true );
+		return $this->rule_ids_by_name[ $rule_name ] ?? false;
 	}
 
 	/**
@@ -58,6 +60,7 @@ class WP_Parser_Grammar {
 		foreach ( $grammar['rules_names'] as $rule_index => $rule_name ) {
 			$this->rule_names[ $rule_index + $grammar['rules_offset'] ] = $rule_name;
 			$this->rules[ $rule_index + $grammar['rules_offset'] ]      = array();
+			$this->rule_ids_by_name[ $rule_name ]                       = $rule_index + $grammar['rules_offset'];
 
 			/**
 			 * Treat all intermediate rules as fragments to inline before returning
@@ -85,55 +88,140 @@ class WP_Parser_Grammar {
 			$this->rules[ $rule_id ] = $branches;
 		}
 
-		/**
-		 * Compute a rule => [token => true] lookup table for each rule
-		 * that starts with a terminal OR with another rule that already
-		 * has a lookahead mapping.
-		 *
-		 * This is similar to left-factoring the grammar, even if not quite
-		 * the same.
-		 *
-		 * This enables us to quickly bail out from checking branches that
-		 * cannot possibly match the current token. This increased the parser
-		 * speed by a whopping 80%!
-		 *
-		 * @TODO: Explore these possible next steps:
-		 *
-		 * * Compute a rule => [token => branch[]] list lookup table and only
-		 *   process the branches that have a chance of matching the current token.
-		 * * Actually left-factor the grammar as much as possible. This, however,
-		 *   could inflate the serialized grammar size.
-		 */
-		// 5 iterations seem to give us all the speed gains we can get from this.
-		for ( $i = 0; $i < 5; $i++ ) {
-			foreach ( $grammar['grammar'] as $rule_index => $branches ) {
-				$rule_id = $rule_index + $grammar['rules_offset'];
-				if ( isset( $this->lookahead_is_match_possible[ $rule_id ] ) ) {
-					continue;
-				}
-				$rule_lookup                                   = array();
-				$first_symbol_can_be_expanded_to_all_terminals = true;
-				foreach ( $branches as $branch ) {
-					$terminals                   = false;
-					$branch_starts_with_terminal = $branch[0] < $this->lowest_non_terminal_id;
-					if ( $branch_starts_with_terminal ) {
-						$terminals = array( $branch[0] );
-					} elseif ( isset( $this->lookahead_is_match_possible[ $branch[0] ] ) ) {
-						$terminals = array_keys( $this->lookahead_is_match_possible[ $branch[0] ] );
-					}
+		$this->compute_lookahead_tables();
+	}
 
-					if ( false === $terminals ) {
-						$first_symbol_can_be_expanded_to_all_terminals = false;
-						break;
-					}
-					foreach ( $terminals as $terminal ) {
-						$rule_lookup[ $terminal ] = true;
+	/**
+	 * Compute FIRST-set lookahead tables for rules and individual branches.
+	 */
+	private function compute_lookahead_tables(): void {
+		$first_sets = array();
+		foreach ( $this->rules as $rule_id => $_branches ) {
+			$first_sets[ $rule_id ] = array();
+		}
+
+		do {
+			$changed = false;
+			foreach ( $this->rules as $rule_id => $branches ) {
+				foreach ( $branches as $branch ) {
+					$branch_first = $this->get_branch_first_set( $branch, $first_sets );
+					foreach ( $branch_first as $token_id => $_ ) {
+						if ( ! isset( $first_sets[ $rule_id ][ $token_id ] ) ) {
+							$first_sets[ $rule_id ][ $token_id ] = true;
+							$changed                             = true;
+						}
 					}
 				}
-				if ( $first_symbol_can_be_expanded_to_all_terminals ) {
-					$this->lookahead_is_match_possible[ $rule_id ] = $rule_lookup;
+			}
+		} while ( $changed );
+
+		$this->lookahead_is_match_possible = $first_sets;
+
+		foreach ( $this->rules as $rule_id => $branches ) {
+			$this->branch_candidates[ $rule_id ] = array();
+			foreach ( $branches as $branch_index => $branch ) {
+				$branch_first = $this->get_branch_first_set(
+					$branch,
+					$first_sets
+				);
+				foreach ( $branch_first as $token_id => $_ ) {
+					$this->branch_candidates[ $rule_id ][ $token_id ][] = $branch_index;
+				}
+			}
+			if ( isset( $this->branch_candidates[ $rule_id ][ self::EMPTY_RULE_ID ] ) ) {
+				$empty_branches = $this->branch_candidates[ $rule_id ][ self::EMPTY_RULE_ID ];
+				foreach ( $this->branch_candidates[ $rule_id ] as $token_id => $branch_indexes ) {
+					if ( self::EMPTY_RULE_ID === $token_id ) {
+						continue;
+					}
+					$this->branch_candidates[ $rule_id ][ $token_id ] = $this->merge_branch_indexes(
+						$branch_indexes,
+						$empty_branches
+					);
 				}
 			}
 		}
+	}
+
+	/**
+	 * Compute the FIRST set for a single branch.
+	 *
+	 * @param int[] $branch     A sequence of terminal and non-terminal rule IDs.
+	 * @param array $first_sets Already-known FIRST sets for non-terminals.
+	 * @return array<int, true> Token IDs that can start the branch.
+	 */
+	private function get_branch_first_set( array $branch, array $first_sets ): array {
+		$branch_first  = array();
+		$allows_empty  = true;
+		$branch_length = count( $branch );
+
+		for ( $i = 0; $i < $branch_length; $i++ ) {
+			$symbol = $branch[ $i ];
+
+			if ( $symbol <= $this->highest_terminal_id ) {
+				if ( self::EMPTY_RULE_ID !== $symbol ) {
+					$branch_first[ $symbol ] = true;
+					$allows_empty            = false;
+					break;
+				}
+				continue;
+			}
+
+			$symbol_first = $first_sets[ $symbol ] ?? array();
+			foreach ( $symbol_first as $token_id => $_ ) {
+				if ( self::EMPTY_RULE_ID !== $token_id ) {
+					$branch_first[ $token_id ] = true;
+				}
+			}
+
+			if ( ! isset( $symbol_first[ self::EMPTY_RULE_ID ] ) ) {
+				$allows_empty = false;
+				break;
+			}
+		}
+
+		if ( $allows_empty ) {
+			$branch_first[ self::EMPTY_RULE_ID ] = true;
+		}
+
+		return $branch_first;
+	}
+
+	/**
+	 * Merge two branch-index lists while preserving grammar order.
+	 *
+	 * @param int[] $left  First sorted branch-index list.
+	 * @param int[] $right Second sorted branch-index list.
+	 * @return int[] Merged sorted branch-index list.
+	 */
+	private function merge_branch_indexes( array $left, array $right ): array {
+		$merged      = array();
+		$left_index  = 0;
+		$right_index = 0;
+		$left_count  = count( $left );
+		$right_count = count( $right );
+
+		while ( $left_index < $left_count || $right_index < $right_count ) {
+			if (
+				$right_index >= $right_count ||
+				(
+					$left_index < $left_count &&
+					$left[ $left_index ] < $right[ $right_index ]
+				)
+			) {
+				$merged[] = $left[ $left_index++ ];
+			} elseif (
+				$left_index >= $left_count ||
+				$right[ $right_index ] < $left[ $left_index ]
+			) {
+				$merged[] = $right[ $right_index++ ];
+			} else {
+				$merged[] = $left[ $left_index ];
+				++$left_index;
+				++$right_index;
+			}
+		}
+
+		return $merged;
 	}
 }

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-token.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-token.php
@@ -35,7 +35,7 @@ class WP_Parser_Token {
 	 *
 	 * @var string
 	 */
-	private $input;
+	protected $input;
 
 	/**
 	 * Constructor.

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
@@ -12,6 +12,7 @@ class WP_Parser {
 	protected $grammar;
 	protected $tokens;
 	protected $position;
+	private $token_ids;
 	private $rules;
 	private $rule_names;
 	private $fragment_ids;
@@ -35,6 +36,10 @@ class WP_Parser {
 		$this->highest_terminal_id         = $this->grammar->highest_terminal_id;
 		$this->select_statement_rule_id    = $this->grammar->get_rule_id( 'selectStatement' );
 		$this->token_count                 = count( $this->tokens );
+		$this->token_ids                   = array();
+		foreach ( $this->tokens as $token ) {
+			$this->token_ids[] = $token->id;
+		}
 		$this->failed_matches              = array();
 
 		// @TODO: Make the starting rule lookup non-grammar-specific.
@@ -54,7 +59,7 @@ class WP_Parser {
 				return true;
 			}
 
-			if ( $this->tokens[ $this->position ]->id === $rule_id ) {
+			if ( $this->token_ids[ $this->position ] === $rule_id ) {
 				return $this->tokens[ $this->position++ ];
 			}
 			return false;
@@ -68,7 +73,7 @@ class WP_Parser {
 		$branches          = $this->rules[ $rule_id ];
 
 		$token_id = $this->position < $this->token_count
-			? $this->tokens[ $this->position ]->id
+			? $this->token_ids[ $this->position ]
 			: null;
 		$rule_name          = $this->rule_names[ $rule_id ];
 		$branch_candidates  = $this->branch_candidates[ $rule_id ];
@@ -76,14 +81,20 @@ class WP_Parser {
 			? $branch_candidates[ $token_id ]
 			: ( $branch_candidates[ WP_Parser_Grammar::EMPTY_RULE_ID ] ?? array() );
 
-		if ( ! count( $branch_indexes ) ) {
+		$single_branch_index = is_int( $branch_indexes ) ? $branch_indexes : null;
+
+		if ( null === $single_branch_index && ! count( $branch_indexes ) ) {
 			$this->failed_matches[ $starting_position ][ $rule_id ] = true;
 			return false;
 		}
 
 		$branch_matches     = false;
 		$node               = null;
-		foreach ( $branch_indexes as $branch_index ) {
+		$branch_index_count = null === $single_branch_index ? count( $branch_indexes ) : 1;
+		for ( $branch_index_offset = 0; $branch_index_offset < $branch_index_count; $branch_index_offset++ ) {
+			$branch_index   = null === $single_branch_index
+				? $branch_indexes[ $branch_index_offset ]
+				: $single_branch_index;
 			$branch         = $branches[ $branch_index ];
 			$this->position = $starting_position;
 			$node           = new WP_Parser_Node( $rule_id, $rule_name );
@@ -116,11 +127,13 @@ class WP_Parser {
 			//        for right-associative rules, which could solve this.
 			//        See: https://github.com/mysql/mysql-workbench/blob/8.0.38/library/parsers/grammars/MySQLParser.g4#L994
 			//        See: https://github.com/antlr/antlr4/issues/488
-			$la = $this->tokens[ $this->position ] ?? null;
+			$lookahead_id = $this->position < $this->token_count
+				? $this->token_ids[ $this->position ]
+				: null;
 			if (
-				$la
+				null !== $lookahead_id
 				&& $rule_id === $this->select_statement_rule_id
-				&& WP_MySQL_Lexer::INTO_SYMBOL === $la->id
+				&& WP_MySQL_Lexer::INTO_SYMBOL === $lookahead_id
 			) {
 				$branch_matches = false;
 			}

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
@@ -20,7 +20,6 @@ class WP_Parser {
 	private $highest_terminal_id;
 	private $select_statement_rule_id;
 	private $token_count;
-	private $failed_matches;
 
 	public function __construct( WP_Parser_Grammar $grammar, array $tokens ) {
 		$this->grammar  = $grammar;
@@ -40,7 +39,6 @@ class WP_Parser {
 		foreach ( $this->tokens as $token ) {
 			$this->token_ids[] = $token->id;
 		}
-		$this->failed_matches              = array();
 
 		// @TODO: Make the starting rule lookup non-grammar-specific.
 		$query_rule_id = $this->grammar->get_rule_id( 'query' );
@@ -66,9 +64,6 @@ class WP_Parser {
 		}
 
 		$starting_position = $this->position;
-		if ( isset( $this->failed_matches[ $starting_position ][ $rule_id ] ) ) {
-			return false;
-		}
 
 		$branches          = $this->rules[ $rule_id ];
 
@@ -84,7 +79,6 @@ class WP_Parser {
 		$single_branch_index = is_int( $branch_indexes ) ? $branch_indexes : null;
 
 		if ( null === $single_branch_index && ! count( $branch_indexes ) ) {
-			$this->failed_matches[ $starting_position ][ $rule_id ] = true;
 			return false;
 		}
 
@@ -143,7 +137,6 @@ class WP_Parser {
 
 		if ( ! $branch_matches ) {
 			$this->position = $starting_position;
-			$this->failed_matches[ $starting_position ][ $rule_id ] = true;
 			return false;
 		}
 

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
@@ -12,6 +12,14 @@ class WP_Parser {
 	protected $grammar;
 	protected $tokens;
 	protected $position;
+	private $rules;
+	private $rule_names;
+	private $fragment_ids;
+	private $branch_candidates;
+	private $highest_terminal_id;
+	private $select_statement_rule_id;
+	private $token_count;
+	private $failed_matches;
 
 	public function __construct( WP_Parser_Grammar $grammar, array $tokens ) {
 		$this->grammar  = $grammar;
@@ -20,6 +28,15 @@ class WP_Parser {
 	}
 
 	public function parse() {
+		$this->rules                       = $this->grammar->rules;
+		$this->rule_names                  = $this->grammar->rule_names;
+		$this->fragment_ids                = $this->grammar->fragment_ids;
+		$this->branch_candidates           = $this->grammar->branch_candidates;
+		$this->highest_terminal_id         = $this->grammar->highest_terminal_id;
+		$this->select_statement_rule_id    = $this->grammar->get_rule_id( 'selectStatement' );
+		$this->token_count                 = count( $this->tokens );
+		$this->failed_matches              = array();
+
 		// @TODO: Make the starting rule lookup non-grammar-specific.
 		$query_rule_id = $this->grammar->get_rule_id( 'query' );
 		$ast           = $this->parse_recursive( $query_rule_id );
@@ -27,9 +44,9 @@ class WP_Parser {
 	}
 
 	private function parse_recursive( $rule_id ) {
-		$is_terminal = $rule_id <= $this->grammar->highest_terminal_id;
+		$is_terminal = $rule_id <= $this->highest_terminal_id;
 		if ( $is_terminal ) {
-			if ( $this->position >= count( $this->tokens ) ) {
+			if ( $this->position >= $this->token_count ) {
 				return false;
 			}
 
@@ -38,32 +55,36 @@ class WP_Parser {
 			}
 
 			if ( $this->tokens[ $this->position ]->id === $rule_id ) {
-				++$this->position;
-				return $this->tokens[ $this->position - 1 ];
+				return $this->tokens[ $this->position++ ];
 			}
 			return false;
 		}
 
-		$branches = $this->grammar->rules[ $rule_id ];
-		if ( ! count( $branches ) ) {
-			return false;
-		}
-
-		// Bale out from processing the current branch if none of its rules can
-		// possibly match the current token.
-		if ( isset( $this->grammar->lookahead_is_match_possible[ $rule_id ] ) ) {
-			$token_id = $this->tokens[ $this->position ]->id;
-			if (
-				! isset( $this->grammar->lookahead_is_match_possible[ $rule_id ][ $token_id ] ) &&
-				! isset( $this->grammar->lookahead_is_match_possible[ $rule_id ][ WP_Parser_Grammar::EMPTY_RULE_ID ] )
-			) {
-				return false;
-			}
-		}
-
-		$rule_name         = $this->grammar->rule_names[ $rule_id ];
 		$starting_position = $this->position;
-		foreach ( $branches as $branch ) {
+		if ( isset( $this->failed_matches[ $starting_position ][ $rule_id ] ) ) {
+			return false;
+		}
+
+		$branches          = $this->rules[ $rule_id ];
+
+		$token_id = $this->position < $this->token_count
+			? $this->tokens[ $this->position ]->id
+			: null;
+		$rule_name          = $this->rule_names[ $rule_id ];
+		$branch_candidates  = $this->branch_candidates[ $rule_id ];
+		$branch_indexes     = null !== $token_id && isset( $branch_candidates[ $token_id ] )
+			? $branch_candidates[ $token_id ]
+			: ( $branch_candidates[ WP_Parser_Grammar::EMPTY_RULE_ID ] ?? array() );
+
+		if ( ! count( $branch_indexes ) ) {
+			$this->failed_matches[ $starting_position ][ $rule_id ] = true;
+			return false;
+		}
+
+		$branch_matches     = false;
+		$node               = null;
+		foreach ( $branch_indexes as $branch_index ) {
+			$branch         = $branches[ $branch_index ];
 			$this->position = $starting_position;
 			$node           = new WP_Parser_Node( $rule_id, $rule_name );
 			$branch_matches = true;
@@ -80,13 +101,8 @@ class WP_Parser {
 					 * It is used to represent optional grammar productions.
 					 */
 					continue;
-				} elseif ( is_array( $subnode ) && 0 === count( $subnode ) ) {
-					continue;
 				}
-				if ( is_array( $subnode ) && ! count( $subnode ) ) {
-					continue;
-				}
-				if ( isset( $this->grammar->fragment_ids[ $subrule_id ] ) ) {
+				if ( isset( $this->fragment_ids[ $subrule_id ] ) ) {
 					$node->merge_fragment( $subnode );
 				} else {
 					$node->append_child( $subnode );
@@ -101,7 +117,11 @@ class WP_Parser {
 			//        See: https://github.com/mysql/mysql-workbench/blob/8.0.38/library/parsers/grammars/MySQLParser.g4#L994
 			//        See: https://github.com/antlr/antlr4/issues/488
 			$la = $this->tokens[ $this->position ] ?? null;
-			if ( $la && 'selectStatement' === $rule_name && WP_MySQL_Lexer::INTO_SYMBOL === $la->id ) {
+			if (
+				$la
+				&& $rule_id === $this->select_statement_rule_id
+				&& WP_MySQL_Lexer::INTO_SYMBOL === $la->id
+			) {
 				$branch_matches = false;
 			}
 
@@ -112,10 +132,11 @@ class WP_Parser {
 
 		if ( ! $branch_matches ) {
 			$this->position = $starting_position;
+			$this->failed_matches[ $starting_position ][ $rule_id ] = true;
 			return false;
 		}
 
-		if ( ! $node->has_child() ) {
+		if ( null === $node || ! $node->has_child() ) {
 			return true;
 		}
 

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
@@ -127,15 +127,13 @@ class WP_Parser {
 			//        for right-associative rules, which could solve this.
 			//        See: https://github.com/mysql/mysql-workbench/blob/8.0.38/library/parsers/grammars/MySQLParser.g4#L994
 			//        See: https://github.com/antlr/antlr4/issues/488
-			$lookahead_id = $this->position < $this->token_count
-				? $this->token_ids[ $this->position ]
-				: null;
-			if (
-				null !== $lookahead_id
-				&& $rule_id === $this->select_statement_rule_id
-				&& WP_MySQL_Lexer::INTO_SYMBOL === $lookahead_id
-			) {
-				$branch_matches = false;
+			if ( $rule_id === $this->select_statement_rule_id ) {
+				$lookahead_id = $this->position < $this->token_count
+					? $this->token_ids[ $this->position ]
+					: null;
+				if ( WP_MySQL_Lexer::INTO_SYMBOL === $lookahead_id ) {
+					$branch_matches = false;
+				}
 			}
 
 			if ( true === $branch_matches ) {


### PR DESCRIPTION
## What changed

This draft explores faster MySQL lexing and parsing while keeping the parser compact.

- Speeds up `WP_MySQL_Lexer::remaining_tokens()` by avoiding repeated public method calls during bulk tokenization.
- Caches the SQL payload length in the lexer and uses cheaper character checks on hot paths.
- Speeds up MySQL token construction by avoiding an extra parent constructor call per token.
- Replaces the parser grammar's limited iterative lookahead table with full FIRST-set computation.
- Adds per-token branch candidate tables so the parser tries only grammar branches that can start with the current token.
- Caches parser grammar tables on the parser instance during a parse.
- Caches token IDs alongside parser tokens to avoid repeated object-property reads in terminal/lookahead checks.
- Adds a rule-name lookup map to avoid repeated linear `array_search()` calls.
- Reuses computed branch dispatch tables for identical grammar loads, drops retained intermediate FIRST sets, and stores single-candidate dispatch entries as integers to keep default test memory under control.
- Avoids reading the next token for MySQL's `SELECT ... INTO` negative-lookahead check unless the current rule is `selectStatement`.
- Removes parser failed-match memoization after branch dispatch made it net overhead in the benchmark suite.

## Why

The dynamic recursive-descent parser spends a lot of time repeatedly rejecting grammar branches that cannot match the current token. The lexer benchmark also paid avoidable overhead for the common `remaining_tokens()` path used before parsing.

This keeps the current architecture and grammar file format intact while moving more branch-selection work to grammar initialization.

## Performance

Original trunk baseline captured before this branch:

- Lexer: 69,578 queries in `4.824s` @ `14.4k QPS`
- Parser including lexing: 69,577 queries in `21.275s` @ `3.27k QPS`

Fresh local run on this branch:

- Lexer: 69,578 queries in `1.76580s` @ `39.4k QPS`
- Parser including lexing: 69,577 queries in `9.31625s` @ `7.47k QPS`

Reviewer run from the adversarial loop:

- Lexer: 69,578 queries in `1.71405s` @ `40.6k QPS`
- Parser including lexing: 69,577 queries in `9.70479s` @ `7.17k QPS`

This is roughly:

- `2.8x` faster lexer time.
- `2.28x` faster end-to-end parser time.

It does not reach 10x. The independent reviewer concluded that further large gains likely require a generated/specialized parser or larger rearchitecture.

## Parser size constraint

The current compact parser footprint remains well under the requested 200 KB cap:

- `src/parser/*.php` plus `src/mysql/mysql-grammar.php`: `92,090` bytes total.
- Current follow-up commits: `93,804` bytes total.

## Validation

- `git diff --check`
- `php -l` on modified lexer/parser files
- `composer run test -- --filter 'WP_MySQL_(Lexer|Server_Suite_(Lexer|Parser))'`
  - `141` tests
  - `1,420,987` assertions
- `composer run test`
  - `667` tests
  - `1,427,673` assertions
  - `2` skipped, `2` incomplete
- `php packages/mysql-on-sqlite/tests/tools/run-lexer-benchmark.php`
- `php packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php`

## Follow-up exploration

The next phase should investigate whether a compact specialized parser can preserve the 200 KB cap while reducing dynamic recursive-descent overhead further. Promising directions:

- generate compact predictive dispatch tables rather than expanding PHP parser code;
- specialize the high-volume statement families used by WordPress while falling back to the generic parser;
- keep any generated artifacts small enough that `src/parser/*.php` plus grammar metadata stays below 200 KB.
