### PR TITLE
Speed up native AST materialization

### DIFF
--- a/.github/workflows/mysql-parser-extension-tests.yml
+++ b/.github/workflows/mysql-parser-extension-tests.yml
@@ -81,7 +81,9 @@ jobs:
               exit( 1 );
           }
           '
-          ./vendor/bin/phpunit -c ./phpunit.xml.dist tests/mysql/WP_MySQL_Lexer_Tests.php tests/parser/WP_Parser_Node_Tests.php
+
+      - name: Run PHPUnit tests with parser extension
+        run: php -d extension="$GITHUB_WORKSPACE/packages/mysql-on-sqlite/ext/wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
         working-directory: packages/mysql-on-sqlite
 
   sqlite-driver-extension-tests:
@@ -149,3 +151,7 @@ jobs:
               exit( 1 );
           }
           '
+
+      - name: Run PHPUnit tests with SQLite driver using parser extension
+        run: php -d extension="$GITHUB_WORKSPACE/packages/mysql-on-sqlite/ext/wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
+        working-directory: packages/mysql-on-sqlite

--- a/.github/workflows/mysql-parser-extension-tests.yml
+++ b/.github/workflows/mysql-parser-extension-tests.yml
@@ -81,9 +81,10 @@ jobs:
               exit( 1 );
           }
           '
+        working-directory: packages/mysql-on-sqlite
 
       - name: Run PHPUnit tests with parser extension
-        run: php -d extension="$GITHUB_WORKSPACE/packages/mysql-on-sqlite/ext/wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
+        run: php -d extension="$GITHUB_WORKSPACE/packages/php-ext-wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
         working-directory: packages/mysql-on-sqlite
 
   sqlite-driver-extension-tests:
@@ -153,5 +154,5 @@ jobs:
           '
 
       - name: Run PHPUnit tests with SQLite driver using parser extension
-        run: php -d extension="$GITHUB_WORKSPACE/packages/mysql-on-sqlite/ext/wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
+        run: php -d extension="$GITHUB_WORKSPACE/packages/php-ext-wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
         working-directory: packages/mysql-on-sqlite

--- a/.github/workflows/wp-tests-phpunit.yml
+++ b/.github/workflows/wp-tests-phpunit.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Build and load parser extension in WordPress PHP containers
         run: bash .github/workflows/wp-tests-phpunit-native-extension-setup.sh
 
-      - name: Verify WordPress uses parser extension
-        run: cd wordpress && node tools/local-env/scripts/docker.js run --rm php php /var/www/native-verify-extension.php
+      - name: Run WordPress PHPUnit tests with parser extension
+        run: node .github/workflows/wp-tests-phpunit-run.js
 
       - name: Stop Docker containers
         if: always()

--- a/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php
+++ b/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php
@@ -9,6 +9,17 @@ class WP_MySQL_Parser extends WP_Parser {
 	private $current_ast;
 
 	/**
+	 * Reset this parser with a new token stream.
+	 *
+	 * @param array<WP_Parser_Token> $tokens The parser tokens.
+	 */
+	public function reset_tokens( array $tokens ): void {
+		$this->tokens      = $tokens;
+		$this->position    = 0;
+		$this->current_ast = null;
+	}
+
+	/**
 	 * Parse the next query from the input SQL string.
 	 *
 	 * This method reads tokens until a query is parsed, or the parsing fails.

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -11,15 +11,15 @@
  * children are never materialized into PHP arrays unless something actually
  * asks for them.
  *
- * Read methods eagerly call `materialize_native_children()` — once the
- * children have been copied into PHP, `was_mutated()` returns true and the
- * call falls through to the parent implementation. The `was_mutated` flag is
- * NOT a runtime check for whether the native extension is loaded — if this
- * class is in use, the extension is loaded by definition. It tracks whether
- * THIS specific node has had its children pulled into the inherited
- * `$children` array (which happens on first read or first mutation via
- * `append_child()` / `merge_fragment()`). From that point on, the node is a
- * plain PHP-backed `WP_Parser_Node`.
+ * The hedge in those methods (`if ( $this->was_mutated() )`) is NOT a runtime
+ * check for whether the native extension is loaded — if this class is in use,
+ * the extension is loaded by definition. It checks whether THIS specific node
+ * has been mutated from PHP. A node loses its native backing the first time
+ * `append_child()` or `merge_fragment()` is called on it: those overrides
+ * invoke `materialize_native_children()`, which copies the native children
+ * into the inherited `$children` array and drops the native AST reference.
+ * From that point on, the node is a plain PHP-backed `WP_Parser_Node` and the
+ * read methods fall through to the parent implementation.
  *
  * Mutation from PHP is real and intentional — query rewriters in
  * `WP_PDO_MySQL_On_SQLite` (e.g. building synthetic `count(*)` expressions)

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -3,11 +3,29 @@
 /**
  * Parser node backed by a native (Rust) AST.
  *
- * Constructed by the native MySQL parser extension. Read methods delegate
- * into the Rust-owned AST so children are never copied into PHP unless a
- * caller actually walks the tree. On the first mutation (append_child or
- * merge_fragment), the node materializes its children into the inherited
- * `$children` array and behaves like a plain WP_Parser_Node from then on.
+ * Instances of this class are constructed exclusively by the native MySQL
+ * parser extension: when the extension parses a query, it produces a tree of
+ * `WP_MySQL_Native_Parser_Node` objects whose `$native_ast` and
+ * `$native_node_index` fields point into a Rust-owned AST buffer. Read methods
+ * (`get_start`, `has_child`, `get_children`, ...) delegate to the extension so
+ * children are never materialized into PHP arrays unless something actually
+ * asks for them.
+ *
+ * Read methods eagerly call `materialize_native_children()` — once the
+ * children have been copied into PHP, `was_mutated()` returns true and the
+ * call falls through to the parent implementation. The `was_mutated` flag is
+ * NOT a runtime check for whether the native extension is loaded — if this
+ * class is in use, the extension is loaded by definition. It tracks whether
+ * THIS specific node has had its children pulled into the inherited
+ * `$children` array (which happens on first read or first mutation via
+ * `append_child()` / `merge_fragment()`). From that point on, the node is a
+ * plain PHP-backed `WP_Parser_Node`.
+ *
+ * Mutation from PHP is real and intentional — query rewriters in
+ * `WP_PDO_MySQL_On_SQLite` (e.g. building synthetic `count(*)` expressions)
+ * call `append_child()` on parsed nodes. The lazy-then-materialize design
+ * keeps the fast path (read-only traversal) cheap while still allowing
+ * mutation when callers need it.
  */
 class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 	private $native_ast        = null;
@@ -164,10 +182,30 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		return wp_sqlite_mysql_native_ast_get_length( $this->native_ast, $this->native_node_index );
 	}
 
