### PR TITLE
Add WASM extension artifact publishing workflow

### DIFF
--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -101,7 +101,7 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: jspi
-          COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.26'
+          COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 

--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -1,0 +1,199 @@
+name: Publish WASM extension artifact
+
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'packages/php-ext-wp-mysql-parser/**'
+      - '.github/workflows/publish-wasm-extension-artifact.yml'
+  workflow_dispatch:
+    inputs:
+      playground-ref:
+        description: 'wordpress-playground branch/tag/SHA to build against'
+        required: false
+        default: 'trunk'
+      retention-days:
+        description: 'Actions artifact retention in days'
+        required: false
+        default: '30'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build wp_mysql_parser.so (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        # The Rust WASM path uses ext-php-rs 0.15, which depends on PHP 8
+        # Zend APIs. PHP 7.4 cannot be added here by extending the matrix.
+        php: ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0']
+
+    steps:
+      - name: Check out sqlite-database-integration
+        uses: actions/checkout@v4
+        with:
+          path: sqlite-database-integration
+
+      - name: Check out wordpress-playground
+        uses: actions/checkout@v4
+        with:
+          repository: WordPress/wordpress-playground
+          ref: ${{ github.event.inputs.playground-ref || 'trunk' }}
+          path: wordpress-playground
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            /package.json
+            /package-lock.json
+            /nx.json
+            /tsconfig.base.json
+            /packages/meta/
+            /packages/nx-extensions/
+            /packages/php-wasm/cli-util/
+            /packages/php-wasm/compile-extension/
+            /packages/php-wasm/compile/
+            /packages/php-wasm/fs-journal/
+            /packages/php-wasm/logger/
+            /packages/php-wasm/node/
+            /packages/php-wasm/node-builds/8-0/
+            /packages/php-wasm/node-builds/8-1/
+            /packages/php-wasm/node-builds/8-2/
+            /packages/php-wasm/node-builds/8-3/
+            /packages/php-wasm/node-builds/8-4/
+            /packages/php-wasm/node-builds/8-5/
+            /packages/php-wasm/progress/
+            /packages/php-wasm/scopes/
+            /packages/php-wasm/stream-compression/
+            /packages/php-wasm/universal/
+            /packages/php-wasm/util/
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: wordpress-playground/package-lock.json
+
+      - name: Install Playground deps
+        working-directory: wordpress-playground
+        run: npm ci --ignore-scripts
+
+      - name: Configure Docker DNS
+        run: |
+          echo '{"dns": ["8.8.8.8", "1.1.1.1"]}' | sudo tee /etc/docker/daemon.json
+          sudo systemctl restart docker
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if docker info >/dev/null 2>&1; then break; fi
+            sleep 2
+          done
+
+      - name: Build wp_mysql_parser side module
+        working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
+        env:
+          PHP_VERSION: ${{ matrix.php }}
+          ASYNC_MODE: jspi
+          PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
+        run: bash build-in-docker-rust.sh
+
+      - name: Verify side module exists
+        working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
+        run: |
+          test -f dist/wp_mysql_parser-php${{ matrix.php }}-jspi.so
+          ls -lh dist/wp_mysql_parser-php${{ matrix.php }}-jspi.so
+
+      - name: Upload side module
+        uses: actions/upload-artifact@v4
+        with:
+          name: wp_mysql_parser-php${{ matrix.php }}-jspi-so
+          path: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/dist/wp_mysql_parser-php${{ matrix.php }}-jspi.so
+          if-no-files-found: error
+          retention-days: ${{ github.event.inputs.retention-days || '30' }}
+
+      - name: Upload diagnostic logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-extension-publish-failure-php${{ matrix.php }}
+          path: |
+            sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/dist/
+            sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/*.log
+          if-no-files-found: ignore
+          retention-days: 14
+
+  package:
+    name: Package extension manifest
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out sqlite-database-integration
+        uses: actions/checkout@v4
+
+      - name: Download side modules
+        uses: actions/download-artifact@v4
+        with:
+          pattern: wp_mysql_parser-php*-jspi-so
+          path: build/wp_mysql_parser-wasm-extension
+          merge-multiple: true
+
+      - name: Write Playground extension manifest
+        env:
+          ASYNC_MODE: jspi
+          EXTENSION_VERSION: ${{ github.sha }}
+        run: |
+          node packages/php-ext-wp-mysql-parser/wasm-spike/write-extension-manifest.mjs \
+            build/wp_mysql_parser-wasm-extension \
+            8.5 8.4 8.3 8.2 8.1 8.0
+
+      - name: Verify published manifest shape
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+
+          const root = 'build/wp_mysql_parser-wasm-extension';
+          const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+          if (manifest.name !== 'wp_mysql_parser') {
+            throw new Error(`Unexpected extension name: ${manifest.name}`);
+          }
+          if (manifest.mode !== 'php-extension') {
+            throw new Error(`Unexpected manifest mode: ${manifest.mode}`);
+          }
+          if (!Array.isArray(manifest.artifacts) || manifest.artifacts.length !== 6) {
+            throw new Error('Expected six PHP 8.x artifacts.');
+          }
+          for (const artifact of manifest.artifacts) {
+            if (!artifact.phpVersion || !artifact.sourcePath) {
+              throw new Error(`Invalid artifact entry: ${JSON.stringify(artifact)}`);
+            }
+            if ('file' in artifact || 'sha256' in artifact) {
+              throw new Error(`Manifest uses the retired pre-PR-3580 fields: ${JSON.stringify(artifact)}`);
+            }
+            const artifactPath = path.join(root, artifact.sourcePath);
+            if (!fs.existsSync(artifactPath)) {
+              throw new Error(`Manifest references missing artifact: ${artifactPath}`);
+            }
+          }
+          NODE
+
+      - name: Write checksums
+        working-directory: build/wp_mysql_parser-wasm-extension
+        run: sha256sum *.so > SHA256SUMS
+
+      - name: Upload packaged extension
+        uses: actions/upload-artifact@v4
+        with:
+          name: wp_mysql_parser-wasm-extension
+          path: build/wp_mysql_parser-wasm-extension/
+          if-no-files-found: error
+          retention-days: ${{ github.event.inputs.retention-days || '30' }}

--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -19,7 +19,7 @@ on:
         default: '30'
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -198,3 +198,48 @@ jobs:
           path: build/wp_mysql_parser-wasm-extension/
           if-no-files-found: error
           retention-days: ${{ github.event.inputs.retention-days || '30' }}
+
+      - name: Publish static extension bundle to gh-pages
+        env:
+          BUNDLE_DIR: build/wp_mysql_parser-wasm-extension
+          EXTENSION_PATH: wp_mysql_parser-wasm-extension
+          GITHUB_TOKEN: ${{ github.token }}
+          SITE_BRANCH: gh-pages
+          VERSION_PATH: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          pages_dir="$(mktemp -d)"
+          git init "$pages_dir"
+          git -C "$pages_dir" remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git -C "$pages_dir" config http.https://github.com/.extraheader "AUTHORIZATION: bearer ${GITHUB_TOKEN}"
+          git -C "$pages_dir" config user.name "github-actions[bot]"
+          git -C "$pages_dir" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          if git -C "$pages_dir" ls-remote --exit-code --heads origin "$SITE_BRANCH" >/dev/null 2>&1; then
+            git -C "$pages_dir" fetch --depth=1 origin "$SITE_BRANCH"
+            git -C "$pages_dir" checkout -B "$SITE_BRANCH" FETCH_HEAD
+          else
+            git -C "$pages_dir" checkout --orphan "$SITE_BRANCH"
+          fi
+
+          mkdir -p "$pages_dir/$EXTENSION_PATH"
+          rm -rf "$pages_dir/$EXTENSION_PATH/$VERSION_PATH" "$pages_dir/$EXTENSION_PATH/latest"
+          mkdir -p "$pages_dir/$EXTENSION_PATH/$VERSION_PATH" "$pages_dir/$EXTENSION_PATH/latest"
+          cp -R "$BUNDLE_DIR"/. "$pages_dir/$EXTENSION_PATH/$VERSION_PATH/"
+          cp -R "$BUNDLE_DIR"/. "$pages_dir/$EXTENSION_PATH/latest/"
+          touch "$pages_dir/.nojekyll"
+
+          git -C "$pages_dir" add .nojekyll "$EXTENSION_PATH"
+          if git -C "$pages_dir" diff --cached --quiet; then
+            echo "No gh-pages changes to publish."
+            exit 0
+          fi
+
+          git -C "$pages_dir" commit -m "Publish wp_mysql_parser WASM extension ${VERSION_PATH}"
+          git -C "$pages_dir" push origin "HEAD:$SITE_BRANCH"
+
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          repo="${GITHUB_REPOSITORY#*/}"
+          echo "Published latest manifest: https://${owner}.github.io/${repo}/${EXTENSION_PATH}/latest/manifest.json"
+          echo "Published immutable manifest: https://${owner}.github.io/${repo}/${EXTENSION_PATH}/${VERSION_PATH}/manifest.json"

