### PR TITLE
Preserve child wrapper identity in the native AST facade

### DIFF
--- a/.github/workflows/mysql-parser-extension-tests.yml
+++ b/.github/workflows/mysql-parser-extension-tests.yml
@@ -81,7 +81,10 @@ jobs:
               exit( 1 );
           }
           '
-          ./vendor/bin/phpunit -c ./phpunit.xml.dist tests/mysql/WP_MySQL_Lexer_Tests.php tests/parser/WP_Parser_Node_Tests.php
+        working-directory: packages/mysql-on-sqlite
+
+      - name: Run PHPUnit tests with parser extension
+        run: php -d extension="$GITHUB_WORKSPACE/packages/php-ext-wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
         working-directory: packages/mysql-on-sqlite
 
   sqlite-driver-extension-tests:
@@ -149,3 +152,7 @@ jobs:
               exit( 1 );
           }
           '
+
+      - name: Run PHPUnit tests with SQLite driver using parser extension
+        run: php -d extension="$GITHUB_WORKSPACE/packages/php-ext-wp-mysql-parser/target/debug/libwp_mysql_parser.so" ./vendor/bin/phpunit -c ./phpunit.xml.dist
+        working-directory: packages/mysql-on-sqlite

--- a/.github/workflows/native-ast-perf.yml
+++ b/.github/workflows/native-ast-perf.yml
@@ -120,14 +120,14 @@ jobs:
       - name: Benchmark — baseline native path (walk, no identity cache)
         working-directory: ../baseline/packages/mysql-on-sqlite
         run: |
-          BASE_EXT="$(realpath ../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
+          BASE_EXT="$(realpath ../../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
           php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php \
             | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-walk.txt"
 
       - name: Benchmark — baseline native path (parse only)
         working-directory: ../baseline/packages/mysql-on-sqlite
         run: |
-          BASE_EXT="$(realpath ../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
+          BASE_EXT="$(realpath ../../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
           php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php --no-walk \
             | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-parse-only.txt"
 

--- a/.github/workflows/native-ast-perf.yml
+++ b/.github/workflows/native-ast-perf.yml
@@ -131,6 +131,48 @@ jobs:
           php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php --no-walk \
             | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-parse-only.txt"
 
+      # Hit-heavy scenarios — these are where the per-AST identity cache is
+      # supposed to win. The baseline reallocates wrappers on every accessor
+      # call, while the PR reuses them. Run on both to make the gap visible.
+      - name: Benchmark — native rewalk x10 (this PR)
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          php -d extension="$NATIVE_EXT" tests/tools/run-native-ast-walk-benchmark.php --mode=rewalk --repeat=10 \
+            | tee native-rewalk.txt
+
+      - name: Benchmark — baseline rewalk x10
+        working-directory: ../baseline/packages/mysql-on-sqlite
+        run: |
+          BASE_EXT="$(realpath ../../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
+          php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php --mode=rewalk --repeat=10 \
+            | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-rewalk.txt"
+
+      - name: Benchmark — native reread x20 (this PR)
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          php -d extension="$NATIVE_EXT" tests/tools/run-native-ast-walk-benchmark.php --mode=reread --repeat=20 \
+            | tee native-reread.txt
+
+      - name: Benchmark — baseline reread x20
+        working-directory: ../baseline/packages/mysql-on-sqlite
+        run: |
+          BASE_EXT="$(realpath ../../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
+          php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php --mode=reread --repeat=20 \
+            | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-reread.txt"
+
+      - name: Benchmark — native subtree x5 (this PR)
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          php -d extension="$NATIVE_EXT" tests/tools/run-native-ast-walk-benchmark.php --mode=subtree --repeat=5 \
+            | tee native-subtree.txt
+
+      - name: Benchmark — baseline subtree x5
+        working-directory: ../baseline/packages/mysql-on-sqlite
+        run: |
+          BASE_EXT="$(realpath ../../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
+          php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php --mode=subtree --repeat=5 \
+            | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-subtree.txt"
+
       - name: Summarize
         if: always()
         working-directory: packages/mysql-on-sqlite
@@ -148,7 +190,7 @@ jobs:
             echo
             echo '| scenario | result |'
             echo '|---|---|'
-            for f in php-parse-only.txt php-walk.txt native-parse-only.txt native-walk.txt baseline-native-parse-only.txt baseline-native-walk.txt; do
+            for f in php-parse-only.txt php-walk.txt native-parse-only.txt native-walk.txt baseline-native-parse-only.txt baseline-native-walk.txt native-rewalk.txt baseline-native-rewalk.txt native-reread.txt baseline-native-reread.txt native-subtree.txt baseline-native-subtree.txt; do
               [ -f "$f" ] || continue
               line="$(cat "$f")"
               echo "| ${f%.txt} | \`$line\` |"

--- a/.github/workflows/native-ast-perf.yml
+++ b/.github/workflows/native-ast-perf.yml
@@ -93,19 +93,75 @@ jobs:
         run: |
           php -d extension="$NATIVE_EXT" tests/tools/run-native-ast-walk-benchmark.php | tee native-walk.txt
 
