### PR TITLE
Add a hook for native MySQL lexer and parser implementations

### DIFF
--- a/packages/mysql-on-sqlite/src/load.php
+++ b/packages/mysql-on-sqlite/src/load.php
@@ -12,8 +12,24 @@ require_once __DIR__ . '/parser/class-wp-parser.php';
 require_once __DIR__ . '/parser/class-wp-parser-node.php';
 require_once __DIR__ . '/parser/class-wp-parser-token.php';
 require_once __DIR__ . '/mysql/class-wp-mysql-token.php';
-require_once __DIR__ . '/mysql/class-wp-mysql-lexer.php';
-require_once __DIR__ . '/mysql/class-wp-mysql-parser.php';
+
+/*
+ * The MySQL lexer and parser have an optional native (e.g. Rust) implementation.
+ * When the native extension is loaded, it pre-declares WP_MySQL_Native_Lexer /
+ * WP_MySQL_Native_Parser; otherwise we fall back to the pure-PHP classes shipped
+ * here. WP_MySQL_Lexer / WP_MySQL_Parser is the public entrypoint either way.
+ */
+if ( class_exists( 'WP_MySQL_Native_Lexer', false ) ) {
+	require_once __DIR__ . '/mysql/native/class-wp-mysql-lexer.php';
+} else {
+	require_once __DIR__ . '/mysql/class-wp-mysql-lexer.php';
+}
+
+if ( class_exists( 'WP_MySQL_Native_Parser', false ) ) {
+	require_once __DIR__ . '/mysql/native/class-wp-mysql-parser.php';
+} else {
+	require_once __DIR__ . '/mysql/class-wp-mysql-parser.php';
+}
 require_once __DIR__ . '/sqlite/class-wp-sqlite-connection.php';
 require_once __DIR__ . '/sqlite/class-wp-sqlite-configurator.php';
 require_once __DIR__ . '/sqlite/class-wp-sqlite-driver.php';

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-lexer.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-lexer.php
@@ -1,0 +1,3 @@
+<?php
+
+class WP_MySQL_Lexer extends WP_MySQL_Native_Lexer {}

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-parser.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-parser.php
@@ -1,0 +1,3 @@
+<?php
+
+class WP_MySQL_Parser extends WP_MySQL_Native_Parser {}


### PR DESCRIPTION
## Summary

Add a small entry point in `load.php` so an optional native (e.g. Rust) MySQL lexer/parser extension can plug itself in as `WP_MySQL_Lexer` / `WP_MySQL_Parser`. The extension pre-declares `WP_MySQL_Native_Lexer` / `WP_MySQL_Native_Parser` before this file loads; otherwise the existing pure-PHP classes ship as the implementation, unchanged.

The existing PHP files keep their original names, locations, and class names — no rename, no polyfill scaffolding. Native shims live in a separate `mysql/native/` directory and are only required when the native classes are present.

## Testing

- `php -l` on changed files
- Smoke: `WP_MySQL_Lexer` and `WP_MySQL_Parser` instantiate and parse `SELECT 1` end-to-end with no native extension loaded
- `phpcs` clean