--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -101,6 +101,7 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: jspi
+          COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.26'
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -111,14 +111,24 @@ jobs:
           test -f dist/libwp_mysql_parser.a
           ls -lh dist/
 
-      - name: Verify manifest sha256 matches the .so byte-for-byte
+      - name: Rewrite manifest for Playground extension loading
+        working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
+        env:
+          ASYNC_MODE: ${{ matrix.async-mode }}
+          EXTENSION_VERSION: ${{ github.sha }}
+        run: |
+          node write-extension-manifest.mjs dist ${{ matrix.php }}
+
+      - name: Verify manifest references the built side module
         working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
         run: |
-          MANIFEST_SHA=$(node -e "console.log(require('./dist/manifest.json').artifacts[0].sha256)")
-          ACTUAL_SHA=$(sha256sum dist/wp_mysql_parser-php${{ matrix.php }}-${{ matrix.async-mode }}.so | cut -d' ' -f1)
-          echo "manifest: $MANIFEST_SHA"
-          echo "actual:   $ACTUAL_SHA"
-          test "$MANIFEST_SHA" = "$ACTUAL_SHA"
+          SOURCE_PATH=$(node -e "console.log(require('./dist/manifest.json').artifacts[0].sourcePath)")
+          EXPECTED="wp_mysql_parser-php${{ matrix.php }}-${{ matrix.async-mode }}.so"
+          echo "manifest sourcePath: $SOURCE_PATH"
+          echo "expected artifact:   $EXPECTED"
+          test "$SOURCE_PATH" = "$EXPECTED"
+          test -f "dist/$SOURCE_PATH"
+          node -e "const artifact = require('./dist/manifest.json').artifacts[0]; if ('file' in artifact || 'sha256' in artifact) { throw new Error('manifest uses retired artifact fields'); }"
 
       - name: Load the extension in Playground and parse a query
         working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -100,7 +100,7 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: ${{ matrix.async-mode }}