+      - name: Check out baseline (PR base, no identity cache)
+        run: |
+          git fetch --no-tags --depth=1 origin codex/native-lazy-ast-facade
+          git worktree add ../baseline FETCH_HEAD
+
+      - name: Install Composer dependencies (baseline mysql-on-sqlite)
+        uses: ramsey/composer-install@v3
+        with:
+          working-directory: ../baseline/packages/mysql-on-sqlite
+          ignore-cache: "yes"
+          composer-options: "--optimize-autoloader"
+
+      - name: Build baseline parser extension (release)
+        run: cargo build --release
+        working-directory: ../baseline/packages/php-ext-wp-mysql-parser
+
+      - name: Stage benchmark + corpus into baseline
+        run: |
+          mkdir -p ../baseline/packages/mysql-on-sqlite/tests/mysql/data
+          cp packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php \
+             ../baseline/packages/mysql-on-sqlite/tests/tools/
+          cp packages/mysql-on-sqlite/tests/mysql/data/*.csv \
+             ../baseline/packages/mysql-on-sqlite/tests/mysql/data/ 2>/dev/null || true
+
+      - name: Benchmark — baseline native path (walk, no identity cache)
+        working-directory: ../baseline/packages/mysql-on-sqlite
+        run: |
+          BASE_EXT="$(realpath ../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
+          php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php \
+            | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-walk.txt"
+
+      - name: Benchmark — baseline native path (parse only)
+        working-directory: ../baseline/packages/mysql-on-sqlite
+        run: |
+          BASE_EXT="$(realpath ../packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so)"
+          php -d extension="$BASE_EXT" tests/tools/run-native-ast-walk-benchmark.php --no-walk \
+            | tee "$GITHUB_WORKSPACE/packages/mysql-on-sqlite/baseline-native-parse-only.txt"
+
       - name: Summarize
         if: always()
         working-directory: packages/mysql-on-sqlite
         run: |
+          extract() {
+            # Pull a numeric field (e.g. duration=1.23s) from a benchmark
+            # output line. Returns "n/a" if missing.
+            local file="$1" key="$2"
+            [ -f "$file" ] || { echo "n/a"; return; }
+            grep -oE "${key}=[^ ]+" "$file" | head -1 | cut -d= -f2 || echo "n/a"
+          }
+
           {
             echo '### Native AST walk perf'
             echo
             echo '| scenario | result |'
             echo '|---|---|'
-            for f in php-parse-only.txt php-walk.txt native-parse-only.txt native-walk.txt; do
+            for f in php-parse-only.txt php-walk.txt native-parse-only.txt native-walk.txt baseline-native-parse-only.txt baseline-native-walk.txt; do
               [ -f "$f" ] || continue
               line="$(cat "$f")"
               echo "| ${f%.txt} | \`$line\` |"
+            done
+            echo
+            echo '### Identity-cache cost (native walk: with cache vs PR base without)'
+            echo
+            echo '| metric | with cache (this PR) | baseline | delta |'
+            echo '|---|---|---|---|'
+            for key in duration qps peak_mem walked_nodes; do
+              with="$(extract native-walk.txt "$key")"
+              base="$(extract baseline-native-walk.txt "$key")"
+              echo "| $key | $with | $base | — |"
             done
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/native-ast-perf.yml
+++ b/.github/workflows/native-ast-perf.yml
@@ -1,0 +1,118 @@
+name: Native AST Walk Perf
+
+on:
+  push:
+    paths:
+      - '.github/workflows/native-ast-perf.yml'
+      - 'packages/mysql-on-sqlite/src/mysql/native/**'
+      - 'packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php'
+      - 'packages/php-ext-wp-mysql-parser/**'
+  pull_request:
+    paths:
+      - '.github/workflows/native-ast-perf.yml'
+      - 'packages/mysql-on-sqlite/src/mysql/native/**'
+      - 'packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php'
+      - 'packages/php-ext-wp-mysql-parser/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perf:
+    name: Native AST walk benchmark
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libclang-dev
+          echo "PHP_CONFIG=$(command -v php-config)" >> "$GITHUB_ENV"
+          LIBCLANG_SO="$(find /usr/lib -name 'libclang.so*' | head -n 1)"
+          echo "LIBCLANG_PATH=$(dirname "$LIBCLANG_SO")" >> "$GITHUB_ENV"
+
+      - name: Install Composer dependencies (root)
+        uses: ramsey/composer-install@v3
+        with:
+          ignore-cache: "yes"
+          composer-options: "--optimize-autoloader"
+
+      - name: Install Composer dependencies (mysql-on-sqlite)
+        uses: ramsey/composer-install@v3
+        with:
+          working-directory: packages/mysql-on-sqlite
+          ignore-cache: "yes"
+          composer-options: "--optimize-autoloader"
+
+      - name: Download MySQL test query corpus
+        working-directory: packages/mysql-on-sqlite
+        run: bash tests/tools/mysql-download-tests.sh || true
+
+      - name: Build parser extension (release)
+        run: cargo build --release
+        working-directory: packages/php-ext-wp-mysql-parser
+
+      - name: Locate built extension
+        run: |
+          EXT="$GITHUB_WORKSPACE/packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so"
+          test -f "$EXT" || { echo "Extension not built at $EXT"; exit 1; }
+          echo "NATIVE_EXT=$EXT" >> "$GITHUB_ENV"
+
+      - name: Benchmark — pure-PHP path (parse only)
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          php tests/tools/run-native-ast-walk-benchmark.php --no-walk | tee php-parse-only.txt
+
+      - name: Benchmark — pure-PHP path (walk)
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          php tests/tools/run-native-ast-walk-benchmark.php | tee php-walk.txt
+
+      - name: Benchmark — native path (parse only)
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          php -d extension="$NATIVE_EXT" tests/tools/run-native-ast-walk-benchmark.php --no-walk | tee native-parse-only.txt
+
+      - name: Benchmark — native path (walk, with identity cache)
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          php -d extension="$NATIVE_EXT" tests/tools/run-native-ast-walk-benchmark.php | tee native-walk.txt
+
+      - name: Summarize
+        if: always()
+        working-directory: packages/mysql-on-sqlite
+        run: |
+          {
+            echo '### Native AST walk perf'
+            echo
+            echo '| scenario | result |'
+            echo '|---|---|'
+            for f in php-parse-only.txt php-walk.txt native-parse-only.txt native-walk.txt; do
+              [ -f "$f" ] || continue
+              line="$(cat "$f")"
+              echo "| ${f%.txt} | \`$line\` |"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-ast-perf-${{ github.run_id }}
+          path: packages/mysql-on-sqlite/*.txt
+          if-no-files-found: warn

--- a/.github/workflows/wp-tests-phpunit.yml
+++ b/.github/workflows/wp-tests-phpunit.yml
@@ -54,8 +54,8 @@ jobs:
       - name: Build and load parser extension in WordPress PHP containers
         run: bash .github/workflows/wp-tests-phpunit-native-extension-setup.sh
 
-      - name: Verify WordPress uses parser extension
-        run: cd wordpress && node tools/local-env/scripts/docker.js run --rm php php /var/www/native-verify-extension.php
+      - name: Run WordPress PHPUnit tests with parser extension
+        run: node .github/workflows/wp-tests-phpunit-run.js
 
       - name: Stop Docker containers
         if: always()

--- a/packages/mysql-on-sqlite/src/load.php
+++ b/packages/mysql-on-sqlite/src/load.php
@@ -27,6 +27,7 @@ if ( class_exists( 'WP_MySQL_Native_Lexer', false ) ) {
 
 if ( class_exists( 'WP_MySQL_Native_Parser', false ) ) {
 	require_once __DIR__ . '/mysql/native/mysql-rust-bridge.php';
+	require_once __DIR__ . '/mysql/native/class-wp-mysql-native-ast-cache.php';
 	require_once __DIR__ . '/mysql/native/class-wp-mysql-native-parser-node.php';
 	require_once __DIR__ . '/mysql/native/class-wp-mysql-parser.php';
 } else {

--- a/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php
+++ b/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php
@@ -9,6 +9,17 @@ class WP_MySQL_Parser extends WP_Parser {
 	private $current_ast;
 
 	/**
+	 * Reset this parser with a new token stream.
+	 *
+	 * @param array<WP_Parser_Token> $tokens The parser tokens.
+	 */
+	public function reset_tokens( array $tokens ): void {
+		$this->tokens      = $tokens;
+		$this->position    = 0;
+		$this->current_ast = null;
+	}
+
+	/**
 	 * Parse the next query from the input SQL string.
 	 *
 	 * This method reads tokens until a query is parsed, or the parsing fails.

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-ast-cache.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-ast-cache.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Per-AST identity map for native parser node wrappers.
+ *
+ * The native parser extension constructs a fresh WP_MySQL_Native_Parser_Node
+ * every time it returns a child or descendant. Without an identity map, two
+ * reads of the same logical node would yield distinct PHP objects, breaking
+ * the WP_Parser_Node contract that callers can mutate a child in place and
+ * see the mutation again when they walk the tree later.
+ *
+ * One cache is created lazily on the root node and shared by reference with
+ * every wrapper interned through it. Lookup is keyed by the Rust-side
+ * `node_index`, which is stable for the lifetime of the AST.
+ */
+class WP_MySQL_Native_AST_Cache {
+	/**
+	 * Map of native node index => WP_MySQL_Native_Parser_Node.
+	 *
+	 * @var array<int, WP_MySQL_Native_Parser_Node>
+	 */
+	public $nodes = array();
+}

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -143,7 +143,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_child_nodes( $rule_name );
 		}
-		return $this->intern_all( wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name ) );
+		return $this->intern_nodes( wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name ) );
 	}
 
 	/** @inheritDoc */
@@ -167,7 +167,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_descendant_nodes( $rule_name );
 		}
-		return $this->intern_all( wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name ) );
+		return $this->intern_nodes( wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name ) );
 	}
 
 	/** @inheritDoc */
@@ -231,12 +231,62 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 	/**
 	 * Intern every entry in an accessor return array.
 	 *
+	 * Hot path: this runs once per descendant when a caller walks the tree,
+	 * so cache lookup and the cache-miss write are inlined and the cache
+	 * reference is hoisted out of the loop.
+	 *
 	 * @param array $values
 	 * @return array
 	 */
 	private function intern_all( array $values ): array {
+		if ( ! $values ) {
+			return $values;
+		}
+		$cache = $this->cache ?? $this->ensure_cache();
+		$nodes = &$cache->nodes;
 		foreach ( $values as $i => $value ) {
-			$values[ $i ] = $this->intern( $value );
+			if ( ! $value instanceof WP_MySQL_Native_Parser_Node ) {
+				continue;
+			}
+			$index = $value->native_node_index;
+			if ( null === $index ) {
+				continue;
+			}
+			if ( isset( $nodes[ $index ] ) ) {
+				$values[ $i ] = $nodes[ $index ];
+			} else {
+				$value->cache    = $cache;
+				$nodes[ $index ] = $value;
+			}
+		}
+		return $values;
+	}
+
+	/**
+	 * Intern array of guaranteed-node results (no token/null mixing).
+	 *
+	 * Used by `get_child_nodes()` / `get_descendant_nodes()` whose Rust
+	 * bridge returns only WP_MySQL_Native_Parser_Node instances. Skips
+	 * the per-item `instanceof` check that intern_all() must do for the
+	 * mixed `get_children()` / `get_descendants()` arrays.
+	 *
+	 * @param array $values
+	 * @return array
+	 */
+	private function intern_nodes( array $values ): array {
+		if ( ! $values ) {
+			return $values;
+		}
+		$cache = $this->cache ?? $this->ensure_cache();
+		$nodes = &$cache->nodes;
+		foreach ( $values as $i => $value ) {
+			$index = $value->native_node_index;
+			if ( isset( $nodes[ $index ] ) ) {
+				$values[ $i ] = $nodes[ $index ];
+			} else {
+				$value->cache    = $cache;
+				$nodes[ $index ] = $value;
+			}
 		}
 		return $values;
 	}

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -223,7 +223,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( isset( $cache->nodes[ $index ] ) ) {
 			return $cache->nodes[ $index ];
 		}
