### PR TITLE
Clean up WASM CI workarounds

### DIFF
--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -87,15 +87,6 @@ jobs:
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
 
-      - name: Configure Docker DNS
-        run: |
-          echo '{"dns": ["8.8.8.8", "1.1.1.1"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if docker info >/dev/null 2>&1; then break; fi
-            sleep 2
-          done
-
       - name: Build wp_mysql_parser side module
         working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
         env:
@@ -118,17 +109,6 @@ jobs:
           path: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/dist/wp_mysql_parser-php${{ matrix.php }}-jspi.so
           if-no-files-found: error
           retention-days: ${{ github.event.inputs.retention-days || '30' }}
-
-      - name: Upload diagnostic logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: wasm-extension-publish-failure-php${{ matrix.php }}
-          path: |
-            sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/dist/
-            sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/*.log
-          if-no-files-found: ignore
-          retention-days: 14
 
   package:
     name: Package extension manifest

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -81,20 +81,6 @@ jobs:
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
 
-      - name: Configure Docker DNS
-        run: |
-          # GitHub-hosted runners occasionally have a Docker daemon whose
-          # default bridge network can't resolve archive.ubuntu.com. Pin
-          # explicit public resolvers so apt-get inside the base image build
-          # can reach the Ubuntu mirrors.
-          echo '{"dns": ["8.8.8.8", "1.1.1.1"]}' | sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-          # Wait for Docker to come back up.
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if docker info >/dev/null 2>&1; then break; fi
-            sleep 2
-          done
-
       - name: Build wp_mysql_parser side module
         working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
         env:
@@ -137,15 +123,4 @@ jobs:
           name: wp_mysql_parser-php${{ matrix.php }}-${{ matrix.async-mode }}
           path: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/dist/
           if-no-files-found: error
-          retention-days: 14
-
-      - name: Upload diagnostic logs on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: wasm-spike-failure-php${{ matrix.php }}-${{ matrix.async-mode }}
-          path: |
-            sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/dist/
-            sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike/*.log
-          if-no-files-found: ignore
           retention-days: 14


### PR DESCRIPTION
## What changed

Removes the temporary WASM workflow noise that was added while stabilizing the extension build PR:

- Drops the `Configure Docker DNS` steps from the WASM CI and publish workflows.
- Drops the failure-only diagnostic artifact uploads from both workflows.

The normal build artifacts are unchanged.

## Why

Those steps were useful while chasing transient GitHub-hosted runner and Ubuntu mirror failures, but they make the workflows harder to read and maintain now that the publishing path has landed.

## Validation

```bash
actionlint .github/workflows/wasm-spike.yml .github/workflows/publish-wasm-extension-artifact.yml
git diff --check
```