-          COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.26'
+          COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -100,6 +100,7 @@ jobs:
         env:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: ${{ matrix.async-mode }}
+          COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.26'
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 
@@ -110,14 +111,6 @@ jobs:
           test -f dist/manifest.json
           test -f dist/libwp_mysql_parser.a
           ls -lh dist/
-
-      - name: Rewrite manifest for Playground extension loading
-        working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
-        env:
-          ASYNC_MODE: ${{ matrix.async-mode }}
-          EXTENSION_VERSION: ${{ github.sha }}
-        run: |
-          node write-extension-manifest.mjs dist ${{ matrix.php }}
 
       - name: Verify manifest references the built side module
         working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
@@ -21,6 +21,10 @@ The build uses the published `@php-wasm/compile-extension` CLI for the phpize
 side-module build, static archive force-linking, wasm-opt pass, and manifest
 generation. A sparse Playground checkout is still required for the
 `packages/php-wasm/compile` Docker assets and for CI's Playground load test.
+The CLI is installed into an isolated temporary npm prefix before it is run;
+the sparse Playground workspace also contains an unbuilt local
+`@php-wasm/compile-extension` package, so relying on workspace `.bin` links
+would bypass the published package.
 The local glue that remains is Rust-specific: build `libwp_mysql_parser.a`
 with the same Emscripten/PHP.wasm ABI and patch the vendored `ext-php-rs`
 registry copy so it can run as a PHP.wasm side module.
@@ -117,4 +121,5 @@ PLAYGROUND_REPO=/abs/path/to/wordpress-playground PHP_VERSION=8.4 \
 
 The workflow still uses a sparse checkout of `WordPress/wordpress-playground`
 for `packages/php-wasm/compile` Docker assets and the Playground loader smoke
-test, while the extension compile itself runs through the published npm CLI.
+test, while the extension compile itself runs through an isolated install of
+the published npm CLI.

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
@@ -131,3 +131,8 @@ The workflow still uses a sparse checkout of `WordPress/wordpress-playground`
 for `packages/php-wasm/compile` Docker assets and the Playground loader smoke
 test, while the extension compile itself runs through an isolated install of
 the published npm CLI.