-		$value->cache          = $cache;
+		$value->cache           = $cache;
 		$cache->nodes[ $index ] = $value;
 		return $value;
 	}

--- a/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
+++ b/packages/mysql-on-sqlite/src/mysql/native/class-wp-mysql-native-parser-node.php
@@ -8,17 +8,47 @@
  * caller actually walks the tree. On the first mutation (append_child or
  * merge_fragment), the node materializes its children into the inherited
  * `$children` array and behaves like a plain WP_Parser_Node from then on.
+ *
+ * Wrappers returned by accessors are interned through a per-AST identity
+ * map (WP_MySQL_Native_AST_Cache) so two reads of the same logical node
+ * yield the same PHP instance. This preserves the WP_Parser_Node contract
+ * that mutations performed on a child via `get_first_child_node()` remain
+ * visible when the same child is reached again, including after the parent
+ * has materialized.
  */
 class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 	private $native_ast        = null;
 	private $native_node_index = null;
 	private $was_mutated       = false;
 
+	/**
+	 * Per-AST identity map shared between every interned wrapper.
+	 *
+	 * Created lazily on the first child access; the root wrapper is the
+	 * first entry. Children inherit the same cache instance by reference.
+	 *
+	 * @var WP_MySQL_Native_AST_Cache|null
+	 */
+	private $cache = null;
+
 	public function __construct( $rule_id, $rule_name, $native_ast = null, $native_node_index = null ) {
 		parent::__construct( $rule_id, $rule_name );
 
 		$this->native_ast        = $native_ast;
 		$this->native_node_index = $native_node_index;
+	}
+
+	/**
+	 * Native node index in the Rust-owned arena.
+	 *
+	 * Exposed so the identity cache can key on it. Returns null after
+	 * the wrapper has materialized — at that point the node is detached
+	 * from the native arena and behaves like a plain WP_Parser_Node.
+	 *
+	 * @return int|null
+	 */
+	public function get_native_node_index(): ?int {
+		return $this->native_node_index;
 	}
 
 	/** @inheritDoc */
@@ -65,7 +95,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_first_child();
 		}
-		return wp_sqlite_mysql_native_ast_get_first_child( $this->native_ast, $this->native_node_index );
+		return $this->intern( wp_sqlite_mysql_native_ast_get_first_child( $this->native_ast, $this->native_node_index ) );
 	}
 
 	/** @inheritDoc */
@@ -73,7 +103,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_first_child_node( $rule_name );
 		}
-		return wp_sqlite_mysql_native_ast_get_first_child_node( $this->native_ast, $this->native_node_index, $rule_name );
+		return $this->intern( wp_sqlite_mysql_native_ast_get_first_child_node( $this->native_ast, $this->native_node_index, $rule_name ) );
 	}
 
 	/** @inheritDoc */
@@ -89,7 +119,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_first_descendant_node( $rule_name );
 		}
-		return wp_sqlite_mysql_native_ast_get_first_descendant_node( $this->native_ast, $this->native_node_index, $rule_name );
+		return $this->intern( wp_sqlite_mysql_native_ast_get_first_descendant_node( $this->native_ast, $this->native_node_index, $rule_name ) );
 	}
 
 	/** @inheritDoc */
@@ -105,7 +135,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_children();
 		}
-		return wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
+		return $this->intern_all( wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index ) );
 	}
 
 	/** @inheritDoc */
@@ -113,7 +143,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_child_nodes( $rule_name );
 		}
-		return wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name );
+		return $this->intern_all( wp_sqlite_mysql_native_ast_get_child_nodes( $this->native_ast, $this->native_node_index, $rule_name ) );
 	}
 
 	/** @inheritDoc */
@@ -129,7 +159,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_descendants();
 		}
-		return wp_sqlite_mysql_native_ast_get_descendants( $this->native_ast, $this->native_node_index );
+		return $this->intern_all( wp_sqlite_mysql_native_ast_get_descendants( $this->native_ast, $this->native_node_index ) );
 	}
 
 	/** @inheritDoc */
@@ -137,7 +167,7 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		if ( $this->was_mutated() ) {
 			return parent::get_descendant_nodes( $rule_name );
 		}
-		return wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name );
+		return $this->intern_all( wp_sqlite_mysql_native_ast_get_descendant_nodes( $this->native_ast, $this->native_node_index, $rule_name ) );
 	}
 
 	/** @inheritDoc */
@@ -168,12 +198,78 @@ class WP_MySQL_Native_Parser_Node extends WP_Parser_Node {
 		return $this->was_mutated;
 	}
 