+	/**
+	 * Indicates whether this node has been mutated from PHP.
+	 *
+	 * Returns false for freshly-parsed nodes whose children still live in the
+	 * Rust-owned AST buffer; returns true once `append_child()` or
+	 * `merge_fragment()` has copied the children into the inherited
+	 * `$children` array and dropped the native AST reference.
+	 *
+	 * This is a per-instance state check, not a check for whether the native
+	 * extension is loaded.
+	 */
 	private function was_mutated(): bool {
 		return $this->was_mutated;
 	}
 
+	/**
+	 * Copies native children into the inherited PHP $children array and drops
+	 * the native AST reference for this node.
+	 *
+	 * Called before any mutation (append_child, merge_fragment) so the node's
+	 * authoritative state lives in PHP from that point on. After this runs,
+	 * was_mutated() returns true and read methods fall through to the parent
+	 * WP_Parser_Node implementation.
+	 */
 	private function materialize_native_children(): void {
 		if ( $this->was_mutated ) {
 			return;

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -3,29 +3,11 @@
 /**
  * Parser node backed by a native (Rust) AST.
  *
- * Instances of this class are constructed exclusively by the native MySQL
- * parser extension: when the extension parses a query, it produces a tree of
- * `WP_MySQL_Native_Parser_Node` objects whose `$native_ast` and
- * `$native_node_index` fields point into a Rust-owned AST buffer. Read methods
- * (`get_start`, `has_child`, `get_children`, ...) delegate to the extension so
- * children are never materialized into PHP arrays unless something actually
- * asks for them.
- *
- * The hedge in those methods (`if ( $this->was_mutated() )`) is NOT a runtime
- * check for whether the native extension is loaded — if this class is in use,
- * the extension is loaded by definition. It checks whether THIS specific node
- * has been mutated from PHP. A node loses its native backing the first time
- * `append_child()` or `merge_fragment()` is called on it: those overrides
- * invoke `materialize_native_children()`, which copies the native children
- * into the inherited `$children` array and drops the native AST reference.
- * From that point on, the node is a plain PHP-backed `WP_Parser_Node` and the
- * read methods fall through to the parent implementation.
- *
- * Mutation from PHP is real and intentional — query rewriters in
- * `WP_PDO_MySQL_On_SQLite` (e.g. building synthetic `count(*)` expressions)
- * call `append_child()` on parsed nodes. The lazy-then-materialize design
- * keeps the fast path (read-only traversal) cheap while still allowing
- * mutation when callers need it.
+ * Constructed by the native MySQL parser extension. Read methods delegate
+ * into the Rust-owned AST so children are never copied into PHP unless a
+ * caller actually walks the tree. On the first mutation (append_child or
+ * merge_fragment), the node materializes its children into the inherited
+ * `$children` array and behaves like a plain WP_Parser_Node from then on.
  */
 class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 	private $native_ast        = null;
@@ -39,24 +21,13 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		$this->native_node_index = $native_node_index;
 	}
 
-	/**
-	 * Materializes any native children before mutating, then appends.
-	 *
-	 * Once a node is mutated, its native AST is no longer authoritative, so we
-	 * copy the native children into PHP storage first and drop the native
-	 * reference. Subsequent reads use the parent's PHP implementation.
-	 */
+	/** @inheritDoc */
 	public function append_child( $node ) {
 		$this->materialize_native_children();
 		parent::append_child( $node );
 	}
 
-	/**
-	 * Materializes any native children on both nodes before merging.
-	 *
-	 * @see self::append_child() for why materialization is required before
-	 * mutation.
-	 */
+	/** @inheritDoc */
 	public function merge_fragment( $node ) {
 		$this->materialize_native_children();
 		if ( $node instanceof self ) {
@@ -193,30 +164,10 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		return wp_sqlite_mysql_native_ast_get_length( $this->native_ast, $this->native_node_index );
 	}
 
-	/**
-	 * Indicates whether this node has been mutated from PHP.
-	 *
-	 * Returns false for freshly-parsed nodes whose children still live in the
-	 * Rust-owned AST buffer; returns true once `append_child()` or
-	 * `merge_fragment()` has copied the children into the inherited
-	 * `$children` array and dropped the native AST reference.
-	 *
-	 * This is a per-instance state check, not a check for whether the native
-	 * extension is loaded.
-	 */
 	private function was_mutated(): bool {
 		return $this->was_mutated;
 	}
 
-	/**
-	 * Copies native children into the inherited PHP $children array and drops
-	 * the native AST reference for this node.
-	 *
-	 * Called before any mutation (append_child, merge_fragment) so the node's
-	 * authoritative state lives in PHP from that point on. After this runs,
-	 * was_mutated() returns true and read methods fall through to the parent
-	 * WP_Parser_Node implementation.
-	 */
 	private function materialize_native_children(): void {
 		if ( $this->was_mutated ) {
 			return;

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -3,29 +3,9 @@
 /**
  * Parser node backed by a native (Rust) AST.
  *
- * Instances of this class are constructed exclusively by the native MySQL
- * parser extension: when the extension parses a query, it produces a tree of
- * `WP_MySQL_Native_Parser_Node` objects whose `$native_ast` and
- * `$native_node_index` fields point into a Rust-owned AST buffer. Read methods
- * (`get_start`, `has_child`, `get_children`, ...) delegate to the extension so
- * children are never materialized into PHP arrays unless something actually
- * asks for them.
- *
- * The hedge in those methods (`if ( $this->was_mutated() )`) is NOT a runtime
- * check for whether the native extension is loaded — if this class is in use,
- * the extension is loaded by definition. It checks whether THIS specific node
- * has been mutated from PHP. A node loses its native backing the first time
- * `append_child()` or `merge_fragment()` is called on it: those overrides
- * invoke `materialize_native_children()`, which copies the native children
- * into the inherited `$children` array and drops the native AST reference.
- * From that point on, the node is a plain PHP-backed `WP_Parser_Node` and the
- * read methods fall through to the parent implementation.
- *
- * Mutation from PHP is real and intentional — query rewriters in
- * `WP_PDO_MySQL_On_SQLite` (e.g. building synthetic `count(*)` expressions)
- * call `append_child()` on parsed nodes. The lazy-then-materialize design
- * keeps the fast path (read-only traversal) cheap while still allowing
- * mutation when callers need it.
+ * This subclass keeps the regular WP_Parser_Node API while delegating lazy AST
+ * reads to the optional native MySQL parser extension. The base node remains a
+ * plain PHP tree node for the polyfill parser.
  */
 class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 	private $native_ast        = null;
@@ -56,158 +36,138 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 
 	/** @inheritDoc */
 	public function has_child(): bool {
-		if ( $this->was_mutated() ) {
-			return parent::has_child();
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_has_child( $this->native_ast, $this->native_node_index );
 		}
 		return wp_sqlite_mysql_native_ast_has_child( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function has_child_node( ?string $rule_name = null ): bool {
-		if ( $this->was_mutated() ) {
-			return parent::has_child_node( $rule_name );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_has_child_node( $this->native_ast, $this->native_node_index, $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_has_child_node( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function has_child_token( ?int $token_id = null ): bool {
-		if ( $this->was_mutated() ) {
-			return parent::has_child_token( $token_id );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_has_child_token( $this->native_ast, $this->native_node_index, $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_has_child_token( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_first_child() {
-		if ( $this->was_mutated() ) {
-			return parent::get_first_child();
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_first_child( $this->native_ast, $this->native_node_index );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_child( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_first_child_node( ?string $rule_name = null ): ?WP_Parser_Node {
-		if ( $this->was_mutated() ) {
-			return parent::get_first_child_node( $rule_name );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_first_child_node( $this->native_ast, $this->native_node_index, $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_child_node( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_first_child_token( ?int $token_id = null ): ?WP_Parser_Token {
-		if ( $this->was_mutated() ) {
-			return parent::get_first_child_token( $token_id );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_first_child_token( $this->native_ast, $this->native_node_index, $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_child_token( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_first_descendant_node( ?string $rule_name = null ): ?WP_Parser_Node {
-		if ( $this->was_mutated() ) {
-			return parent::get_first_descendant_node( $rule_name );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_first_descendant_node( $this->native_ast, $this->native_node_index, $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_descendant_node( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_first_descendant_token( ?int $token_id = null ): ?WP_Parser_Token {
-		if ( $this->was_mutated() ) {
-			return parent::get_first_descendant_token( $token_id );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_first_descendant_token( $this->native_ast, $this->native_node_index, $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_descendant_token( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_children(): array {
-		if ( $this->was_mutated() ) {
-			return parent::get_children();
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
 		}
 		return wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_child_nodes( ?string $rule_name = null ): array {
-		if ( $this->was_mutated() ) {
-			return parent::get_child_nodes( $rule_name );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_child_tokens( ?int $token_id = null ): array {
-		if ( $this->was_mutated() ) {
-			return parent::get_child_tokens( $token_id );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_child_tokens( $this->native_ast, $this->native_node_index, $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_child_tokens( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_descendants(): array {
-		if ( $this->was_mutated() ) {
-			return parent::get_descendants();
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_descendants( $this->native_ast, $this->native_node_index );
 		}
 		return wp_sqlite_mysql_native_ast_get_descendants( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_descendant_nodes( ?string $rule_name = null ): array {
-		if ( $this->was_mutated() ) {
-			return parent::get_descendant_nodes( $rule_name );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_descendant_tokens( ?int $token_id = null ): array {
-		if ( $this->was_mutated() ) {
-			return parent::get_descendant_tokens( $token_id );
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_descendant_tokens( $this->native_ast, $this->native_node_index, $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_descendant_tokens( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_start(): int {
-		if ( $this->was_mutated() ) {
-			return parent::get_start();
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_start( $this->native_ast, $this->native_node_index );
 		}
 		return wp_sqlite_mysql_native_ast_get_start( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_length(): int {
-		if ( $this->was_mutated() ) {
-			return parent::get_length();
+		if ( $this->has_native_ast() ) {
+			return wp_sqlite_mysql_native_ast_get_length( $this->native_ast, $this->native_node_index );
 		}
 		return wp_sqlite_mysql_native_ast_get_length( $this->native_ast, $this->native_node_index );
 	}
 
-	/**
-	 * Indicates whether this node has been mutated from PHP.
-	 *
-	 * Returns false for freshly-parsed nodes whose children still live in the
-	 * Rust-owned AST buffer; returns true once `append_child()` or
-	 * `merge_fragment()` has copied the children into the inherited
-	 * `$children` array and dropped the native AST reference.
-	 *
-	 * This is a per-instance state check, not a check for whether the native
-	 * extension is loaded.
-	 */
-	private function was_mutated(): bool {
-		return $this->was_mutated;
+	private function has_native_ast(): bool {
+		return null !== $this->native_ast;
 	}
 
-	/**
-	 * Copies native children into the inherited PHP $children array and drops
-	 * the native AST reference for this node.
-	 *
-	 * Called before any mutation (append_child, merge_fragment) so the node's
-	 * authoritative state lives in PHP from that point on. After this runs,
-	 * was_mutated() returns true and read methods fall through to the parent
-	 * WP_Parser_Node implementation.
-	 */
 	private function materialize_native_children(): void {
-		if ( $this->was_mutated ) {
+		if ( ! $this->has_native_ast() ) {
 			return;
 		}
 

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -3,9 +3,29 @@
 /**
  * Parser node backed by a native (Rust) AST.
  *
- * This subclass keeps the regular WP_Parser_Node API while delegating lazy AST
- * reads to the optional native MySQL parser extension. The base node remains a
- * plain PHP tree node for the polyfill parser.
+ * Instances of this class are constructed exclusively by the native MySQL
+ * parser extension: when the extension parses a query, it produces a tree of
+ * `WP_MySQL_Native_Parser_Node` objects whose `$native_ast` and
+ * `$native_node_index` fields point into a Rust-owned AST buffer. Read methods
+ * (`get_start`, `has_child`, `get_children`, ...) delegate to the extension so
+ * children are never materialized into PHP arrays unless something actually
+ * asks for them.
+ *
+ * The hedge in those methods (`if ( $this->was_mutated() )`) is NOT a runtime
+ * check for whether the native extension is loaded — if this class is in use,
+ * the extension is loaded by definition. It checks whether THIS specific node
+ * has been mutated from PHP. A node loses its native backing the first time
+ * `append_child()` or `merge_fragment()` is called on it: those overrides
+ * invoke `materialize_native_children()`, which copies the native children
+ * into the inherited `$children` array and drops the native AST reference.
+ * From that point on, the node is a plain PHP-backed `WP_Parser_Node` and the
+ * read methods fall through to the parent implementation.
+ *
+ * Mutation from PHP is real and intentional — query rewriters in
+ * `WP_PDO_MySQL_On_SQLite` (e.g. building synthetic `count(*)` expressions)
+ * call `append_child()` on parsed nodes. The lazy-then-materialize design
+ * keeps the fast path (read-only traversal) cheap while still allowing
+ * mutation when callers need it.
  */
 class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 	private $native_ast        = null;
@@ -19,13 +39,24 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		$this->native_node_index = $native_node_index;
 	}
 
-	/** @inheritDoc */
+	/**
+	 * Materializes any native children before mutating, then appends.
+	 *
+	 * Once a node is mutated, its native AST is no longer authoritative, so we
+	 * copy the native children into PHP storage first and drop the native
+	 * reference. Subsequent reads use the parent's PHP implementation.
+	 */
 	public function append_child( $node ) {
 		$this->materialize_native_children();
 		parent::append_child( $node );
 	}
 
-	/** @inheritDoc */
+	/**
+	 * Materializes any native children on both nodes before merging.
+	 *
+	 * @see self::append_child() for why materialization is required before
+	 * mutation.
+	 */
 	public function merge_fragment( $node ) {
 		$this->materialize_native_children();
 		if ( $node instanceof self ) {
@@ -36,138 +67,158 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 
 	/** @inheritDoc */
 	public function has_child(): bool {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_has_child( $this->native_ast, $this->native_node_index );
+		if ( $this->was_mutated() ) {
+			return parent::has_child();
 		}
 		return wp_sqlite_mysql_native_ast_has_child( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function has_child_node( ?string $rule_name = null ): bool {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_has_child_node( $this->native_ast, $this->native_node_index, $rule_name );
+		if ( $this->was_mutated() ) {
+			return parent::has_child_node( $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_has_child_node( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function has_child_token( ?int $token_id = null ): bool {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_has_child_token( $this->native_ast, $this->native_node_index, $token_id );
+		if ( $this->was_mutated() ) {
+			return parent::has_child_token( $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_has_child_token( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_first_child() {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_first_child( $this->native_ast, $this->native_node_index );
+		if ( $this->was_mutated() ) {
+			return parent::get_first_child();
 		}
 		return wp_sqlite_mysql_native_ast_get_first_child( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_first_child_node( ?string $rule_name = null ): ?WP_Parser_Node {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_first_child_node( $this->native_ast, $this->native_node_index, $rule_name );
+		if ( $this->was_mutated() ) {
+			return parent::get_first_child_node( $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_child_node( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_first_child_token( ?int $token_id = null ): ?WP_Parser_Token {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_first_child_token( $this->native_ast, $this->native_node_index, $token_id );
+		if ( $this->was_mutated() ) {
+			return parent::get_first_child_token( $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_child_token( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_first_descendant_node( ?string $rule_name = null ): ?WP_Parser_Node {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_first_descendant_node( $this->native_ast, $this->native_node_index, $rule_name );
+		if ( $this->was_mutated() ) {
+			return parent::get_first_descendant_node( $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_descendant_node( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_first_descendant_token( ?int $token_id = null ): ?WP_Parser_Token {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_first_descendant_token( $this->native_ast, $this->native_node_index, $token_id );
+		if ( $this->was_mutated() ) {
+			return parent::get_first_descendant_token( $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_first_descendant_token( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_children(): array {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
+		if ( $this->was_mutated() ) {
+			return parent::get_children();
 		}
 		return wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_child_nodes( ?string $rule_name = null ): array {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name );
+		if ( $this->was_mutated() ) {
+			return parent::get_child_nodes( $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_child_tokens( ?int $token_id = null ): array {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_child_tokens( $this->native_ast, $this->native_node_index, $token_id );
+		if ( $this->was_mutated() ) {
+			return parent::get_child_tokens( $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_child_tokens( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_descendants(): array {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_descendants( $this->native_ast, $this->native_node_index );
+		if ( $this->was_mutated() ) {
+			return parent::get_descendants();
 		}
 		return wp_sqlite_mysql_native_ast_get_descendants( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_descendant_nodes( ?string $rule_name = null ): array {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name );
+		if ( $this->was_mutated() ) {
+			return parent::get_descendant_nodes( $rule_name );
 		}
 		return wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name );
 	}
 
 	/** @inheritDoc */
 	public function get_descendant_tokens( ?int $token_id = null ): array {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_descendant_tokens( $this->native_ast, $this->native_node_index, $token_id );
+		if ( $this->was_mutated() ) {
+			return parent::get_descendant_tokens( $token_id );
 		}
 		return wp_sqlite_mysql_native_ast_get_descendant_tokens( $this->native_ast, $this->native_node_index, $token_id );
 	}
 
 	/** @inheritDoc */
 	public function get_start(): int {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_start( $this->native_ast, $this->native_node_index );
+		if ( $this->was_mutated() ) {
+			return parent::get_start();
 		}
 		return wp_sqlite_mysql_native_ast_get_start( $this->native_ast, $this->native_node_index );
 	}
 
 	/** @inheritDoc */
 	public function get_length(): int {
-		if ( $this->has_native_ast() ) {
-			return wp_sqlite_mysql_native_ast_get_length( $this->native_ast, $this->native_node_index );
+		if ( $this->was_mutated() ) {
+			return parent::get_length();
 		}
 		return wp_sqlite_mysql_native_ast_get_length( $this->native_ast, $this->native_node_index );
 	}
 
-	private function has_native_ast(): bool {
-		return null !== $this->native_ast;
+	/**
+	 * Indicates whether this node has been mutated from PHP.
+	 *
+	 * Returns false for freshly-parsed nodes whose children still live in the
+	 * Rust-owned AST buffer; returns true once `append_child()` or
+	 * `merge_fragment()` has copied the children into the inherited
+	 * `$children` array and dropped the native AST reference.
+	 *
+	 * This is a per-instance state check, not a check for whether the native
+	 * extension is loaded.
+	 */
+	private function was_mutated(): bool {
+		return $this->was_mutated;
 	}
 
+	/**
+	 * Copies native children into the inherited PHP $children array and drops
+	 * the native AST reference for this node.
+	 *
+	 * Called before any mutation (append_child, merge_fragment) so the node's
+	 * authoritative state lives in PHP from that point on. After this runs,
+	 * was_mutated() returns true and read methods fall through to the parent
+	 * WP_Parser_Node implementation.
+	 */
 	private function materialize_native_children(): void {
-		if ( ! $this->has_native_ast() ) {
+		if ( $this->was_mutated ) {
 			return;
 		}
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -411,6 +411,13 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	private static $mysql_grammar;
 
 	/**
+	 * A reusable parser instance for MySQL queries.
+	 *
+	 * @var WP_MySQL_Parser|null
+	 */
+	private $mysql_parser = null;
+
+	/**
 	 * The main database name.
 	 *
 	 * The name of the main database that is used by the driver.
@@ -1160,11 +1167,27 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		);
 		if ( $lexer instanceof WP_MySQL_Native_Lexer ) {
 			$tokens = $lexer->native_token_stream();
-			return new WP_MySQL_Parser( self::$mysql_grammar, $tokens );
+			return $this->reset_or_create_parser( $tokens );
 		}
 
 		$tokens = $lexer->remaining_tokens();
-		return new WP_MySQL_Parser( self::$mysql_grammar, $tokens );
+		return $this->reset_or_create_parser( $tokens );
+	}
+
+	/**
+	 * Reset the reusable parser with new tokens or create it on first use.
+	 *
+	 * @param  array<WP_Parser_Token>|object $tokens Parser tokens.
+	 * @return WP_MySQL_Parser                       A parser initialized for the token stream.
+	 */
+	private function reset_or_create_parser( $tokens ): WP_MySQL_Parser {
+		if ( null === $this->mysql_parser || ! method_exists( $this->mysql_parser, 'reset_tokens' ) ) {
+			$this->mysql_parser = new WP_MySQL_Parser( self::$mysql_grammar, $tokens );
+		} else {
+			$this->mysql_parser->reset_tokens( $tokens );
+		}
+
+		return $this->mysql_parser;
 	}
 
 	/**

--- a/packages/php-ext-wp-mysql-parser/src/lib.rs
+++ b/packages/php-ext-wp-mysql-parser/src/lib.rs
@@ -93,10 +93,19 @@ fn update_object_property(
 }
 
 fn create_mysql_token(sql_zval: &Zval, token: TokenInfo, no_backslash: bool) -> PhpResult<Zval> {
+    let classes = php_classes()?;
+    create_mysql_token_with_classes(sql_zval, token, no_backslash, &classes)
+}
+
+fn create_mysql_token_with_classes(
+    sql_zval: &Zval,
+    token: TokenInfo,
+    no_backslash: bool,
+    classes: &PhpClasses,
+) -> PhpResult<Zval> {
     let id = token.id;
     let start = i64::try_from(token.start).map_err(php_error)?;
     let length = i64::try_from(token.end.saturating_sub(token.start)).map_err(php_error)?;
-    let classes = php_classes()?;
     let mut object = classes.mysql_token.new();
 
     update_object_property(&mut object, classes.parser_token, "id", id)?;
@@ -940,7 +949,7 @@ enum ParserTokenSource {
 }
 
 impl ParserTokenSource {
-    fn create_php_token(&self, index: usize) -> PhpResult<Zval> {
+    fn create_php_token_with_classes(&self, index: usize, classes: &PhpClasses) -> PhpResult<Zval> {
         match self {
             Self::Php(tokens) => tokens
                 .get(index)
@@ -955,7 +964,7 @@ impl ParserTokenSource {
                     .get(index)
                     .copied()
                     .ok_or_else(|| php_error("Parser token index is out of range"))?;
-                create_mysql_token(sql_zval, token, *no_backslash)
+                create_mysql_token_with_classes(sql_zval, token, *no_backslash, classes)
             }
         }
     }
@@ -1020,6 +1029,7 @@ struct NativeAstNode {
     children: Vec<NativeAstChild>,
     first_token: Option<usize>,
     last_token: Option<usize>,
+    descendant_count: usize,
 }
 
 struct NativeAstArena {
@@ -1049,10 +1059,12 @@ impl NativeAstArena {
         let index = self.nodes.len();
         let mut first_token = None;
         let mut last_token = None;
+        let mut descendant_count = 0;
         for child in &children {
             match child {
                 NativeAstChild::Node(child_index) => {
                     if let Some(node) = self.nodes.get(*child_index) {
+                        descendant_count += 1 + node.descendant_count;
                         if first_token.is_none() {
                             first_token = node.first_token;
                         }
@@ -1066,6 +1078,7 @@ impl NativeAstArena {
                         first_token = Some(*token_index);
                     }
                     last_token = Some(*token_index);
+                    descendant_count += 1;
                 }
             }
         }
@@ -1075,11 +1088,21 @@ impl NativeAstArena {
             children,
             first_token,
             last_token,
+            descendant_count,
         });
         index
     }
 
     fn create_php_ast(&self, native_ast_zval: &Zval) -> PhpResult<Zval> {
+        let classes = php_classes()?;
+        self.create_php_ast_with_classes(native_ast_zval, &classes)
+    }
+
+    fn create_php_ast_with_classes(
+        &self,
+        native_ast_zval: &Zval,
+        classes: &PhpClasses,
+    ) -> PhpResult<Zval> {
         match self.root {
             NativeAstRoot::No => Ok(Zval::null()),
             NativeAstRoot::Empty => {
@@ -1087,14 +1110,22 @@ impl NativeAstArena {
                 zval.set_bool(true);
                 Ok(zval)
             }
-            NativeAstRoot::Node(index) => self.create_php_node(native_ast_zval, index),
-            NativeAstRoot::Token(index) => self.token_source.create_php_token(index),
+            NativeAstRoot::Node(index) => {
+                self.create_php_node_with_classes(native_ast_zval, index, classes)
+            }
+            NativeAstRoot::Token(index) => self
+                .token_source
+                .create_php_token_with_classes(index, classes),
         }
     }
 
-    fn create_php_node(&self, native_ast_zval: &Zval, index: usize) -> PhpResult<Zval> {
+    fn create_php_node_with_classes(
+        &self,
+        native_ast_zval: &Zval,
+        index: usize,
+        classes: &PhpClasses,
+    ) -> PhpResult<Zval> {
         let node = self.node(index)?;
-        let classes = php_classes()?;
         let mut object = classes.native_parser_node.new();
         let rule_name = self
             .grammar
@@ -1137,10 +1168,19 @@ impl NativeAstArena {
             .ok_or_else(|| php_error("Native AST node index is out of range"))
     }
 
-    fn child_to_zval(&self, native_ast_zval: &Zval, child: NativeAstChild) -> PhpResult<Zval> {
+    fn child_to_zval_with_classes(
+        &self,
+        native_ast_zval: &Zval,
+        child: NativeAstChild,
+        classes: &PhpClasses,
+    ) -> PhpResult<Zval> {
         match child {
-            NativeAstChild::Node(index) => self.create_php_node(native_ast_zval, index),
-            NativeAstChild::Token(index) => self.token_source.create_php_token(index),
+            NativeAstChild::Node(index) => {
+                self.create_php_node_with_classes(native_ast_zval, index, classes)
+            }
+            NativeAstChild::Token(index) => self
+                .token_source
+                .create_php_token_with_classes(index, classes),
         }
     }
 
@@ -1172,8 +1212,9 @@ impl NativeAstArena {
     }
 
     fn descendant_stack(&self, index: usize) -> PhpResult<Vec<NativeAstChild>> {
-        let mut stack = self.node(index)?.children.clone();
-        stack.reverse();
+        let node = self.node(index)?;
+        let mut stack = Vec::with_capacity(node.descendant_count);
+        stack.extend(node.children.iter().rev().copied());
         Ok(stack)
     }
 }
@@ -1238,6 +1279,7 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child(
     node_index: i64,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let Some(child) = ast
         .arena
         .node(native_ast_node_index(node_index)?)?
@@ -1247,7 +1289,8 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child(
     else {
         return Ok(Zval::null());
     };
-    ast.arena.child_to_zval(native_ast_zval, child)
+    ast.arena
+        .child_to_zval_with_classes(native_ast_zval, child, &classes)
 }
 
 #[php_function]
@@ -1257,9 +1300,12 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child_node(
     rule_name: Option<String>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     for child in &ast.arena.node(native_ast_node_index(node_index)?)?.children {
         if ast.arena.child_node_matches(*child, rule_name.as_deref()) {
-            return ast.arena.child_to_zval(native_ast_zval, *child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, *child, &classes);
         }
     }
     Ok(Zval::null())
@@ -1272,9 +1318,12 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child_token(
     token_id: Option<i64>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     for child in &ast.arena.node(native_ast_node_index(node_index)?)?.children {
         if ast.arena.child_token_matches(*child, token_id) {
-            return ast.arena.child_to_zval(native_ast_zval, *child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, *child, &classes);
         }
     }
     Ok(Zval::null())
@@ -1287,12 +1336,15 @@ pub fn wp_sqlite_mysql_native_ast_get_first_descendant_node(
     rule_name: Option<String>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_node_matches(child, rule_name.as_deref()) {
-            return ast.arena.child_to_zval(native_ast_zval, child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
@@ -1310,12 +1362,15 @@ pub fn wp_sqlite_mysql_native_ast_get_first_descendant_token(
     token_id: Option<i64>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_token_matches(child, token_id) {
-            return ast.arena.child_to_zval(native_ast_zval, child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
@@ -1332,12 +1387,16 @@ pub fn wp_sqlite_mysql_native_ast_get_children(
     node_index: i64,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     ast.arena
         .node(native_ast_node_index(node_index)?)?
         .children
         .iter()
         .copied()
-        .map(|child| ast.arena.child_to_zval(native_ast_zval, child))
+        .map(|child| {
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)
+        })
         .collect()
 }
 
@@ -1348,13 +1407,17 @@ pub fn wp_sqlite_mysql_native_ast_get_child_nodes(
     rule_name: Option<String>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     ast.arena
         .node(native_ast_node_index(node_index)?)?
         .children
         .iter()
         .copied()
         .filter(|child| ast.arena.child_node_matches(*child, rule_name.as_deref()))
-        .map(|child| ast.arena.child_to_zval(native_ast_zval, child))
+        .map(|child| {
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)
+        })
         .collect()
 }
 
@@ -1365,13 +1428,17 @@ pub fn wp_sqlite_mysql_native_ast_get_child_tokens(
     token_id: Option<i64>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     ast.arena
         .node(native_ast_node_index(node_index)?)?
         .children
         .iter()
         .copied()
         .filter(|child| ast.arena.child_token_matches(*child, token_id))
-        .map(|child| ast.arena.child_to_zval(native_ast_zval, child))
+        .map(|child| {
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)
+        })
         .collect()
 }
 
@@ -1381,12 +1448,17 @@ pub fn wp_sqlite_mysql_native_ast_get_descendants(
     node_index: i64,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
-    let mut descendants = Vec::new();
+    let classes = php_classes()?;
+    let root = ast.arena.node(native_ast_node_index(node_index)?)?;
+    let mut descendants = Vec::with_capacity(root.descendant_count);
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
-        descendants.push(ast.arena.child_to_zval(native_ast_zval, child)?);
+        descendants.push(
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)?,
+        );
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
                 stack.push(*child);
@@ -1403,13 +1475,18 @@ pub fn wp_sqlite_mysql_native_ast_get_descendant_nodes(
     rule_name: Option<String>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut descendants = Vec::new();
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_node_matches(child, rule_name.as_deref()) {
-            descendants.push(ast.arena.child_to_zval(native_ast_zval, child)?);
+            descendants.push(ast.arena.child_to_zval_with_classes(
+                native_ast_zval,
+                child,
+                &classes,
+            )?);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
@@ -1427,13 +1504,18 @@ pub fn wp_sqlite_mysql_native_ast_get_descendant_tokens(
     token_id: Option<i64>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut descendants = Vec::new();
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_token_matches(child, token_id) {
-            descendants.push(ast.arena.child_to_zval(native_ast_zval, child)?);
+            descendants.push(ast.arena.child_to_zval_with_classes(
+                native_ast_zval,
+                child,
+                &classes,
+            )?);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {

--- a/packages/php-ext-wp-mysql-parser/src/lib.rs
+++ b/packages/php-ext-wp-mysql-parser/src/lib.rs
@@ -1587,6 +1587,18 @@ impl WpMySqlNativeParser {
         })
     }
 
+    pub fn reset_tokens(&mut self, tokens: &mut Zval) -> PhpResult<()> {
+        let (token_source, token_ids) = export_tokens(tokens)?;
+
+        self.token_source = Arc::new(token_source);
+        self.token_ids = token_ids;
+        self.position = 0;
+        self.current_ast = None;
+        self.current_php_ast = None;
+
+        Ok(())
+    }
+
     pub fn parse(&mut self) -> PhpResult<Zval> {
         stacker::maybe_grow(STACK_RED_ZONE, STACK_GROW_SIZE, || {
             let ast = self.parse_native_ast()?;


### PR DESCRIPTION
## Summary
- reuse one `WP_MySQL_Parser` instance inside the SQLite driver and reset its token stream per query
- add `reset_tokens()` to the PHP parser polyfill and the Rust native parser
- restore native parser-node accessor fast paths in `WP_MySQL_Native_Parser_Node`, while keeping PHP child materialization for mutation
- fix the local native extension build helper for Nix/libclang bindgen by undefining `__SSE2__` during binding generation

## Stack
This is the top PR in the native MySQL lexer/parser stack. The stack is split so each GitHub diff shows one reviewable concern:

1. [#384 Extract MySQL lexer and parser polyfills](https://github.com/WordPress/sqlite-database-integration/pull/384)
   - `trunk` -> `codex/native-parser-php-facade`
   - extraction-only PHP refactor
   - moves the existing PHP lexer/parser implementations into polyfill classes
   - keeps public `WP_MySQL_Lexer` and `WP_MySQL_Parser` as thin PHP subclasses

2. [#385 Add optional native parser routing](https://github.com/WordPress/sqlite-database-integration/pull/385)
   - `codex/native-parser-php-facade` -> `codex/native-parser-class-routing`
   - adds fallback `WP_MySQL_Native_*` PHP classes
   - routes the public lexer/parser classes through native classes when the Rust extension provides them
   - adds the minimal PHP grammar-export bridge for the native parser

3. [#386 Add lazy native parser node facade](https://github.com/WordPress/sqlite-database-integration/pull/386)
   - `codex/native-parser-class-routing` -> `codex/native-parser-node-facade`
   - keeps `WP_Parser_Node` as the plain PHP tree node
   - adds `WP_MySQL_Native_Parser_Node extends WP_Parser_Node` for native-backed lazy AST nodes
   - keeps native AST handles and native accessor delegation out of the base node class

4. [#381 Add lazy native AST facade](https://github.com/WordPress/sqlite-database-integration/pull/381)
   - `codex/native-parser-node-facade` -> `codex/native-lazy-ast-facade`
   - implements the Rust lexer/parser extension and lazy native AST facade
   - makes the Rust extension instantiate `WP_MySQL_Native_Parser_Node`
   - adds native-extension CI coverage for the SQLite driver and WordPress PHPUnit tests
   - includes the local SQLite facade smoke benchmark

5. [#387 Cache native grammar on parser grammar object](https://github.com/WordPress/sqlite-database-integration/pull/387)
   - `codex/native-lazy-ast-facade` -> `codex/native-parser-object-grammar-cache`
   - restores the object-attached native grammar cache
   - adds only `WP_Parser_Grammar::$native_grammar` on the PHP side
   - removes the Rust content-hash cache that walked the whole exported grammar on every parser construction

6. This PR, [#388 Speed up native AST materialization](https://github.com/WordPress/sqlite-database-integration/pull/388)
   - `codex/native-parser-object-grammar-cache` -> `codex/native-parser-bulk-materialization`
   - optimizes native-to-PHP AST access after the grammar-cache performance restoration
   - reuses the SQLite driver's parser instance instead of constructing it per query

## Why
The native lexer/parser itself is fast, but the PHP-facing path can lose that benefit if each query repeatedly rebuilds native parser state or forces full PHP AST materialization. On the current stack, #387 already removes the large grammar export/hash cost. This PR removes the remaining per-query parser construction churn and restores the native AST accessor path for descendant-heavy SQLite driver workloads.

## Measurements
Environment: local PHP 8.2 via the native build helper, release Rust extension, current top of this PR.

Focused constructor/reset benchmark over 5000 unique SELECT queries:

| Phase | Time |
| --- | ---: |
| native tokenize | 22.62 us/query |
| fresh native parser constructor only | 2.31 us/query |
| reusable parser `reset_tokens()` only | 0.32 us/query |
| reusable parser reset + parse + `get_descendants()` | 157.06 us/query |
| constructor/reset ratio | 7.3x |

The previously reported ~622 us/query constructor cost does not reproduce on this stack because #387 already caches the native grammar on the PHP grammar object. Parser reuse still removes most of the remaining constructor overhead.

SQLite facade smoke workload:

Command:

```bash
TMP_TEST_NATIVE_QUERY_COUNT=250 ./tmp-test-native/run.sh
```

| Workload | PHP fallback | Native extension | Speedup |
| --- | ---: | ---: | ---: |
| 250 generated queries, including 1 x 2000-row insert | 4.060s | 0.525s | 7.73x |

## Testing
- `cargo fmt --check`
- `git diff --check`
- `composer run check-cs`
- `composer run test` from `packages/mysql-on-sqlite`
- `php -d extension=packages/mysql-on-sqlite/ext/wp-mysql-parser/target/release/libwp_mysql_parser.so packages/mysql-on-sqlite/vendor/bin/phpunit -c packages/mysql-on-sqlite/phpunit.xml.dist`
- `TMP_TEST_NATIVE_QUERY_COUNT=250 ./tmp-test-native/run.sh`