+
+Follow-up for Playground: make `@php-wasm/compile-extension` self-contained so
+external extension projects do not need to shallow or sparse checkout
+`WordPress/wordpress-playground` just to access Docker assets or test harness
+files.

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
@@ -96,6 +96,7 @@ extension build and manifest machinery.
 | --- | --- |
 | `Dockerfile.rust` | Rust/nightly/host-PHP layer on top of Playground's compile-extension image. |
 | `build-in-docker-rust.sh` | Builds the Rust staticlib, then calls Playground's `@php-wasm/compile-extension` CLI. |
+| `write-extension-manifest.mjs` | Rewrites build outputs into the Playground PR #3580 manifest shape. |
 | `shim/config.m4` | Minimal phpize wrapper. |
 | `shim/wp_mysql_parser_shim.c` | Pulls the Rust `get_module()` symbol into the side-module link. |
 | `run-spike.mjs` | Loads the generated manifest in Playground and verifies the native lexer. |

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
@@ -23,6 +23,34 @@ manifest generation. The local glue that remains is Rust-specific: build
 `libwp_mysql_parser.a` with the same Emscripten/PHP.wasm ABI and patch the
 vendored `ext-php-rs` registry copy so it can run as a PHP.wasm side module.
 
+## Publishing a Playground extension artifact
+
+`.github/workflows/publish-wasm-extension-artifact.yml` builds the JSPI side
+module for PHP 8.0 through 8.5, collects the side modules into one Actions
+artifact, and writes a Playground extension manifest using the sidecar format
+from WordPress/wordpress-playground#3580:
+
+```json
+{
+  "name": "wp_mysql_parser",
+  "mode": "php-extension",
+  "artifacts": [
+    {
+      "phpVersion": "8.4",
+      "sourcePath": "wp_mysql_parser-php8.4-jspi.so"
+    }
+  ]
+}
+```
+
+The published manifest deliberately uses `sourcePath` and omits the retired
+`file` and `sha256` artifact fields. The per-version build still gets whatever
+manifest the current Playground compile helper emits, but the publish job
+replaces it with the PR #3580 shape before uploading the final artifact.
+The uploaded manifest is intended for Playground builds that include that
+resolver change; older Playground loaders still expect `file`. Checksums are
+published separately in `SHA256SUMS`.
+
 ## What the Playground helper covers
 
 `@php-wasm/compile-extension` is complete enough to replace the custom

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
@@ -17,11 +17,13 @@ would require a different binding layer, or real PHP 7.4 support in
 generated/wrapped Zend API surface itself, including PHP 8-only symbols and
 struct fields.
 
-The build uses the upstream Playground compile-extension tooling for the
-phpize side-module build, static archive force-linking, wasm-opt pass, and
-manifest generation. The local glue that remains is Rust-specific: build
-`libwp_mysql_parser.a` with the same Emscripten/PHP.wasm ABI and patch the
-vendored `ext-php-rs` registry copy so it can run as a PHP.wasm side module.
+The build uses the published `@php-wasm/compile-extension` CLI for the phpize
+side-module build, static archive force-linking, wasm-opt pass, and manifest
+generation. A sparse Playground checkout is still required for the
+`packages/php-wasm/compile` Docker assets and for CI's Playground load test.
+The local glue that remains is Rust-specific: build `libwp_mysql_parser.a`
+with the same Emscripten/PHP.wasm ABI and patch the vendored `ext-php-rs`
+registry copy so it can run as a PHP.wasm side module.
 
 ## Publishing a Playground extension artifact
 
