### PR TITLE
Build native parser extension in release mode for CI

### DIFF
--- a/.github/workflows/wp-tests-phpunit-native-extension-setup.sh
+++ b/.github/workflows/wp-tests-phpunit-native-extension-setup.sh
@@ -94,7 +94,7 @@ LIBCLANG_PATH="$(dirname "$LIBCLANG_SO")"
 export LIBCLANG_PATH
 
 cd /var/native-parser-extension-src
-cargo build
+cargo build --release
 EOF
 
 chmod +x "$WP_DIR/native-build-extension.sh"
@@ -103,7 +103,7 @@ cd "$WP_DIR"
 node tools/local-env/scripts/docker.js run --rm php sh /var/www/native-build-extension.sh
 
 mkdir -p "$RUNTIME_DIR"
-cp "$ROOT_DIR/packages/php-ext-wp-mysql-parser/target/debug/libwp_mysql_parser.so" "$RUNTIME_DIR/libwp_mysql_parser.so"
+cp "$ROOT_DIR/packages/php-ext-wp-mysql-parser/target/release/libwp_mysql_parser.so" "$RUNTIME_DIR/libwp_mysql_parser.so"
 printf '%s\n' 'extension=/var/native-parser-extension/libwp_mysql_parser.so' > "$RUNTIME_DIR/wp-mysql-parser.ini"
 
 add_volume_to_service php "$EXTENSION_RUNTIME_VOLUME"


### PR DESCRIPTION
## What it does

Builds the native Rust MySQL parser extension with `cargo build --release` in the WordPress PHPUnit native-extension job, then loads `target/release/libwp_mysql_parser.so`.

## Rationale

The previous workflow loaded `target/debug/libwp_mysql_parser.so`, so the WordPress PHPUnit timing compared pure PHP against an unoptimized Rust extension. That made the Rust-extension job look slower for the wrong reason.

With this change, the PR run confirms the release extension is faster in the PHPUnit phase:

| Job | Wall time | PHPUnit time |
| --- | ---: | ---: |
| WordPress PHPUnit Tests | `10m49s` | `06:41.969` |
| WordPress PHPUnit Tests / Rust extension | `10m24s` | `05:05.385` |

The Rust-extension job still pays separate setup/build cost, but the optimized extension is about `1m36s` faster during PHPUnit itself in this run.

## Implementation

Changes the generated build script from:

```sh
cargo build
```

to:

```sh
cargo build --release
```

and copies the built extension from `target/release` instead of `target/debug`.

## Testing instructions

- `bash -n .github/workflows/wp-tests-phpunit-native-extension-setup.sh`
- Built `target/release/libwp_mysql_parser.so` locally and verified PHP loads `wp_mysql_parser`
- CI: WordPress PHPUnit Tests passed
  - normal: https://github.com/WordPress/sqlite-database-integration/actions/runs/25343877499/job/74307884595
  - Rust extension: https://github.com/WordPress/sqlite-database-integration/actions/runs/25343877499/job/74307884603
- Full PR check suite is passing on #398