### PR TITLE
Add lazy native parser node facade

### DIFF
--- a/packages/mysql-on-sqlite/src/load.php
+++ b/packages/mysql-on-sqlite/src/load.php
@@ -27,6 +27,7 @@ if ( class_exists( 'WP_MySQL_Native_Lexer', false ) ) {
 
 if ( class_exists( 'WP_MySQL_Native_Parser', false ) ) {
 	require_once __DIR__ . '/mysql/native/mysql-rust-bridge.php';
+	require_once __DIR__ . '/mysql/native/class-wp-mysql-native-parser-node.php';
 	require_once __DIR__ . '/mysql/native/class-wp-mysql-parser.php';
 } else {
 	require_once __DIR__ . '/mysql/class-wp-mysql-parser.php';

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * Parser node backed by a native (Rust) AST.
+ *
+ * Constructed by the native MySQL parser extension. Read methods delegate
+ * into the Rust-owned AST so children are never copied into PHP unless a
+ * caller actually walks the tree. On the first mutation (append_child or
+ * merge_fragment), the node materializes its children into the inherited
+ * `$children` array and behaves like a plain WP_Parser_Node from then on.
+ */
+class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
+	private $native_ast        = null;
+	private $native_node_index = null;
+	private $was_mutated       = false;
+
+	public function __construct( $rule_id, $rule_name, $native_ast = null, $native_node_index = null ) {
+		parent::__construct( $rule_id, $rule_name );
+
+		$this->native_ast        = $native_ast;
+		$this->native_node_index = $native_node_index;
+	}
+
+	/** @inheritDoc */
+	public function append_child( $node ) {
+		$this->materialize_native_children();
+		parent::append_child( $node );
+	}
+
+	/** @inheritDoc */
+	public function merge_fragment( $node ) {
+		$this->materialize_native_children();
+		if ( $node instanceof self ) {
+			$node->materialize_native_children();
+		}
+		parent::merge_fragment( $node );
+	}
+
+	/** @inheritDoc */
+	public function has_child(): bool {
+		if ( $this->was_mutated() ) {
+			return parent::has_child();
+		}
+		return wp_sqlite_mysql_native_ast_has_child( $this->native_ast, $this->native_node_index );
+	}
+
+	/** @inheritDoc */
+	public function has_child_node( ?string $rule_name = null ): bool {
+		if ( $this->was_mutated() ) {
+			return parent::has_child_node( $rule_name );
+		}
+		return wp_sqlite_mysql_native_ast_has_child_node( $this->native_ast, $this->native_node_index, $rule_name );
+	}
+
+	/** @inheritDoc */
+	public function has_child_token( ?int $token_id = null ): bool {
+		if ( $this->was_mutated() ) {
+			return parent::has_child_token( $token_id );
+		}
+		return wp_sqlite_mysql_native_ast_has_child_token( $this->native_ast, $this->native_node_index, $token_id );
+	}
+
+	/** @inheritDoc */
+	public function get_first_child() {
+		if ( $this->was_mutated() ) {
+			return parent::get_first_child();
+		}
+		return wp_sqlite_mysql_native_ast_get_first_child( $this->native_ast, $this->native_node_index );
+	}
+
+	/** @inheritDoc */
+	public function get_first_child_node( ?string $rule_name = null ): ?WP_Parser_Node {
+		if ( $this->was_mutated() ) {
+			return parent::get_first_child_node( $rule_name );
+		}
+		return wp_sqlite_mysql_native_ast_get_first_child_node( $this->native_ast, $this->native_node_index, $rule_name );
+	}
+
+	/** @inheritDoc */
+	public function get_first_child_token( ?int $token_id = null ): ?WP_Parser_Token {
+		if ( $this->was_mutated() ) {
+			return parent::get_first_child_token( $token_id );
+		}
+		return wp_sqlite_mysql_native_ast_get_first_child_token( $this->native_ast, $this->native_node_index, $token_id );
+	}
+
+	/** @inheritDoc */
+	public function get_first_descendant_node( ?string $rule_name = null ): ?WP_Parser_Node {
+		if ( $this->was_mutated() ) {
+			return parent::get_first_descendant_node( $rule_name );
+		}
+		return wp_sqlite_mysql_native_ast_get_first_descendant_node( $this->native_ast, $this->native_node_index, $rule_name );
+	}
+
+	/** @inheritDoc */
+	public function get_first_descendant_token( ?int $token_id = null ): ?WP_Parser_Token {
+		if ( $this->was_mutated() ) {
+			return parent::get_first_descendant_token( $token_id );
+		}
+		return wp_sqlite_mysql_native_ast_get_first_descendant_token( $this->native_ast, $this->native_node_index, $token_id );
+	}
+
+	/** @inheritDoc */
+	public function get_children(): array {
+		if ( $this->was_mutated() ) {
+			return parent::get_children();
+		}
+		return wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
+	}
+
+	/** @inheritDoc */
+	public function get_child_nodes( ?string $rule_name = null ): array {
+		if ( $this->was_mutated() ) {
+			return parent::get_child_nodes( $rule_name );
+		}
+		return wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name );
+	}
+
+	/** @inheritDoc */
+	public function get_child_tokens( ?int $token_id = null ): array {
+		if ( $this->was_mutated() ) {
+			return parent::get_child_tokens( $token_id );
+		}
+		return wp_sqlite_mysql_native_ast_get_child_tokens( $this->native_ast, $this->native_node_index, $token_id );
+	}
+
+	/** @inheritDoc */
+	public function get_descendants(): array {
+		if ( $this->was_mutated() ) {
+			return parent::get_descendants();
+		}
+		return wp_sqlite_mysql_native_ast_get_descendants( $this->native_ast, $this->native_node_index );
+	}
+
+	/** @inheritDoc */
+	public function get_descendant_nodes( ?string $rule_name = null ): array {
+		if ( $this->was_mutated() ) {
+			return parent::get_descendant_nodes( $rule_name );
+		}
+		return wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name );
+	}
+
+	/** @inheritDoc */
+	public function get_descendant_tokens( ?int $token_id = null ): array {
+		if ( $this->was_mutated() ) {
+			return parent::get_descendant_tokens( $token_id );
+		}
+		return wp_sqlite_mysql_native_ast_get_descendant_tokens( $this->native_ast, $this->native_node_index, $token_id );
+	}
+
+	/** @inheritDoc */
+	public function get_start(): int {
+		if ( $this->was_mutated() ) {
+			return parent::get_start();
+		}
+		return wp_sqlite_mysql_native_ast_get_start( $this->native_ast, $this->native_node_index );
+	}
+
+	/** @inheritDoc */
+	public function get_length(): int {
+		if ( $this->was_mutated() ) {
+			return parent::get_length();
+		}
+		return wp_sqlite_mysql_native_ast_get_length( $this->native_ast, $this->native_node_index );
+	}
+
+	private function was_mutated(): bool {
+		return $this->was_mutated;
+	}
+
+	private function materialize_native_children(): void {
+		if ( $this->was_mutated ) {
+			return;
+		}
+
+		$this->children          = wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
+		$this->native_ast        = null;
+		$this->native_node_index = null;
+		$this->was_mutated       = true;
+	}
+}

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
@@ -15,7 +15,7 @@ class WP_Parser_Node {
 	 */
 	public $rule_id;
 	public $rule_name;
-	private $children = array();
+	protected $children = array();
 
 	public function __construct( $rule_id, $rule_name ) {
 		$this->rule_id   = $rule_id;


### PR DESCRIPTION
## Summary

Adds `WP_MySQL_Native_Parser_Node`, a `WP_Parser_Node` subclass the native MySQL parser extension constructs when it produces an AST. Read methods delegate into the Rust-owned AST so children aren't copied into PHP unless something walks the tree. On the first `append_child()` / `merge_fragment()`, the node copies its native children into the inherited `$children` array and behaves like a plain `WP_Parser_Node` from then on — that's what `was_mutated()` tracks.

Mutation matters because `WP_PDO_MySQL_On_SQLite` rewrites parsed queries (e.g. synthetic `count(*)` expressions) by appending children to existing nodes.

## Other change

`WP_Parser_Node::$children` private → protected so the subclass can populate it during materialization.