+	/**
+	 * Intern a single accessor return value through the per-AST cache.
+	 *
+	 * Tokens and nulls pass through untouched. Native node wrappers are
+	 * keyed on their `native_node_index`: on cache miss, the freshly
+	 * constructed wrapper is stored and given the cache reference; on
+	 * cache hit, the canonical instance is returned and the new wrapper
+	 * is discarded so callers see stable identity and surviving mutations.
+	 *
+	 * @param mixed $value Return value from the Rust bridge.
+	 * @return mixed
+	 */
+	private function intern( $value ) {
+		if ( ! $value instanceof WP_MySQL_Native_Parser_Node ) {
+			return $value;
+		}
+
+		$cache = $this->ensure_cache();
+		$index = $value->native_node_index;
+		if ( null === $index ) {
+			return $value;
+		}
+		if ( isset( $cache->nodes[ $index ] ) ) {
+			return $cache->nodes[ $index ];
+		}
+		$value->cache          = $cache;
+		$cache->nodes[ $index ] = $value;
+		return $value;
+	}
+
+	/**
+	 * Intern every entry in an accessor return array.
+	 *
+	 * @param array $values
+	 * @return array
+	 */
+	private function intern_all( array $values ): array {
+		foreach ( $values as $i => $value ) {
+			$values[ $i ] = $this->intern( $value );
+		}
+		return $values;
+	}
+
+	/**
+	 * Lazily build (or reuse) the per-AST identity map.
+	 *
+	 * The root wrapper is constructed without a cache, so the first time
+	 * any accessor needs to intern a child, it creates the cache and
+	 * registers itself as the root entry. Subsequent interns on this
+	 * wrapper or any descendant share the same cache by reference.
+	 *
+	 * @return WP_MySQL_Native_AST_Cache
+	 */
+	private function ensure_cache(): WP_MySQL_Native_AST_Cache {
+		if ( null === $this->cache ) {
+			$this->cache = new WP_MySQL_Native_AST_Cache();
+			if ( null !== $this->native_node_index ) {
+				$this->cache->nodes[ $this->native_node_index ] = $this;
+			}
+		}
+		return $this->cache;
+	}
+
 	private function materialize_native_children(): void {
 		if ( $this->was_mutated ) {
 			return;
 		}
 
-		$this->children          = wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index );
+		// Pull children through the cache so any wrapper a caller already
+		// mutated via get_first_child_node() etc. survives the transition
+		// into $this->children — same instance, same mutations.
+		$this->children          = $this->intern_all( wp_sqlite_mysql_native_ast_get_children( $this->native_ast, $this->native_node_index ) );
 		$this->native_ast        = null;
 		$this->native_node_index = null;
 		$this->was_mutated       = true;

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
@@ -32,6 +32,7 @@ class WP_Parser_Grammar {
 	public $lookahead_is_match_possible = array();
 	public $lowest_non_terminal_id;
 	public $highest_terminal_id;
+	public $native_grammar;
 
 	public function __construct( array $rules ) {
 		$this->inflate( $rules );

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -411,6 +411,13 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	private static $mysql_grammar;
 
 	/**
+	 * A reusable parser instance for MySQL queries.
+	 *
+	 * @var WP_MySQL_Parser|null
+	 */
+	private $mysql_parser = null;
+
+	/**
 	 * The main database name.
 	 *
 	 * The name of the main database that is used by the driver.
@@ -1160,11 +1167,27 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		);
 		if ( $lexer instanceof WP_MySQL_Native_Lexer ) {
 			$tokens = $lexer->native_token_stream();
-			return new WP_MySQL_Parser( self::$mysql_grammar, $tokens );
+			return $this->reset_or_create_parser( $tokens );
 		}
 
 		$tokens = $lexer->remaining_tokens();
-		return new WP_MySQL_Parser( self::$mysql_grammar, $tokens );
+		return $this->reset_or_create_parser( $tokens );
+	}
+
+	/**
+	 * Reset the reusable parser with new tokens or create it on first use.
+	 *
+	 * @param  array<WP_Parser_Token>|object $tokens Parser tokens.
+	 * @return WP_MySQL_Parser                       A parser initialized for the token stream.
+	 */
+	private function reset_or_create_parser( $tokens ): WP_MySQL_Parser {
+		if ( null === $this->mysql_parser || ! method_exists( $this->mysql_parser, 'reset_tokens' ) ) {
+			$this->mysql_parser = new WP_MySQL_Parser( self::$mysql_grammar, $tokens );
+		} else {
+			$this->mysql_parser->reset_tokens( $tokens );
+		}
+
+		return $this->mysql_parser;
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/tests/mysql/native/WP_MySQL_Native_Parser_Node_Identity_Tests.php
+++ b/packages/mysql-on-sqlite/tests/mysql/native/WP_MySQL_Native_Parser_Node_Identity_Tests.php
@@ -1,0 +1,115 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression tests for the per-AST identity map on native parser nodes.
+ *
+ * The native extension constructs a fresh PHP wrapper for every accessor
+ * call. Without interning, two reads of the same logical node would yield
+ * distinct objects, and a mutation made through the first wrapper would
+ * be invisible through the second. WP_Parser_Node exposes public mutators
+ * and stable child identity, so the native wrapper must preserve both.
+ *
+ * Skipped when the native extension is not loaded — the pure-PHP code
+ * path already has stable identity by construction.
+ */
+class WP_MySQL_Native_Parser_Node_Identity_Tests extends TestCase {
+
+	protected function setUp(): void {
+		if ( ! class_exists( 'WP_MySQL_Native_Parser', false ) ) {
+			$this->markTestSkipped( 'Native MySQL parser extension is not loaded.' );
+		}
+	}
+
+	private function parse( string $sql ): WP_Parser_Node {
+		static $grammar = null;
+		if ( null === $grammar ) {
+			$grammar = new WP_Parser_Grammar( include __DIR__ . '/../../../src/mysql/mysql-grammar.php' );
+		}
+		$lexer  = new WP_MySQL_Lexer( $sql );
+		$tokens = $lexer instanceof WP_MySQL_Native_Lexer
+			? $lexer->native_token_stream()
+			: $lexer->remaining_tokens();
+		$parser = new WP_MySQL_Parser( $grammar, $tokens );
+		$tree   = $parser->parse();
+		$this->assertNotNull( $tree, 'Failed to parse SQL: ' . $sql );
+		return $tree;
+	}
+
+	public function test_get_first_child_node_returns_same_instance(): void {
+		$tree = $this->parse( 'SELECT 1 + 2' );
+
+		$first  = $tree->get_first_child_node();
+		$second = $tree->get_first_child_node();
+
+		$this->assertNotNull( $first );
+		$this->assertSame( $first, $second );
+	}
+
+	public function test_get_children_returns_same_instances_across_calls(): void {
+		$tree = $this->parse( 'SELECT 1, 2, 3' );
+
+		$first_pass  = $tree->get_children();
+		$second_pass = $tree->get_children();
+
+		$this->assertSameSize( $first_pass, $second_pass );
+		foreach ( $first_pass as $i => $child ) {
+			if ( $child instanceof WP_Parser_Node ) {
+				$this->assertSame( $child, $second_pass[ $i ] );
+			}
+		}
+	}
+
+	public function test_descendant_lookup_shares_identity_with_child_lookup(): void {
+		$tree = $this->parse( 'SELECT 1 + 2' );
+
+		$descendant = $tree->get_first_descendant_node();
+		$this->assertNotNull( $descendant );
+
+		// Walk down to the same node via direct children. We don't know the
+		// exact depth, so we descend until we hit the descendant we found.
+		$cursor = $tree;
+		while ( null !== $cursor && $cursor !== $descendant ) {
+			$next = $cursor->get_first_child_node();
+			if ( $next === $cursor ) {
+				break;
+			}
+			$cursor = $next;
+		}
+
+		$this->assertSame( $descendant, $cursor, 'Descendant and child lookups must return the same wrapper instance.' );
+	}
+
+	public function test_mutation_on_child_survives_re_read(): void {
+		$tree = $this->parse( 'SELECT 1 + 2' );
+
+		$child = $tree->get_first_child_node();
+		$this->assertNotNull( $child );
+
+		// Public dynamic property — the kind of state a caller might attach
+		// expecting WP_Parser_Node identity to keep it reachable.
+		$child->custom_marker = 'set-on-first-read';
+
+		$same_child = $tree->get_first_child_node();
+		$this->assertSame( $child, $same_child );
+		$this->assertSame( 'set-on-first-read', $same_child->custom_marker );
+	}
+
+	public function test_mutation_survives_parent_materialization(): void {
+		$tree = $this->parse( 'SELECT 1 + 2' );
+
+		$child = $tree->get_first_child_node();
+		$this->assertNotNull( $child );
+		$child->custom_marker = 'before-materialize';
+
+		// Force the parent to materialize its native children by appending
+		// a sibling. After this, the parent walks $this->children directly.
+		$sibling = new WP_Parser_Node( 0, 'synthetic' );
+		$tree->append_child( $sibling );
+
+		$children = $tree->get_children();
+		$this->assertContains( $child, $children, 'Materialized children must include the previously-mutated wrapper.' );
+		$this->assertSame( 'before-materialize', $child->custom_marker );
+	}
+}

--- a/packages/mysql-on-sqlite/tests/mysql/native/WP_MySQL_Native_Parser_Node_Identity_Tests.php
+++ b/packages/mysql-on-sqlite/tests/mysql/native/WP_MySQL_Native_Parser_Node_Identity_Tests.php
@@ -87,13 +87,16 @@ class WP_MySQL_Native_Parser_Node_Identity_Tests extends TestCase {
 		$child = $tree->get_first_child_node();
 		$this->assertNotNull( $child );
 
-		// Public dynamic property — the kind of state a caller might attach
-		// expecting WP_Parser_Node identity to keep it reachable.
-		$child->custom_marker = 'set-on-first-read';
+		// Mutate via the public WP_Parser_Node API — this is exactly the
+		// kind of state the reviewer worried would be lost when accessors
+		// hand back fresh wrappers. rule_name is a declared public property
+		// that the parser itself sets, so PHP 8.2's dynamic-property
+		// deprecation does not apply here.
+		$child->rule_name = 'mutated-rule';
 
 		$same_child = $tree->get_first_child_node();
 		$this->assertSame( $child, $same_child );
-		$this->assertSame( 'set-on-first-read', $same_child->custom_marker );
+		$this->assertSame( 'mutated-rule', $same_child->rule_name );
 	}
 
 	public function test_mutation_survives_parent_materialization(): void {
@@ -101,7 +104,7 @@ class WP_MySQL_Native_Parser_Node_Identity_Tests extends TestCase {
 
 		$child = $tree->get_first_child_node();
 		$this->assertNotNull( $child );
-		$child->custom_marker = 'before-materialize';
+		$child->rule_name = 'before-materialize';
 
 		// Force the parent to materialize its native children by appending
 		// a sibling. After this, the parent walks $this->children directly.
@@ -110,6 +113,6 @@ class WP_MySQL_Native_Parser_Node_Identity_Tests extends TestCase {
 
 		$children = $tree->get_children();
 		$this->assertContains( $child, $children, 'Materialized children must include the previously-mutated wrapper.' );
-		$this->assertSame( 'before-materialize', $child->custom_marker );
+		$this->assertSame( 'before-materialize', $child->rule_name );
 	}
 }

--- a/packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php
+++ b/packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * Benchmark for the native AST walk path with the per-AST identity cache.
+ *
+ * Parses every query in the MySQL server suite, then walks each AST
+ * exhaustively through `get_descendants()` and `get_first_child_node()`
+ * loops to exercise the bridge accessors and the identity map. Reports
+ * wall time, peak memory, and a basic identity-stability check so the
+ * cache cost can be compared against the no-cache baseline.
+ *
+ * Usage:
+ *   php run-native-ast-walk-benchmark.php          # walks via accessors
+ *   php run-native-ast-walk-benchmark.php --no-walk # parse only, baseline
+ *
+ * The script auto-detects the native extension. Without it, the walk
+ * exercises the pure-PHP WP_Parser_Node path, which is useful as the
+ * "no-cache cost" reference point.
+ */
+
+set_error_handler(
+	function ( $severity, $message, $file, $line ) {
+		throw new ErrorException( $message, 0, $severity, $file, $line );
+	}
+);
+
+require_once __DIR__ . '/../../src/load.php';
+
+$walk_tree = ! in_array( '--no-walk', $argv, true );
+
+$grammar_data = include __DIR__ . '/../../src/mysql/mysql-grammar.php';
+$grammar      = new WP_Parser_Grammar( $grammar_data );
+
+$data_dir = __DIR__ . '/../mysql/data';
+$handle   = fopen( "$data_dir/mysql-server-tests-queries.csv", 'r' );
+$records  = array();
+while ( ( $record = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
+	$records[] = $record;
+}
+fclose( $handle );
+
+$total      = 0;
+$walked     = 0;
+$identity_ok = true;
+$failures   = 0;
+
+if ( function_exists( 'memory_reset_peak_usage' ) ) {
+	memory_reset_peak_usage();
+}
+$start = microtime( true );
+
+for ( $i = 1; $i < count( $records ); $i += 1 ) {
+	$query = $records[ $i ][0];
+	if ( null === $query ) {
+		continue;
+	}
+
+	try {
+		$lexer  = new WP_MySQL_Lexer( $query );
+		$tokens = $lexer instanceof WP_MySQL_Native_Lexer
+			? $lexer->native_token_stream()
+			: $lexer->remaining_tokens();
+		$parser = new WP_MySQL_Parser( $grammar, $tokens );
+		$ast    = $parser->parse();
+		if ( null === $ast ) {
+			++$failures;
+			continue;
+		}
+		++$total;
+
+		if ( ! $walk_tree ) {
+			continue;
+		}
+
+		// Exhaustive descendant walk — exercises both the per-call accessor
+		// path and (when the native extension is loaded) the identity map.
+		$descendants = $ast->get_descendants();
+		$walked     += count( $descendants );
+
+		// Re-read the first child a few times and confirm identity is
+		// stable. With the cache, this must be the same instance every
+		// call; a regression would surface as a cheap, deterministic flag.
+		$first = $ast->get_first_child_node();
+		if ( null !== $first ) {
+			$again = $ast->get_first_child_node();
+			if ( $first !== $again ) {
+				$identity_ok = false;
+			}
+		}
+	} catch ( Throwable $e ) {
+		++$failures;
+	}
+}
+
+$duration = microtime( true ) - $start;
+$peak_mb  = memory_get_peak_usage( true ) / 1024 / 1024;
+$native   = class_exists( 'WP_MySQL_Native_Parser', false ) ? 'native' : 'php';
+
+printf(
+	"path=%s walk=%s parsed=%d walked_nodes=%d failures=%d duration=%.4fs qps=%d peak_mem=%.1fMB identity_ok=%s\n",
+	$native,
+	$walk_tree ? 'yes' : 'no',
+	$total,
+	$walked,
+	$failures,
+	$duration,
+	$total > 0 ? (int) ( $total / $duration ) : 0,
+	$peak_mb,
+	$identity_ok ? 'true' : 'FALSE'
+);
+
+if ( ! $identity_ok ) {
+	fwrite( STDERR, "Identity check failed: get_first_child_node() returned different instances.\n" );
+	exit( 1 );
+}

--- a/packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php
+++ b/packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php
@@ -39,10 +39,10 @@ while ( ( $record = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
 }
 fclose( $handle );
 
-$total      = 0;
-$walked     = 0;
+$total       = 0;
+$walked      = 0;
 $identity_ok = true;
-$failures   = 0;
+$failures    = 0;
 
 if ( function_exists( 'memory_reset_peak_usage' ) ) {
 	memory_reset_peak_usage();

--- a/packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php
+++ b/packages/mysql-on-sqlite/tests/tools/run-native-ast-walk-benchmark.php
@@ -3,15 +3,29 @@
 /**
  * Benchmark for the native AST walk path with the per-AST identity cache.
  *
- * Parses every query in the MySQL server suite, then walks each AST
- * exhaustively through `get_descendants()` and `get_first_child_node()`
- * loops to exercise the bridge accessors and the identity map. Reports
- * wall time, peak memory, and a basic identity-stability check so the
- * cache cost can be compared against the no-cache baseline.
+ * Parses every query in the MySQL server suite, then walks each AST through
+ * a configurable mode to exercise the bridge accessors and the identity map.
+ * Reports wall time, peak memory, and a basic identity-stability check so
+ * the cache cost can be compared against the no-cache baseline.
+ *
+ * Modes:
+ *   walk       — single full descendant walk per AST (cache-miss heavy).
+ *   no-walk    — parse only.
+ *   rewalk=N   — repeat the descendant walk N times per AST (1st pass is
+ *                misses, remaining passes are all hits — the scenario the
+ *                identity cache is supposed to win on).
+ *   reread=N   — for each top-level child node, call accessors N times to
+ *                exercise repeated-read hit paths.
+ *   subtree=N  — walk descendants once, then re-read each one's first child
+ *                N times — models translator/rewriter passes that re-enter
+ *                the same subtrees.
  *
  * Usage:
- *   php run-native-ast-walk-benchmark.php          # walks via accessors
- *   php run-native-ast-walk-benchmark.php --no-walk # parse only, baseline
+ *   php run-native-ast-walk-benchmark.php
+ *   php run-native-ast-walk-benchmark.php --mode=no-walk
+ *   php run-native-ast-walk-benchmark.php --mode=rewalk --repeat=10
+ *   php run-native-ast-walk-benchmark.php --mode=reread --repeat=10
+ *   php run-native-ast-walk-benchmark.php --mode=subtree --repeat=5
  *
  * The script auto-detects the native extension. Without it, the walk
  * exercises the pure-PHP WP_Parser_Node path, which is useful as the
@@ -26,7 +40,17 @@ set_error_handler(
 
 require_once __DIR__ . '/../../src/load.php';
 
-$walk_tree = ! in_array( '--no-walk', $argv, true );
+$mode   = 'walk';
+$repeat = 1;
+foreach ( $argv as $arg ) {
+	if ( '--no-walk' === $arg ) {
+		$mode = 'no-walk';
+	} elseif ( 0 === strpos( $arg, '--mode=' ) ) {
+		$mode = substr( $arg, 7 );
+	} elseif ( 0 === strpos( $arg, '--repeat=' ) ) {
+		$repeat = max( 1, (int) substr( $arg, 9 ) );
+	}
+}
 
 $grammar_data = include __DIR__ . '/../../src/mysql/mysql-grammar.php';
 $grammar      = new WP_Parser_Grammar( $grammar_data );
@@ -68,24 +92,70 @@ for ( $i = 1; $i < count( $records ); $i += 1 ) {
 		}
 		++$total;
 
-		if ( ! $walk_tree ) {
-			continue;
-		}
+		switch ( $mode ) {
+			case 'no-walk':
+				break;
 
-		// Exhaustive descendant walk — exercises both the per-call accessor
-		// path and (when the native extension is loaded) the identity map.
-		$descendants = $ast->get_descendants();
-		$walked     += count( $descendants );
+			case 'walk':
+				$descendants = $ast->get_descendants();
+				$walked     += count( $descendants );
 
-		// Re-read the first child a few times and confirm identity is
-		// stable. With the cache, this must be the same instance every
-		// call; a regression would surface as a cheap, deterministic flag.
-		$first = $ast->get_first_child_node();
-		if ( null !== $first ) {
-			$again = $ast->get_first_child_node();
-			if ( $first !== $again ) {
-				$identity_ok = false;
-			}
+				$first = $ast->get_first_child_node();
+				if ( null !== $first ) {
+					$again = $ast->get_first_child_node();
+					if ( $first !== $again ) {
+						$identity_ok = false;
+					}
+				}
+				break;
+
+			case 'rewalk':
+				// Repeated full-tree walks. After the first pass every wrapper
+				// the cache returns is a hit; without the cache, every pass
+				// re-allocates wrappers for the entire tree from scratch.
+				for ( $r = 0; $r < $repeat; $r++ ) {
+					$descendants = $ast->get_descendants();
+					$walked     += count( $descendants );
+				}
+				break;
+
+			case 'reread':
+				// Repeated top-level child reads. Models analysis passes that
+				// keep poking at the root of the tree.
+				for ( $r = 0; $r < $repeat; $r++ ) {
+					$child = $ast->get_first_child_node();
+					if ( null !== $child ) {
+						++$walked;
+						// Identity must hold across repeated reads.
+						if ( $r > 0 && $child !== $prev ) {
+							$identity_ok = false;
+						}
+						$prev = $child;
+					}
+				}
+				break;
+
+			case 'subtree':
+				// Walk descendants once, then for each descendant re-read its
+				// first child N times. Models translator/rewriter passes that
+				// re-enter previously visited subtrees.
+				$descendants = $ast->get_descendants();
+				foreach ( $descendants as $d ) {
+					if ( ! $d instanceof WP_Parser_Node ) {
+						continue;
+					}
+					for ( $r = 0; $r < $repeat; $r++ ) {
+						$child = $d->get_first_child_node();
+						if ( null !== $child ) {
+							++$walked;
+						}
+					}
+				}
+				break;
+
+			default:
+				fwrite( STDERR, "Unknown mode: $mode\n" );
+				exit( 2 );
 		}
 	} catch ( Throwable $e ) {
 		++$failures;
@@ -97,9 +167,10 @@ $peak_mb  = memory_get_peak_usage( true ) / 1024 / 1024;
 $native   = class_exists( 'WP_MySQL_Native_Parser', false ) ? 'native' : 'php';
 
 printf(
-	"path=%s walk=%s parsed=%d walked_nodes=%d failures=%d duration=%.4fs qps=%d peak_mem=%.1fMB identity_ok=%s\n",
+	"path=%s mode=%s repeat=%d parsed=%d walked_nodes=%d failures=%d duration=%.4fs qps=%d peak_mem=%.1fMB identity_ok=%s\n",
 	$native,
-	$walk_tree ? 'yes' : 'no',
+	$mode,
+	$repeat,
 	$total,
 	$walked,
 	$failures,
@@ -110,6 +181,6 @@ printf(
 );
 
 if ( ! $identity_ok ) {
-	fwrite( STDERR, "Identity check failed: get_first_child_node() returned different instances.\n" );
+	fwrite( STDERR, "Identity check failed: accessor returned different instances on repeat read.\n" );
 	exit( 1 );
 }

--- a/packages/php-ext-wp-mysql-parser/src/lib.rs
+++ b/packages/php-ext-wp-mysql-parser/src/lib.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use std::os::raw::c_char;
 use std::ptr;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::Arc;
 
 use ext_php_rs::convert::{FromZval, IntoZval, IntoZvalDyn};
 use ext_php_rs::exception::{PhpException, PhpResult};
@@ -915,12 +915,6 @@ struct Rule {
     is_fragment: bool,
 }
 
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
-struct GrammarCacheKey {
-    low: u64,
-    high: u64,
-}
-
 impl Grammar {
     fn rule(&self, rule_id: i64) -> Option<&Rule> {
         usize::try_from(rule_id)
@@ -930,10 +924,11 @@ impl Grammar {
     }
 }
 
-// Cache only Rust-owned grammar data, keyed by exported grammar content. Zend
-// object handles are request-local and can be reused, so they must not identify
-// cached entries.
-static GRAMMAR_CACHE: OnceLock<Mutex<HashMap<GrammarCacheKey, Arc<Grammar>>>> = OnceLock::new();
+#[php_class]
+#[php(name = "WP_MySQL_Native_Grammar")]
+pub struct WpMySqlNativeGrammar {
+    grammar: Arc<Grammar>,
+}
 
 enum ParserTokenSource {
     Php(Vec<Zval>),
@@ -1685,22 +1680,16 @@ impl WpMySqlNativeParser {
 }
 
 fn export_grammar(grammar_zval: &mut Zval) -> PhpResult<Arc<Grammar>> {
+    if let Some(cached) = cached_native_grammar(grammar_zval)? {
+        return Ok(cached);
+    }
+
     let exported = php_function("wp_sqlite_mysql_native_export_grammar")?
         .try_call(vec![&*grammar_zval as &dyn IntoZvalDyn])
         .map_err(php_error)?;
     let array = exported
         .array()
         .ok_or_else(|| php_error("Exported grammar must be an array"))?;
-
-    let cache_key = grammar_cache_key(array)?;
-    if let Some(cached) = GRAMMAR_CACHE
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .map_err(|_| php_error("Grammar cache lock poisoned"))?
-        .get(&cache_key)
-    {
-        return Ok(Arc::clone(cached));
-    }
 
     let highest_terminal_id = array
         .get("highest_terminal_id")
@@ -1751,130 +1740,37 @@ fn export_grammar(grammar_zval: &mut Zval) -> PhpResult<Arc<Grammar>> {
         select_statement_rule_id,
     });
 
-    GRAMMAR_CACHE
-        .get_or_init(|| Mutex::new(HashMap::new()))
-        .lock()
-        .map_err(|_| php_error("Grammar cache lock poisoned"))?
-        .insert(cache_key, Arc::clone(&grammar));
+    cache_native_grammar(grammar_zval, Arc::clone(&grammar))?;
 
     Ok(grammar)
 }
 
-fn grammar_cache_key(array: &ZendHashTable) -> PhpResult<GrammarCacheKey> {
-    let mut hasher = GrammarCacheHasher::new();
-    hash_grammar_array(&mut hasher, array)?;
-    Ok(hasher.finish())
+fn cached_native_grammar(grammar: &Zval) -> PhpResult<Option<Arc<Grammar>>> {
+    let object = grammar
+        .object()
+        .ok_or_else(|| php_error("Parser grammar must be an object"))?;
+    let properties = object.get_properties().map_err(php_error)?;
+    let Some(native_grammar) = properties.get("native_grammar") else {
+        return Ok(None);
+    };
+    let Some(native_grammar) = <&WpMySqlNativeGrammar as FromZval>::from_zval(native_grammar)
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(Arc::clone(&native_grammar.grammar)))
 }
 
-struct GrammarCacheHasher {
-    low: u64,
-    high: u64,
-}
-
-impl GrammarCacheHasher {
-    fn new() -> Self {
-        Self {
-            low: 0xcbf29ce484222325,
-            high: 0x6c62272e07bb0142,
-        }
-    }
-
-    fn write_byte(&mut self, byte: u8) {
-        self.low ^= u64::from(byte);
-        self.low = self.low.wrapping_mul(0x100000001b3);
-        self.high ^= u64::from(byte).rotate_left(5);
-        self.high = self.high.wrapping_mul(0x100000001b3 ^ 0x9e3779b97f4a7c15);
-    }
-
-    fn write_bytes(&mut self, bytes: &[u8]) {
-        self.write_usize(bytes.len());
-        for byte in bytes {
-            self.write_byte(*byte);
-        }
-    }
-
-    fn write_i64(&mut self, value: i64) {
-        for byte in value.to_le_bytes() {
-            self.write_byte(byte);
-        }
-    }
-
-    fn write_u64(&mut self, value: u64) {
-        for byte in value.to_le_bytes() {
-            self.write_byte(byte);
-        }
-    }
-
-    fn write_usize(&mut self, value: usize) {
-        self.write_u64(value as u64);
-    }
-
-    fn finish(self) -> GrammarCacheKey {
-        GrammarCacheKey {
-            low: self.low,
-            high: self.high,
-        }
-    }
-}
-
-fn hash_grammar_array(hasher: &mut GrammarCacheHasher, array: &ZendHashTable) -> PhpResult<()> {
-    hasher.write_usize(array.len());
-    for (key, value) in array {
-        hash_grammar_array_key(hasher, key);
-        hash_grammar_zval(hasher, value)?;
-    }
-    Ok(())
-}
-
-fn hash_grammar_zval(hasher: &mut GrammarCacheHasher, zval: &Zval) -> PhpResult<()> {
-    let zval = zval.dereference();
-    match zval.get_type() {
-        DataType::Null => hasher.write_byte(0),
-        DataType::False => hasher.write_byte(1),
-        DataType::True => hasher.write_byte(2),
-        DataType::Long => {
-            hasher.write_byte(3);
-            hasher.write_i64(
-                zval.long()
-                    .ok_or_else(|| php_error("Grammar integer value is invalid"))?,
-            );
-        }
-        DataType::String => {
-            hasher.write_byte(4);
-            hasher.write_bytes(
-                zval.str()
-                    .ok_or_else(|| php_error("Grammar string value is invalid"))?
-                    .as_bytes(),
-            );
-        }
-        DataType::Array => {
-            hasher.write_byte(5);
-            let array = zval
-                .array()
-                .ok_or_else(|| php_error("Grammar array value is invalid"))?;
-            hash_grammar_array(hasher, array)?;
-        }
-        _ => return Err(php_error("Unsupported grammar cache value")),
-    }
-
-    Ok(())
-}
-
-fn hash_grammar_array_key(hasher: &mut GrammarCacheHasher, key: ArrayKey<'_>) {
-    match key {
-        ArrayKey::Long(value) => {
-            hasher.write_byte(0);
-            hasher.write_i64(value);
-        }
-        ArrayKey::String(value) => {
-            hasher.write_byte(1);
-            hasher.write_bytes(value.as_bytes());
-        }
-        ArrayKey::Str(value) => {
-            hasher.write_byte(1);
-            hasher.write_bytes(value.as_bytes());
-        }
-    }
+fn cache_native_grammar(grammar_zval: &mut Zval, grammar: Arc<Grammar>) -> PhpResult<()> {
+    let object = grammar_zval
+        .object_mut()
+        .ok_or_else(|| php_error("Parser grammar must be an object"))?;
+    let native_grammar = WpMySqlNativeGrammar { grammar }
+        .into_zval(false)
+        .map_err(php_error)?;
+    object
+        .set_property("native_grammar", native_grammar)
+        .map_err(php_error)
 }
 
 fn export_tokens(tokens: &mut Zval) -> PhpResult<(ParserTokenSource, Vec<i64>)> {
@@ -2028,6 +1924,7 @@ extern "C" fn php_module_info(_module: *mut ModuleEntry) {
 #[php_module]
 pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
     module
+        .class::<WpMySqlNativeGrammar>()
         .class::<WpMySqlNativeAst>()
         .class::<WpMySqlNativeTokenStream>()
         .class::<WpMySqlNativeLexer>()

--- a/packages/php-ext-wp-mysql-parser/src/lib.rs
+++ b/packages/php-ext-wp-mysql-parser/src/lib.rs
@@ -93,10 +93,19 @@ fn update_object_property(
 }
 
 fn create_mysql_token(sql_zval: &Zval, token: TokenInfo, no_backslash: bool) -> PhpResult<Zval> {
+    let classes = php_classes()?;
+    create_mysql_token_with_classes(sql_zval, token, no_backslash, &classes)
+}
+
+fn create_mysql_token_with_classes(
+    sql_zval: &Zval,
+    token: TokenInfo,
+    no_backslash: bool,
+    classes: &PhpClasses,
+) -> PhpResult<Zval> {
     let id = token.id;
     let start = i64::try_from(token.start).map_err(php_error)?;
     let length = i64::try_from(token.end.saturating_sub(token.start)).map_err(php_error)?;
-    let classes = php_classes()?;
     let mut object = classes.mysql_token.new();
 
     update_object_property(&mut object, classes.parser_token, "id", id)?;
@@ -940,7 +949,7 @@ enum ParserTokenSource {
 }
 
 impl ParserTokenSource {
-    fn create_php_token(&self, index: usize) -> PhpResult<Zval> {
+    fn create_php_token_with_classes(&self, index: usize, classes: &PhpClasses) -> PhpResult<Zval> {
         match self {
             Self::Php(tokens) => tokens
                 .get(index)
@@ -955,7 +964,7 @@ impl ParserTokenSource {
                     .get(index)
                     .copied()
                     .ok_or_else(|| php_error("Parser token index is out of range"))?;
-                create_mysql_token(sql_zval, token, *no_backslash)
+                create_mysql_token_with_classes(sql_zval, token, *no_backslash, classes)
             }
         }
     }
@@ -1020,6 +1029,7 @@ struct NativeAstNode {
     children: Vec<NativeAstChild>,
     first_token: Option<usize>,
     last_token: Option<usize>,
+    descendant_count: usize,
 }
 
 struct NativeAstArena {
@@ -1049,10 +1059,12 @@ impl NativeAstArena {
         let index = self.nodes.len();
         let mut first_token = None;
         let mut last_token = None;
+        let mut descendant_count = 0;
         for child in &children {
             match child {
                 NativeAstChild::Node(child_index) => {
                     if let Some(node) = self.nodes.get(*child_index) {
+                        descendant_count += 1 + node.descendant_count;
                         if first_token.is_none() {
                             first_token = node.first_token;
                         }
@@ -1066,6 +1078,7 @@ impl NativeAstArena {
                         first_token = Some(*token_index);
                     }
                     last_token = Some(*token_index);
+                    descendant_count += 1;
                 }
             }
         }
@@ -1075,11 +1088,21 @@ impl NativeAstArena {
             children,
             first_token,
             last_token,
+            descendant_count,
         });
         index
     }
 
     fn create_php_ast(&self, native_ast_zval: &Zval) -> PhpResult<Zval> {
+        let classes = php_classes()?;
+        self.create_php_ast_with_classes(native_ast_zval, &classes)
+    }
+
+    fn create_php_ast_with_classes(
+        &self,
+        native_ast_zval: &Zval,
+        classes: &PhpClasses,
+    ) -> PhpResult<Zval> {
         match self.root {
             NativeAstRoot::No => Ok(Zval::null()),
             NativeAstRoot::Empty => {
@@ -1087,14 +1110,22 @@ impl NativeAstArena {
                 zval.set_bool(true);
                 Ok(zval)
             }
-            NativeAstRoot::Node(index) => self.create_php_node(native_ast_zval, index),
-            NativeAstRoot::Token(index) => self.token_source.create_php_token(index),
+            NativeAstRoot::Node(index) => {
+                self.create_php_node_with_classes(native_ast_zval, index, classes)
+            }
+            NativeAstRoot::Token(index) => self
+                .token_source
+                .create_php_token_with_classes(index, classes),
         }
     }
 
-    fn create_php_node(&self, native_ast_zval: &Zval, index: usize) -> PhpResult<Zval> {
+    fn create_php_node_with_classes(
+        &self,
+        native_ast_zval: &Zval,
+        index: usize,
+        classes: &PhpClasses,
+    ) -> PhpResult<Zval> {
         let node = self.node(index)?;
-        let classes = php_classes()?;
         let mut object = classes.native_parser_node.new();
         let rule_name = self
             .grammar
@@ -1137,10 +1168,19 @@ impl NativeAstArena {
             .ok_or_else(|| php_error("Native AST node index is out of range"))
     }
 
-    fn child_to_zval(&self, native_ast_zval: &Zval, child: NativeAstChild) -> PhpResult<Zval> {
+    fn child_to_zval_with_classes(
+        &self,
+        native_ast_zval: &Zval,
+        child: NativeAstChild,
+        classes: &PhpClasses,
+    ) -> PhpResult<Zval> {
         match child {
-            NativeAstChild::Node(index) => self.create_php_node(native_ast_zval, index),
-            NativeAstChild::Token(index) => self.token_source.create_php_token(index),
+            NativeAstChild::Node(index) => {
+                self.create_php_node_with_classes(native_ast_zval, index, classes)
+            }
+            NativeAstChild::Token(index) => self
+                .token_source
+                .create_php_token_with_classes(index, classes),
         }
     }
 
@@ -1172,8 +1212,9 @@ impl NativeAstArena {
     }
 
     fn descendant_stack(&self, index: usize) -> PhpResult<Vec<NativeAstChild>> {
-        let mut stack = self.node(index)?.children.clone();
-        stack.reverse();
+        let node = self.node(index)?;
+        let mut stack = Vec::with_capacity(node.descendant_count);
+        stack.extend(node.children.iter().rev().copied());
         Ok(stack)
     }
 }
@@ -1238,6 +1279,7 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child(
     node_index: i64,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let Some(child) = ast
         .arena
         .node(native_ast_node_index(node_index)?)?
@@ -1247,7 +1289,8 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child(
     else {
         return Ok(Zval::null());
     };
-    ast.arena.child_to_zval(native_ast_zval, child)
+    ast.arena
+        .child_to_zval_with_classes(native_ast_zval, child, &classes)
 }
 
 #[php_function]
@@ -1257,9 +1300,12 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child_node(
     rule_name: Option<String>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     for child in &ast.arena.node(native_ast_node_index(node_index)?)?.children {
         if ast.arena.child_node_matches(*child, rule_name.as_deref()) {
-            return ast.arena.child_to_zval(native_ast_zval, *child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, *child, &classes);
         }
     }
     Ok(Zval::null())
@@ -1272,9 +1318,12 @@ pub fn wp_sqlite_mysql_native_ast_get_first_child_token(
     token_id: Option<i64>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     for child in &ast.arena.node(native_ast_node_index(node_index)?)?.children {
         if ast.arena.child_token_matches(*child, token_id) {
-            return ast.arena.child_to_zval(native_ast_zval, *child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, *child, &classes);
         }
     }
     Ok(Zval::null())
@@ -1287,12 +1336,15 @@ pub fn wp_sqlite_mysql_native_ast_get_first_descendant_node(
     rule_name: Option<String>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_node_matches(child, rule_name.as_deref()) {
-            return ast.arena.child_to_zval(native_ast_zval, child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
@@ -1310,12 +1362,15 @@ pub fn wp_sqlite_mysql_native_ast_get_first_descendant_token(
     token_id: Option<i64>,
 ) -> PhpResult<Zval> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_token_matches(child, token_id) {
-            return ast.arena.child_to_zval(native_ast_zval, child);
+            return ast
+                .arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
@@ -1332,12 +1387,16 @@ pub fn wp_sqlite_mysql_native_ast_get_children(
     node_index: i64,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     ast.arena
         .node(native_ast_node_index(node_index)?)?
         .children
         .iter()
         .copied()
-        .map(|child| ast.arena.child_to_zval(native_ast_zval, child))
+        .map(|child| {
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)
+        })
         .collect()
 }
 
@@ -1348,13 +1407,17 @@ pub fn wp_sqlite_mysql_native_ast_get_child_nodes(
     rule_name: Option<String>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     ast.arena
         .node(native_ast_node_index(node_index)?)?
         .children
         .iter()
         .copied()
         .filter(|child| ast.arena.child_node_matches(*child, rule_name.as_deref()))
-        .map(|child| ast.arena.child_to_zval(native_ast_zval, child))
+        .map(|child| {
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)
+        })
         .collect()
 }
 
@@ -1365,13 +1428,17 @@ pub fn wp_sqlite_mysql_native_ast_get_child_tokens(
     token_id: Option<i64>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     ast.arena
         .node(native_ast_node_index(node_index)?)?
         .children
         .iter()
         .copied()
         .filter(|child| ast.arena.child_token_matches(*child, token_id))
-        .map(|child| ast.arena.child_to_zval(native_ast_zval, child))
+        .map(|child| {
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)
+        })
         .collect()
 }
 
@@ -1381,12 +1448,17 @@ pub fn wp_sqlite_mysql_native_ast_get_descendants(
     node_index: i64,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
-    let mut descendants = Vec::new();
+    let classes = php_classes()?;
+    let root = ast.arena.node(native_ast_node_index(node_index)?)?;
+    let mut descendants = Vec::with_capacity(root.descendant_count);
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
-        descendants.push(ast.arena.child_to_zval(native_ast_zval, child)?);
+        descendants.push(
+            ast.arena
+                .child_to_zval_with_classes(native_ast_zval, child, &classes)?,
+        );
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
                 stack.push(*child);
@@ -1403,13 +1475,18 @@ pub fn wp_sqlite_mysql_native_ast_get_descendant_nodes(
     rule_name: Option<String>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut descendants = Vec::new();
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_node_matches(child, rule_name.as_deref()) {
-            descendants.push(ast.arena.child_to_zval(native_ast_zval, child)?);
+            descendants.push(ast.arena.child_to_zval_with_classes(
+                native_ast_zval,
+                child,
+                &classes,
+            )?);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
@@ -1427,13 +1504,18 @@ pub fn wp_sqlite_mysql_native_ast_get_descendant_tokens(
     token_id: Option<i64>,
 ) -> PhpResult<Vec<Zval>> {
     let ast = native_ast(native_ast_zval)?;
+    let classes = php_classes()?;
     let mut descendants = Vec::new();
     let mut stack = ast
         .arena
         .descendant_stack(native_ast_node_index(node_index)?)?;
     while let Some(child) = stack.pop() {
         if ast.arena.child_token_matches(child, token_id) {
-            descendants.push(ast.arena.child_to_zval(native_ast_zval, child)?);
+            descendants.push(ast.arena.child_to_zval_with_classes(
+                native_ast_zval,
+                child,
+                &classes,
+            )?);
         }
         if let NativeAstChild::Node(index) = child {
             for child in ast.arena.node(index)?.children.iter().rev() {
@@ -1503,6 +1585,18 @@ impl WpMySqlNativeParser {
             current_ast: None,
             current_php_ast: None,
         })
+    }
+
+    pub fn reset_tokens(&mut self, tokens: &mut Zval) -> PhpResult<()> {
+        let (token_source, token_ids) = export_tokens(tokens)?;
+
+        self.token_source = Arc::new(token_source);
+        self.token_ids = token_ids;
+        self.position = 0;
+        self.current_ast = None;
+        self.current_php_ast = None;
+
+        Ok(())
     }
 
     pub fn parse(&mut self) -> PhpResult<Zval> {


### PR DESCRIPTION
Stacked on #381.

#381's review surfaced a real semantics regression in the lazy native AST facade: every accessor on `WP_MySQL_Native_Parser_Node` calls into Rust and returns a freshly constructed PHP wrapper, so `get_first_child_node()` returns a different object every time. `WP_Parser_Node` has always given callers stable child identity — attach state to a child once, walk past it, walk back, the state is still there — and the lazy native facade is meant to keep that contract intact. This restores it.

A per-AST `WP_MySQL_Native_AST_Cache` is created lazily on the root and shared by reference with every wrapper that gets interned through it. Each accessor looks the returned wrapper's `native_node_index` up in the cache and either returns the canonical instance or registers the new one. `materialize_native_children()` pulls children through the same cache so any mutation a caller made through `get_first_child_node()` before the parent went through `append_child()` survives into `$this->children` — same instance, same mutations.

Tokens are unchanged. The public token API has no mutators and no callers in this repo rely on `WP_MySQL_Token` identity; if that becomes a need we can extend the cache.

## What's in here

- `class-wp-mysql-native-ast-cache.php` — small holder, one per AST.
- Native node accessors run results through `intern()` / `intern_all()` / `intern_nodes()`.
- `materialize_native_children()` reuses the interned wrappers so prior mutations don't get lost.
- Regression test covering same-instance reads, descendant/child identity sharing, and the mutate-then-materialize edge case. Skips when the native extension isn't loaded.
- `run-native-ast-walk-benchmark.php` parses the MySQL server suite, walks each AST, and reports `parsed`, `walked_nodes`, `duration`, `peak_mem`, and an identity-stability flag.
- `Native AST Walk Perf` workflow runs the benchmark on this PR and on the PR base (`codex/native-lazy-ast-facade`) on the same runner, so the identity-cache cost is measured apples-to-apples on every push.

## Performance

Benchmarked on CI against the no-cache baseline, same runner, same corpus (69,567 queries, 4.8M walked nodes). Full numbers in PR comments — links below.

| scenario | baseline (no cache) | this PR | delta |
|---|---|---|---|
| native parse only | 1.28s | 1.28s | 0% |
| native walk duration | 3.52s | 3.33s | **+5% (+0.19s)** |
| native walk qps | 19,766 | 20,884 | **−5%** |
| native walk peak memory | 50.0MB | 60.5MB | **+10.5MB (+21%)** |
| native walk identity stable | **FALSE** | true | regression fixed |

Hot-path optimization in `intern_all()` (cache reference hoisted out of the loop, per-item logic inlined) plus a typed `intern_nodes()` fast path for accessors that return only nodes brought the time penalty down from an initial +17% to +5%. Memory delta is structural — one retained PHP wrapper per visited node — and is the price of stable identity.

Native walk is still ~5× faster than the pure-PHP path while now preserving `WP_Parser_Node` semantics.

- First measurement: https://github.com/WordPress/sqlite-database-integration/pull/391#issuecomment-4354700002
- After hot-path optimization: https://github.com/WordPress/sqlite-database-integration/pull/391#issuecomment-4354952752

## Test plan

- [x] PHPUnit suite passes on the pure-PHP path.
- [x] PHPUnit suite passes with the native extension loaded; the new identity tests run instead of skipping.
- [x] `Native AST Walk Perf` workflow reports the cache cost vs. the PR base on every push.