@@ -43,13 +45,13 @@ from WordPress/wordpress-playground#3580:
 }
 ```
 
-The published manifest deliberately uses `sourcePath` and omits the retired
-`file` and `sha256` artifact fields. The per-version build still gets whatever
-manifest the current Playground compile helper emits, but the publish job
-replaces it with the PR #3580 shape before uploading the final artifact.
-The uploaded manifest is intended for Playground builds that include that
-resolver change; older Playground loaders still expect `file`. Checksums are
-published separately in `SHA256SUMS`.
+The per-version build manifest comes from `@php-wasm/compile-extension` and
+already uses `sourcePath` while omitting the retired `file` and `sha256`
+artifact fields. The publish job writes a combined all-version manifest in the
+same shape before uploading the final artifact. The uploaded manifest is
+intended for Playground builds that include the #3580 resolver change; older
+Playground loaders still expect `file`. Checksums are published separately in
+`SHA256SUMS`.
 
 ## What the Playground helper covers
 
@@ -62,8 +64,8 @@ Stage 2 path that previously lived in this spike:
 - Accepts Rust or C static archives via `--extra-ldflags` and force-links
   `.a` inputs with `--whole-archive`.
 - Runs `wasm-opt` when available.
-- Emits a manifest with `sha256` hashes that the Playground runtime can load
-  at startup.
+- Emits a `sourcePath` manifest that the Playground runtime can load at
+  startup.
 
 The helper is not a full Rust build system. This crate still needs a
 per-PHP-version prebuild step that produces a wasm32-unknown-emscripten
@@ -95,8 +97,8 @@ extension build and manifest machinery.
 | Path | What it is |
 | --- | --- |
 | `Dockerfile.rust` | Rust/nightly/host-PHP layer on top of Playground's compile-extension image. |
-| `build-in-docker-rust.sh` | Builds the Rust staticlib, then calls Playground's `@php-wasm/compile-extension` CLI. |
-| `write-extension-manifest.mjs` | Rewrites build outputs into the Playground PR #3580 manifest shape. |
+| `build-in-docker-rust.sh` | Builds the Rust staticlib, then calls the published `@php-wasm/compile-extension` CLI. |
+| `write-extension-manifest.mjs` | Writes the combined all-version artifact manifest for the publish workflow. |
 | `shim/config.m4` | Minimal phpize wrapper. |
 | `shim/wp_mysql_parser_shim.c` | Pulls the Rust `get_module()` symbol into the side-module link. |
 | `run-spike.mjs` | Loads the generated manifest in Playground and verifies the native lexer. |
@@ -113,5 +115,6 @@ PLAYGROUND_REPO=/abs/path/to/wordpress-playground PHP_VERSION=8.4 \
   node run-spike.mjs
 ```
 
-The workflow uses a sparse checkout of `WordPress/wordpress-playground` trunk
-until `@php-wasm/compile-extension` is available from npm.
+The workflow still uses a sparse checkout of `WordPress/wordpress-playground`
+for `packages/php-wasm/compile` Docker assets and the Playground loader smoke
+test, while the extension compile itself runs through the published npm CLI.

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/RESULT.md
@@ -33,8 +33,9 @@ registry copy so it can run as a PHP.wasm side module.
 
 `.github/workflows/publish-wasm-extension-artifact.yml` builds the JSPI side
 module for PHP 8.0 through 8.5, collects the side modules into one Actions
