### PR TITLE
[codex] Explore native parser branch dispatch

### DIFF
--- a/packages/mysql-on-sqlite/ext/wp-mysql-parser/src/lib.rs
+++ b/packages/mysql-on-sqlite/ext/wp-mysql-parser/src/lib.rs
@@ -927,10 +927,25 @@ struct Grammar {
 }
 
 struct Rule {
-    branches: Vec<Vec<i64>>,
+    branches: Vec<Branch>,
     lookahead: Option<Vec<i64>>,
     rule_name: String,
     is_fragment: bool,
+}
+
+struct Branch {
+    symbols: Vec<i64>,
+    first_symbol: Option<i64>,
+}
+
+impl Branch {
+    fn new(symbols: Vec<i64>) -> Self {
+        let first_symbol = symbols.first().copied();
+        Self {
+            symbols,
+            first_symbol,
+        }
+    }
 }
 
 impl Grammar {
@@ -945,6 +960,21 @@ impl Grammar {
         self.rule(rule_id)
             .map(|rule| rule.is_fragment)
             .unwrap_or(false)
+    }
+
+    fn can_symbol_start(&self, symbol_id: i64, token_id: i64) -> bool {
+        if symbol_id <= self.highest_terminal_id {
+            return 0 == symbol_id || symbol_id == token_id;
+        }
+
+        let Some(rule) = self.rule(symbol_id) else {
+            return false;
+        };
+        let Some(lookahead) = rule.lookahead.as_ref() else {
+            return true;
+        };
+
+        lookahead.binary_search(&token_id).is_ok() || lookahead.binary_search(&0).is_ok()
     }
 }
 
@@ -1106,14 +1136,22 @@ impl WpMySqlNativeParser {
         }
 
         let starting_position = self.position;
+        let starting_token_id = self.token_ids.get(starting_position).copied().unwrap_or(0);
         let mut matched_node = None;
 
         for branch in &rule.branches {
+            if branch
+                .first_symbol
+                .is_some_and(|symbol_id| !grammar.can_symbol_start(symbol_id, starting_token_id))
+            {
+                continue;
+            }
+
             self.position = starting_position;
             let mut children = Vec::new();
             let mut branch_matches = true;
 
-            for &subrule_id in branch {
+            for &subrule_id in &branch.symbols {
                 match self.parse_recursive_inner(subrule_id)? {
                     ParseMatch::No => {
                         branch_matches = false;
@@ -1360,7 +1398,7 @@ fn build_rules(
         }
 
         dense_rules[index] = Some(Rule {
-            branches,
+            branches: branches.into_iter().map(Branch::new).collect(),
             lookahead,
             rule_name: rule_names.get(&rule_id).cloned().unwrap_or_default(),
             is_fragment: fragment_ids.contains(&rule_id),


### PR DESCRIPTION
## What changed

This is an exploratory stacked PR for parser dispatch architecture, based on #380 and independent from #381.

The implementation compiles grammar branches into small `Branch` records with a precomputed first symbol. During parsing, the native parser checks the current token against that first symbol before trying the branch recursively.

## Result

This did not produce a useful speedup. It is a draft PR so the branch and measurements are easy to inspect, but I do not recommend merging this variant as-is.

## Measurements

Generated inputs are the same three 50 MiB SQL files used in the previous parser PR: unique long inserts, edge-case selects, and mixed DDL/DML.

| File | #380 token-stream total | Branch-first dispatch total | Delta |
| --- | ---: | ---: | ---: |
| `long_inserts_50mib.sql` | 23.104s | 24.245s | 4.9% slower |
| `edge_selects_50mib.sql` | 23.526s | 23.196s | 1.4% faster |
| `mixed_ddl_dml_50mib.sql` | 18.460s | 18.593s | 0.7% slower |

I also measured two stronger compiled-symbol variants locally:

| Variant | `long_inserts` | `edge_selects` | `mixed_ddl_dml` | Outcome |
| --- | ---: | ---: | ---: | --- |
| Branch + per-subrule start checks | 23.249s | 23.577s | 18.900s | neutral/slower |
| Compiled terminal/fragment symbols + branch checks | 24.434s | 30.551s | 21.714s | slower |
| Compiled terminal/fragment symbols without branch checks | 31.891s | 25.479s | 21.330s | slower |

The likely reason is that the current #380 hot path is no longer dominated by failed branch recursion; eager PHP AST materialization and grammar/cache behavior dominate enough that these dispatch checks add overhead or noise.

## Validation

- `cargo fmt --check`
- `cargo build --release`
- `php -d extension=/tmp/mysql-parser-perf/target-branch-dispatch-release/release/libwp_mysql_parser.so -d memory_limit=1024M ./vendor/bin/phpunit -c ./phpunit.xml.dist --filter 'MySQL|Parser|Lexer'`
- `php -d extension=/tmp/mysql-parser-perf/target-branch-dispatch-release/release/libwp_mysql_parser.so -d memory_limit=1024M ./vendor/bin/phpunit -c ./phpunit.xml.dist`
