### PR TITLE
[codex] Split parser single-branch path

### DIFF
--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
@@ -108,7 +108,7 @@ class WP_Parser_Node {
 	 * @return bool True if this node has any child nodes or tokens, false otherwise.
 	 */
 	public function has_child(): bool {
-		return count( $this->children ) > 0;
+		return ! empty( $this->children );
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
@@ -84,12 +84,8 @@ class WP_Parser {
 
 		$branch_matches     = false;
 		$node               = null;
-		$branch_index_count = null === $single_branch_index ? count( $branch_indexes ) : 1;
-		for ( $branch_index_offset = 0; $branch_index_offset < $branch_index_count; $branch_index_offset++ ) {
-			$branch_index   = null === $single_branch_index
-				? $branch_indexes[ $branch_index_offset ]
-				: $single_branch_index;
-			$branch         = $branches[ $branch_index ];
+		if ( null !== $single_branch_index ) {
+			$branch         = $branches[ $single_branch_index ];
 			$this->position = $starting_position;
 			$node           = new WP_Parser_Node( $rule_id, $rule_name );
 			$branch_matches = true;
@@ -129,9 +125,52 @@ class WP_Parser {
 					$branch_matches = false;
 				}
 			}
+		} else {
+			foreach ( $branch_indexes as $branch_index ) {
+				$branch         = $branches[ $branch_index ];
+				$this->position = $starting_position;
+				$node           = new WP_Parser_Node( $rule_id, $rule_name );
+				$branch_matches = true;
+				foreach ( $branch as $subrule_id ) {
+					$subnode = $this->parse_recursive( $subrule_id );
+					if ( false === $subnode ) {
+						$branch_matches = false;
+						break;
+					} elseif ( true === $subnode ) {
+						/*
+						 * The subrule was matched without actually matching a token.
+						 * This means a special empty "ε" (epsilon) rule was matched.
+						 * An "ε" rule in a grammar matches an empty input of 0 bytes.
+						 * It is used to represent optional grammar productions.
+						 */
+						continue;
+					}
+					if ( isset( $this->fragment_ids[ $subrule_id ] ) ) {
+						$node->merge_fragment( $subnode );
+					} else {
+						$node->append_child( $subnode );
+					}
+				}
 
-			if ( true === $branch_matches ) {
-				break;
+				// Negative lookahead for INTO after a valid SELECT statement.
+				// If we match a SELECT statement, but there is an INTO keyword after it,
+				// we're in the wrong branch and need to leave matching to a later rule.
+				// @TODO: Extract this to the "WP_MySQL_Parser" class, or add support
+				//        for right-associative rules, which could solve this.
+				//        See: https://github.com/mysql/mysql-workbench/blob/8.0.38/library/parsers/grammars/MySQLParser.g4#L994
+				//        See: https://github.com/antlr/antlr4/issues/488
+				if ( $rule_id === $this->select_statement_rule_id ) {
+					$lookahead_id = $this->position < $this->token_count
+						? $this->token_ids[ $this->position ]
+						: null;
+					if ( WP_MySQL_Lexer::INTO_SYMBOL === $lookahead_id ) {
+						$branch_matches = false;
+					}
+				}
+
+				if ( true === $branch_matches ) {
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
## What changed

This stacked draft PR builds on #375 and gives the parser a dedicated fast path for the common case where FIRST-set dispatch resolves a rule to exactly one candidate branch.

- Splits single-branch parsing from the multi-branch fallback in `WP_Parser::parse_recursive()`.
- Keeps the existing multi-branch backtracking path for ambiguous dispatch.
- Changes `WP_Parser_Node::has_child()` from `count() > 0` to `! empty()` for the hot AST completion check.

## Why

After #375, branch dispatch commonly resolves directly to a single branch. The parser still paid loop/index bookkeeping designed for multiple candidates. This change duplicates a small amount of branch parsing code so the dominant single-candidate path can avoid that work while keeping the generic parser architecture intact.

This is deliberately still compact: it does not generate a large parser or expand the grammar on disk.

## Performance

Benchmarks are noisy on this machine, so I compared this branch against the stacked base branch immediately before opening this PR.

- Base #375 branch: 69,577 queries in `11.55021s` @ `6,023 QPS`
- This branch: 69,577 queries in `10.90099s` @ `6,382 QPS`

That is roughly a `6%` incremental parser improvement on top of #375 in this run.

## Parser size constraint

`src/parser/*.php` plus `src/mysql/mysql-grammar.php` remains under the requested 200 KB on-disk cap:

- `95,298` bytes total

## Validation

- `git diff --check`
- `php -l` on modified parser files
- `composer run test -- --filter 'WP_MySQL_(Lexer|Server_Suite_(Lexer|Parser))|WP_Parser_Node'`
  - `143` tests
  - `1,421,037` assertions
- `composer run test`
  - `667` tests
  - `1,427,673` assertions
  - `2` skipped, `2` incomplete
- `php packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php`

## Notes

I also tested broader parser reshapes before settling on this smaller fast path: inline terminal matching, in-memory single-fragment expansion, lightweight fragment arrays, direct branch-array dispatch, and by-reference parser cursor state. Those were slower in this codebase, so they are not included here.