-artifact, and writes a Playground extension manifest using the sidecar format
-from WordPress/wordpress-playground#3580:
+artifact, publishes the same bundle to the `gh-pages` branch, and writes a
+Playground extension manifest using the sidecar format from
+WordPress/wordpress-playground#3580:
 
 ```json
 {
@@ -52,10 +53,17 @@ from WordPress/wordpress-playground#3580:
 The per-version build manifest comes from `@php-wasm/compile-extension` and
 already uses `sourcePath` while omitting the retired `file` and `sha256`
 artifact fields. The publish job writes a combined all-version manifest in the
-same shape before uploading the final artifact. The uploaded manifest is
-intended for Playground builds that include the #3580 resolver change; older
-Playground loaders still expect `file`. Checksums are published separately in
-`SHA256SUMS`.
+same shape before uploading the final Actions artifact and publishing the
+static bundle to GitHub Pages. The public URLs are:
+
+- `https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json`
+- `https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/<commit-sha>/manifest.json`
+
+The uploaded manifest is intended for Playground builds that include the #3580
+resolver change; older Playground loaders still expect `file`. Checksums are
+published separately in `SHA256SUMS`. The repository's GitHub Pages source
+must be configured to publish from the `gh-pages` branch root for these URLs to
+resolve.
 
 ## What the Playground helper covers
 

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -21,6 +21,7 @@ ASYNC_MODE="${ASYNC_MODE:-jspi}"
 SPIKE_DIR="$(cd "$(dirname "$0")" && pwd)"
 CRATE_DIR="$(cd "$SPIKE_DIR/.." && pwd)"
 OUT_DIR="${OUT_DIR:-$SPIKE_DIR/dist}"
+COMPILE_EXTENSION_PACKAGE="${COMPILE_EXTENSION_PACKAGE:-@php-wasm/compile-extension@3.1.26}"
 PLAYGROUND_REPO="${PLAYGROUND_REPO:-$(cd "$SPIKE_DIR/../../../../wordpress-playground" 2>/dev/null && pwd || true)}"
 mkdir -p "$OUT_DIR"
 
@@ -30,12 +31,12 @@ if [ "$ASYNC_MODE" != "jspi" ]; then
 fi
 
 case "$PHP_VERSION" in
-  8.0) PHP_API_VERSION=20200930 ;;
-  8.1) PHP_API_VERSION=20210902 ;;
-  8.2) PHP_API_VERSION=20220829 ;;
-  8.3) PHP_API_VERSION=20230831 ;;
-  8.4) PHP_API_VERSION=20240924 ;;
-  8.5) PHP_API_VERSION=20250925 ;;
+  8.0) PHP_API_VERSION=20200930; PHP_RELEASE=8.0.30 ;;
+  8.1) PHP_API_VERSION=20210902; PHP_RELEASE=8.1.34 ;;
+  8.2) PHP_API_VERSION=20220829; PHP_RELEASE=8.2.30 ;;
+  8.3) PHP_API_VERSION=20230831; PHP_RELEASE=8.3.30 ;;
+  8.4) PHP_API_VERSION=20240924; PHP_RELEASE=8.4.20 ;;
+  8.5) PHP_API_VERSION=20250925; PHP_RELEASE=8.5.5 ;;
   7.4)
     echo "Unsupported PHP_VERSION: 7.4" >&2
     echo "The WASM Rust build uses ext-php-rs 0.15, which depends on PHP 8 Zend APIs and does not compile against PHP 7.4 headers." >&2
@@ -48,42 +49,23 @@ case "$PHP_VERSION" in
     ;;
 esac
 
-if [ -z "$PLAYGROUND_REPO" ] || [ ! -f "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/src/cli.ts" ]; then
-  echo "PLAYGROUND_REPO must point at a wordpress-playground checkout with packages/php-wasm/compile-extension." >&2
+if [ -z "$PLAYGROUND_REPO" ] || [ ! -f "$PLAYGROUND_REPO/packages/php-wasm/compile/Makefile" ] || [ ! -f "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/docker/Dockerfile.ext" ]; then
+  echo "PLAYGROUND_REPO must point at a wordpress-playground checkout with packages/php-wasm/compile and packages/php-wasm/compile-extension/docker." >&2
   exit 1
 fi
 
 RUST_IMAGE="playground-php-wasm-ext-rust:${PHP_VERSION}-${ASYNC_MODE}"
 BASE_IMAGE="playground-php-wasm:compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}"
-NODE_TS=(
-  node
-  --experimental-strip-types
-  --experimental-transform-types
-  --disable-warning=ExperimentalWarning
-  --import "$PLAYGROUND_REPO/packages/meta/src/node-es-module-loader/register.mts"
-)
 
 echo "==> Stage 0: preparing $BASE_IMAGE via Playground compile-extension tooling"
-"${NODE_TS[@]}" -e "
-  const { pathToFileURL } = await import('node:url');
-  const docker = await import(pathToFileURL(process.argv[1]).href);
-  const compile = await import(pathToFileURL(process.argv[2]).href);
-  const context = docker.createDockerContext(process.argv[3]);
-  const phpVersion = process.argv[4];
-  const asyncMode = process.argv[5];
-  await docker.buildBaseImage(context);
-  await docker.buildExtensionImage({
-    ...context,
-    phpVersion,
-    phpRelease: compile.resolvePHPRelease(phpVersion),
-    asyncMode,
-  });
-" \
-  "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/src/docker.ts" \
-  "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/src/compile.ts" \
-  "$PLAYGROUND_REPO" \
-  "$PHP_VERSION" \
-  "$ASYNC_MODE"
+make -C "$PLAYGROUND_REPO/packages/php-wasm/compile" base-image
+docker build \
+  -f "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/docker/Dockerfile.ext" \
+  "$PLAYGROUND_REPO/packages/php-wasm" \
+  --tag="$BASE_IMAGE" \
+  --progress=plain \
+  --build-arg "PHP_VERSION=$PHP_RELEASE" \
+  --build-arg "JSPI=yes"
 
 echo "==> Stage 0: building $RUST_IMAGE"
 docker build \
@@ -280,7 +262,7 @@ ARTIFACT="wp_mysql_parser-php${PHP_VERSION}-${ASYNC_MODE}.so"
 
 (
   cd "$PLAYGROUND_REPO"
-  "${NODE_TS[@]}" ./packages/php-wasm/compile-extension/src/cli.ts \
+  npx --yes "$COMPILE_EXTENSION_PACKAGE" \
     --source "$SRC_STAGE" \
     --name wp_mysql_parser \
     --php-versions "$PHP_VERSION" \

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -253,16 +253,20 @@ EOF
 
 echo "==> Stage 2: phpize + emconfigure + emmake (@php-wasm/compile-extension)"
 SRC_STAGE="$(mktemp -d)"
-trap 'rm -rf "$SRC_STAGE"' EXIT
+CLI_STAGE="$(mktemp -d)"
+trap 'rm -rf "$SRC_STAGE" "$CLI_STAGE"' EXIT
 cp "$SPIKE_DIR/shim/config.m4"               "$SRC_STAGE/"
 cp "$SPIKE_DIR/shim/wp_mysql_parser_shim.c"  "$SRC_STAGE/"
 cp "$OUT_DIR/libwp_mysql_parser.a"           "$SRC_STAGE/"
 
 ARTIFACT="wp_mysql_parser-php${PHP_VERSION}-${ASYNC_MODE}.so"
+COMPILE_EXTENSION_CLI="$CLI_STAGE/node_modules/@php-wasm/compile-extension/cli.js"
+
+npm install --prefix "$CLI_STAGE" --no-audit --no-fund --ignore-scripts "$COMPILE_EXTENSION_PACKAGE"
 
 (
   cd "$PLAYGROUND_REPO"
-  npm exec --yes --package "$COMPILE_EXTENSION_PACKAGE" -- php-wasm-compile-extension \
+  node "$COMPILE_EXTENSION_CLI" \
     --source "$SRC_STAGE" \
     --name wp_mysql_parser \
     --php-versions "$PHP_VERSION" \

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -21,7 +21,7 @@ ASYNC_MODE="${ASYNC_MODE:-jspi}"
 SPIKE_DIR="$(cd "$(dirname "$0")" && pwd)"
 CRATE_DIR="$(cd "$SPIKE_DIR/.." && pwd)"
 OUT_DIR="${OUT_DIR:-$SPIKE_DIR/dist}"
-COMPILE_EXTENSION_PACKAGE="${COMPILE_EXTENSION_PACKAGE:-@php-wasm/compile-extension@3.1.26}"
+COMPILE_EXTENSION_PACKAGE="${COMPILE_EXTENSION_PACKAGE:-@php-wasm/compile-extension@3.1.27}"
 PLAYGROUND_REPO="${PLAYGROUND_REPO:-$(cd "$SPIKE_DIR/../../../../wordpress-playground" 2>/dev/null && pwd || true)}"
 mkdir -p "$OUT_DIR"
 

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -262,7 +262,7 @@ ARTIFACT="wp_mysql_parser-php${PHP_VERSION}-${ASYNC_MODE}.so"
 
 (
   cd "$PLAYGROUND_REPO"
-  npx --yes "$COMPILE_EXTENSION_PACKAGE" \
+  npm exec --yes --package "$COMPILE_EXTENSION_PACKAGE" -- php-wasm-compile-extension \
     --source "$SRC_STAGE" \
     --name wp_mysql_parser \
     --php-versions "$PHP_VERSION" \

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/write-extension-manifest.mjs
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/write-extension-manifest.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const DEFAULT_PHP_VERSIONS = ['8.5', '8.4', '8.3', '8.2', '8.1', '8.0'];
+
+const [, , outDirArg, ...argvPhpVersions] = process.argv;
+const outDir = resolve(outDirArg || 'dist');
+const extensionName = process.env.EXTENSION_NAME || 'wp_mysql_parser';
+const asyncMode = process.env.ASYNC_MODE || 'jspi';
+const version = process.env.EXTENSION_VERSION || '';
+const envPhpVersions = (process.env.PHP_VERSIONS || '')
+  .split(/[,\s]+/)
+  .filter(Boolean);
+const phpVersions =
+  argvPhpVersions.length > 0
+    ? argvPhpVersions
+    : envPhpVersions.length > 0
+      ? envPhpVersions
+      : DEFAULT_PHP_VERSIONS;
+
+const missingArtifacts = [];
+const artifacts = phpVersions.map((phpVersion) => {
+  const sourcePath = `${extensionName}-php${phpVersion}-${asyncMode}.so`;
+  if (!existsSync(resolve(outDir, sourcePath))) {
+    missingArtifacts.push(sourcePath);
+  }
+  return {
+    phpVersion,
+    sourcePath,
+  };
+});
+
+if (asyncMode !== 'jspi') {
+  console.error(
+    `Unsupported ASYNC_MODE: ${asyncMode}. Playground external extension manifests are JSPI-only.`
+  );
+  process.exit(1);
+}
+
+if (missingArtifacts.length > 0) {
+  console.error(
+    `Missing extension artifact(s) in ${outDir}: ${missingArtifacts.join(', ')}`
+  );
+  process.exit(1);
+}
+
+const manifest = {
+  name: extensionName,
+  mode: 'php-extension',
+  artifacts,
+};
+
+if (version) {
+  manifest.version = version;
+}
+
+const manifestPath = resolve(outDir, 'manifest.json');
+await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+console.log(`Wrote ${manifestPath}`);


### PR DESCRIPTION
## What it does

Builds a Playground-loadable `wp_mysql_parser` WASM PHP extension bundle for PHP `8.0` through `8.5`.

On `trunk` pushes or manual `workflow_dispatch`, the new publish workflow:

1. Builds one JSPI side module per PHP version.
2. Uploads the collected bundle as an Actions artifact named `wp_mysql_parser-wasm-extension`.
3. Publishes the same files to the `gh-pages` branch:

```text
wp_mysql_parser-wasm-extension/latest/manifest.json
wp_mysql_parser-wasm-extension/<commit-sha>/manifest.json
```

The `latest/` path is replaced on every publish. The `<commit-sha>/` path is immutable.

## Rationale

Playground needs public `manifest.json` and `.so` files it can fetch at runtime. An Actions artifact is useful for debugging, but it is not a stable public URL and should not be treated as a production plugin release.

Publishing the bundle from `gh-pages` gives Playground a static URL without repackaging the WordPress plugin itself. The repository still needs GitHub Pages configured to publish from the `gh-pages` branch root before these URLs resolve:

```text
https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/<commit-sha>/manifest.json
```

PHP `7.4` is intentionally excluded. The Rust path uses `ext-php-rs` `0.15`, which depends on PHP 8 Zend APIs.

## Implementation

Adds `.github/workflows/publish-wasm-extension-artifact.yml` with a serialized PHP matrix for `8.5`, `8.4`, `8.3`, `8.2`, `8.1`, and `8.0`. The package job downloads the per-version `.so` artifacts, writes a combined Playground extension manifest, writes `SHA256SUMS`, uploads the bundle, then commits the static bundle to `gh-pages`.

The manifest follows the WordPress Playground extension format from WordPress/wordpress-playground#3580:

```json
{
  "name": "wp_mysql_parser",
  "mode": "php-extension",
  "artifacts": [
    {
      "phpVersion": "8.4",
      "sourcePath": "wp_mysql_parser-php8.4-jspi.so"
    }
  ]
}
```

The manifest uses `sourcePath` and does not include the retired `file` or `sha256` artifact fields. Checksums are published separately in `SHA256SUMS`.

The Rust build now runs the published `@php-wasm/compile-extension@3.1.27` CLI from an isolated temporary npm prefix. A sparse `WordPress/wordpress-playground` checkout is still required for `packages/php-wasm/compile` Docker assets and for the Playground load smoke test.

Follow-up for Playground: make `@php-wasm/compile-extension` self-contained so external extension projects do not need to shallow or sparse checkout `WordPress/wordpress-playground` just to access Docker assets or test harness files.

## Testing instructions

Run the local static checks:

```bash
bash -n packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
actionlint .github/workflows/wasm-spike.yml .github/workflows/publish-wasm-extension-artifact.yml
node --check packages/php-ext-wp-mysql-parser/wasm-spike/write-extension-manifest.mjs
git diff --check
```

Verify the PR `WASM extension build` check is green for PHP `8.0` through `8.5`. The latest PR run passed all six PHP versions.

After merge, run `Publish WASM extension artifact` with `workflow_dispatch` or let a matching `trunk` push trigger it, then verify both published manifests resolve from GitHub Pages once Pages is configured for the `gh-pages` branch root.