### PR TITLE
Add optional native parser routing

### DIFF
--- a/packages/mysql-on-sqlite/src/load.php
+++ b/packages/mysql-on-sqlite/src/load.php
@@ -26,6 +26,7 @@ if ( class_exists( 'WP_MySQL_Native_Lexer', false ) ) {
 }
 
 if ( class_exists( 'WP_MySQL_Native_Parser', false ) ) {
+	require_once __DIR__ . '/mysql/native/mysql-rust-bridge.php';
 	require_once __DIR__ . '/mysql/native/class-wp-mysql-parser.php';
 } else {
 	require_once __DIR__ . '/mysql/class-wp-mysql-parser.php';

--- a/packages/mysql-on-sqlite/src/mysql/native/mysql-rust-bridge.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/mysql-rust-bridge.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Bridge helpers for the optional Rust MySQL lexer/parser extension.
+ * PHP keeps the grammar object, while Rust owns the exported parser state.
+ */
+
+/**
+ * Export grammar internals for the native parser.
+ *
+ * @param WP_Parser_Grammar $grammar Parser grammar.
+ * @return array<string, mixed>
+ */
+function wp_sqlite_mysql_native_export_grammar( WP_Parser_Grammar $grammar ): array {
+	return array(
+		'highest_terminal_id'         => $grammar->highest_terminal_id,
+		'rules'                       => $grammar->rules,
+		'lookahead_is_match_possible' => $grammar->lookahead_is_match_possible,
+		'rule_names'                  => $grammar->rule_names,
+		'fragment_ids'                => $grammar->fragment_ids,
+	);
+}


### PR DESCRIPTION
## Summary
- add fallback `WP_MySQL_Native_*` classes that extend the PHP polyfills
- route public MySQL lexer/parser classes through native classes when the extension preloads them
- add the minimal PHP bridge that exports grammar data for native parser setup

## Testing
- `php -l` on changed PHP files
- parser smoke: lex and parse `SELECT 1` through `WP_MySQL_Lexer` and `WP_MySQL_Parser`

This PR is intentionally stacked after the polyfill extraction PR so the native routing diff is small and reviewable.