### PR TITLE
Add Rust parser bridge helpers

### DIFF
--- a/packages/mysql-on-sqlite/src/load.php
+++ b/packages/mysql-on-sqlite/src/load.php
@@ -26,6 +26,7 @@ if ( class_exists( 'WP_MySQL_Native_Lexer', false ) ) {
 }
 
 if ( class_exists( 'WP_MySQL_Native_Parser', false ) ) {
+	require_once __DIR__ . '/mysql/native/mysql-rust-bridge.php';
 	require_once __DIR__ . '/mysql/native/class-wp-mysql-parser.php';
 } else {
 	require_once __DIR__ . '/mysql/class-wp-mysql-parser.php';

--- a/packages/mysql-on-sqlite/src/mysql/native/mysql-rust-bridge.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/mysql-rust-bridge.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Bridge helpers for the optional Rust MySQL lexer/parser extension.
+ * PHP keeps the grammar object, while Rust owns the exported parser state.
+ */
+
+/**
+ * Export grammar internals for the native parser.
+ *
+ * @param WP_Parser_Grammar $grammar Parser grammar.
+ * @return array<string, mixed>
+ */
+function wp_sqlite_mysql_native_export_grammar( WP_Parser_Grammar $grammar ): array {
+	return array(
+		'highest_terminal_id'         => $grammar->highest_terminal_id,
+		'rules'                       => $grammar->rules,
+		'lookahead_is_match_possible' => $grammar->lookahead_is_match_possible,
+		'rule_names'                  => $grammar->rule_names,
+		'fragment_ids'                => $grammar->fragment_ids,
+	);
+}


### PR DESCRIPTION
## Summary

When a native MySQL parser extension declares `WP_MySQL_Native_Parser`, load a small bridge file that exposes `WP_Parser_Grammar` internals to the extension. The native parser needs the grammar's terminal table, rules, and lookahead map, but those live on a PHP object — the bridge function hands them out as a plain array the extension can consume.

The bridge file lives under `mysql/native/` since it's only required when a native parser is in use.

## Testing

- `php -l` on changed files
- `phpcs` clean