### PR TITLE
Parallelize WASM extension builds

### DIFF
--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 6
       matrix:
         # The Rust WASM path uses ext-php-rs 0.15, which depends on PHP 8
         # Zend APIs. PHP 7.4 cannot be added here by extending the matrix.
@@ -83,6 +83,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: wordpress-playground/package-lock.json
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Install Playground deps
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
@@ -93,6 +96,8 @@ jobs:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: jspi
           COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
+          DOCKER_BUILD_CACHE: gha
+          DOCKER_BUILD_CACHE_SCOPE_PREFIX: wp-mysql-parser-wasm
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 

--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -26,8 +26,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  base-image:
+    name: Build shared Playground base image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out wordpress-playground
+        uses: actions/checkout@v4
+        with:
+          repository: WordPress/wordpress-playground
+          ref: ${{ github.event.inputs.playground-ref || 'trunk' }}
+          path: wordpress-playground
+          sparse-checkout: |
+            packages/php-wasm/compile/base-image
+
+      - name: Build Playground base image
+        run: |
+          docker build \
+            -f wordpress-playground/packages/php-wasm/compile/base-image/Dockerfile \
+            --tag playground-php-wasm:base \
+            wordpress-playground/packages/php-wasm/compile/base-image
+
+      - name: Save Playground base image
+        run: docker save --output "${RUNNER_TEMP}/playground-php-wasm-base.tar" playground-php-wasm:base
+
+      - name: Upload Playground base image
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-php-wasm-base-image
+          path: ${{ runner.temp }}/playground-php-wasm-base.tar
+          if-no-files-found: error
+          retention-days: 1
+
   build:
     name: Build wp_mysql_parser.so (PHP ${{ matrix.php }})
+    needs: base-image
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -83,6 +117,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: wordpress-playground/package-lock.json
 
+      - name: Download Playground base image
+        uses: actions/download-artifact@v4
+        with:
+          name: playground-php-wasm-base-image
+          path: ${{ runner.temp }}/playground-base-image
+
+      - name: Load Playground base image
+        run: docker load --input "${RUNNER_TEMP}/playground-base-image/playground-php-wasm-base.tar"
+
       - name: Install Playground deps
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
@@ -94,6 +137,7 @@ jobs:
           ASYNC_MODE: jspi
           COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
+          SKIP_BASE_IMAGE_BUILD: '1'
         run: bash build-in-docker-rust.sh
 
       - name: Verify side module exists

--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -83,9 +83,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: wordpress-playground/package-lock.json
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Install Playground deps
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
@@ -96,8 +93,6 @@ jobs:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: jspi
           COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
-          DOCKER_BUILD_CACHE: gha
-          DOCKER_BUILD_CACHE_SCOPE_PREFIX: wp-mysql-parser-wasm
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -77,9 +77,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: wordpress-playground/package-lock.json
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Install Playground deps
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
@@ -90,8 +87,6 @@ jobs:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: ${{ matrix.async-mode }}
           COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
-          DOCKER_BUILD_CACHE: gha
-          DOCKER_BUILD_CACHE_SCOPE_PREFIX: wp-mysql-parser-wasm
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -19,8 +19,42 @@ on:
         default: 'trunk'
 
 jobs:
+  base-image:
+    name: Build shared Playground base image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Check out wordpress-playground
+        uses: actions/checkout@v4
+        with:
+          repository: WordPress/wordpress-playground
+          ref: ${{ github.event.inputs.playground-ref || 'trunk' }}
+          path: wordpress-playground
+          sparse-checkout: |
+            packages/php-wasm/compile/base-image
+
+      - name: Build Playground base image
+        run: |
+          docker build \
+            -f wordpress-playground/packages/php-wasm/compile/base-image/Dockerfile \
+            --tag playground-php-wasm:base \
+            wordpress-playground/packages/php-wasm/compile/base-image
+
+      - name: Save Playground base image
+        run: docker save --output "${RUNNER_TEMP}/playground-php-wasm-base.tar" playground-php-wasm:base
+
+      - name: Upload Playground base image
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-php-wasm-base-image
+          path: ${{ runner.temp }}/playground-php-wasm-base.tar
+          if-no-files-found: error
+          retention-days: 1
+
   build-and-load:
     name: Build wp_mysql_parser.so and load it in Playground (PHP ${{ matrix.php }})
+    needs: base-image
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -77,6 +111,15 @@ jobs:
           cache: 'npm'
           cache-dependency-path: wordpress-playground/package-lock.json
 
+      - name: Download Playground base image
+        uses: actions/download-artifact@v4
+        with:
+          name: playground-php-wasm-base-image
+          path: ${{ runner.temp }}/playground-base-image
+
+      - name: Load Playground base image
+        run: docker load --input "${RUNNER_TEMP}/playground-base-image/playground-php-wasm-base.tar"
+
       - name: Install Playground deps
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
@@ -88,6 +131,7 @@ jobs:
           ASYNC_MODE: ${{ matrix.async-mode }}
           COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
+          SKIP_BASE_IMAGE_BUILD: '1'
         run: bash build-in-docker-rust.sh
 
       - name: Verify build artifacts exist

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 45
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 6
       matrix:
         # The Rust WASM path uses ext-php-rs 0.15, which depends on PHP 8
         # Zend APIs. PHP 7.4 cannot be added here by extending the matrix.
@@ -77,6 +77,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: wordpress-playground/package-lock.json
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Install Playground deps
         working-directory: wordpress-playground
         run: npm ci --ignore-scripts
@@ -87,6 +90,8 @@ jobs:
           PHP_VERSION: ${{ matrix.php }}
           ASYNC_MODE: ${{ matrix.async-mode }}
           COMPILE_EXTENSION_PACKAGE: '@php-wasm/compile-extension@3.1.27'
+          DOCKER_BUILD_CACHE: gha
+          DOCKER_BUILD_CACHE_SCOPE_PREFIX: wp-mysql-parser-wasm
           PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
         run: bash build-in-docker-rust.sh
 

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -54,6 +54,42 @@ if [ -z "$PLAYGROUND_REPO" ] || [ ! -f "$PLAYGROUND_REPO/packages/php-wasm/compi
   exit 1
 fi
 
+patch_compile_extension_cli() {
+  local cli_path="$1"
+
+  # The npm CLI currently rebuilds the Docker images itself. This script has
+  # already prepared those exact images in Stage 0, so patch the pinned CLI to
+  # reuse them and fail loudly if the installed package changes shape.
+  node --input-type=module - "$cli_path" <<'NODE'
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const cliPath = process.argv[2];
+let source = readFileSync(cliPath, 'utf8');
+
+const replacements = [
+  [
+    'async function k(e){await p("make",["base-image"],{cwd:e.compileRoot})}',
+    'async function k(e){if(process.env.COMPILE_EXTENSION_SKIP_IMAGE_BUILD==="1"){await p("docker",["image","inspect","playground-php-wasm:base"],{stdio:"ignore"});console.log("Skipping compile-extension base image build; using existing playground-php-wasm:base");return}await p("make",["base-image"],{cwd:e.compileRoot})}',
+  ],
+  [
+    'async function j(e){const t=$(e);return await p("docker",["build","-f","compile-extension/docker/Dockerfile.ext",".",`--tag=${t}`,"--progress=plain","--build-arg",`PHP_VERSION=${e.phpRelease}`,"--build-arg","JSPI=yes"],{cwd:e.phpWasmRoot}),t}',
+    'async function j(e){const t=$(e);if(process.env.COMPILE_EXTENSION_SKIP_IMAGE_BUILD==="1"){await p("docker",["image","inspect",t],{stdio:"ignore"});console.log(`Skipping compile-extension image build; using existing ${t}`);return t}return await p("docker",["build","-f","compile-extension/docker/Dockerfile.ext",".",`--tag=${t}`,"--progress=plain","--build-arg",`PHP_VERSION=${e.phpRelease}`,"--build-arg","JSPI=yes"],{cwd:e.phpWasmRoot}),t}',
+  ],
+];
+
+for (const [from, to] of replacements) {
+  if (!source.includes(from)) {
+    throw new Error(`Unable to patch @php-wasm/compile-extension CLI. Missing pattern: ${from}`);
+  }
+  source = source.replace(from, to);
+}
+
+writeFileSync(cliPath, source);
+NODE
+
+  grep -q 'COMPILE_EXTENSION_SKIP_IMAGE_BUILD' "$cli_path"
+}
+
 RUST_IMAGE="playground-php-wasm-ext-rust:${PHP_VERSION}-${ASYNC_MODE}"
 BASE_IMAGE="playground-php-wasm:compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}"
 
@@ -275,10 +311,11 @@ ARTIFACT="wp_mysql_parser-php${PHP_VERSION}-${ASYNC_MODE}.so"
 COMPILE_EXTENSION_CLI="$CLI_STAGE/node_modules/@php-wasm/compile-extension/cli.js"
 
 npm install --prefix "$CLI_STAGE" --no-audit --no-fund --ignore-scripts "$COMPILE_EXTENSION_PACKAGE"
+patch_compile_extension_cli "$COMPILE_EXTENSION_CLI"
 
 (
   cd "$PLAYGROUND_REPO"
-  node "$COMPILE_EXTENSION_CLI" \
+  COMPILE_EXTENSION_SKIP_IMAGE_BUILD=1 node "$COMPILE_EXTENSION_CLI" \
     --source "$SRC_STAGE" \
     --name wp_mysql_parser \
     --php-versions "$PHP_VERSION" \

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -56,31 +56,14 @@ fi
 
 RUST_IMAGE="playground-php-wasm-ext-rust:${PHP_VERSION}-${ASYNC_MODE}"
 BASE_IMAGE="playground-php-wasm:compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}"
-DOCKER_BUILD_CACHE="${DOCKER_BUILD_CACHE:-}"
-DOCKER_BUILD_CACHE_SCOPE_PREFIX="${DOCKER_BUILD_CACHE_SCOPE_PREFIX:-wp-mysql-parser-wasm}"
-
-docker_build() {
-  local cache_scope="$1"
-  shift
-
-  if [ "$DOCKER_BUILD_CACHE" = "gha" ]; then
-    docker buildx build --load \
-      --cache-from "type=gha,scope=${DOCKER_BUILD_CACHE_SCOPE_PREFIX}-${cache_scope}" \
-      --cache-to "type=gha,mode=max,scope=${DOCKER_BUILD_CACHE_SCOPE_PREFIX}-${cache_scope}" \
-      "$@"
-    return
-  fi
-
-  docker build "$@"
-}
 
 echo "==> Stage 0: preparing $BASE_IMAGE via Playground compile-extension tooling"
 BASE_IMAGE_DIR="$PLAYGROUND_REPO/packages/php-wasm/compile/base-image"
-docker_build "base-image" \
+docker build \
   -f "$BASE_IMAGE_DIR/Dockerfile" \
   --tag="playground-php-wasm:base" \
   "$BASE_IMAGE_DIR"
-docker_build "compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}" \
+docker build \
   -f "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/docker/Dockerfile.ext" \
   --tag="$BASE_IMAGE" \
   --progress=plain \
@@ -89,7 +72,7 @@ docker_build "compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}" \
   "$PLAYGROUND_REPO/packages/php-wasm"
 
 echo "==> Stage 0: building $RUST_IMAGE"
-docker_build "rust-php${PHP_VERSION//./-}-${ASYNC_MODE}" \
+docker build \
   --build-arg "BASE_IMAGE=$BASE_IMAGE" \
   --build-arg "HOST_PHP_VERSION=$PHP_VERSION" \
   --build-arg "HOST_PHP_API_VERSION=$PHP_API_VERSION" \

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -58,11 +58,19 @@ RUST_IMAGE="playground-php-wasm-ext-rust:${PHP_VERSION}-${ASYNC_MODE}"
 BASE_IMAGE="playground-php-wasm:compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}"
 
 echo "==> Stage 0: preparing $BASE_IMAGE via Playground compile-extension tooling"
-BASE_IMAGE_DIR="$PLAYGROUND_REPO/packages/php-wasm/compile/base-image"
-docker build \
-  -f "$BASE_IMAGE_DIR/Dockerfile" \
-  --tag="playground-php-wasm:base" \
-  "$BASE_IMAGE_DIR"
+if [ "${SKIP_BASE_IMAGE_BUILD:-}" = "1" ]; then
+  if ! docker image inspect playground-php-wasm:base >/dev/null 2>&1; then
+    echo "SKIP_BASE_IMAGE_BUILD=1 requires a preloaded playground-php-wasm:base image." >&2
+    exit 1
+  fi
+  echo "==> Stage 0: using preloaded playground-php-wasm:base"
+else
+  BASE_IMAGE_DIR="$PLAYGROUND_REPO/packages/php-wasm/compile/base-image"
+  docker build \
+    -f "$BASE_IMAGE_DIR/Dockerfile" \
+    --tag="playground-php-wasm:base" \
+    "$BASE_IMAGE_DIR"
+fi
 docker build \
   -f "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/docker/Dockerfile.ext" \
   --tag="$BASE_IMAGE" \

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh
@@ -56,19 +56,40 @@ fi
 
 RUST_IMAGE="playground-php-wasm-ext-rust:${PHP_VERSION}-${ASYNC_MODE}"
 BASE_IMAGE="playground-php-wasm:compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}"
+DOCKER_BUILD_CACHE="${DOCKER_BUILD_CACHE:-}"
+DOCKER_BUILD_CACHE_SCOPE_PREFIX="${DOCKER_BUILD_CACHE_SCOPE_PREFIX:-wp-mysql-parser-wasm}"
+
+docker_build() {
+  local cache_scope="$1"
+  shift
+
+  if [ "$DOCKER_BUILD_CACHE" = "gha" ]; then
+    docker buildx build --load \
+      --cache-from "type=gha,scope=${DOCKER_BUILD_CACHE_SCOPE_PREFIX}-${cache_scope}" \
+      --cache-to "type=gha,mode=max,scope=${DOCKER_BUILD_CACHE_SCOPE_PREFIX}-${cache_scope}" \
+      "$@"
+    return
+  fi
+
+  docker build "$@"
+}
 
 echo "==> Stage 0: preparing $BASE_IMAGE via Playground compile-extension tooling"
-make -C "$PLAYGROUND_REPO/packages/php-wasm/compile" base-image
-docker build \
+BASE_IMAGE_DIR="$PLAYGROUND_REPO/packages/php-wasm/compile/base-image"
+docker_build "base-image" \
+  -f "$BASE_IMAGE_DIR/Dockerfile" \
+  --tag="playground-php-wasm:base" \
+  "$BASE_IMAGE_DIR"
+docker_build "compile-extension-php${PHP_VERSION//./-}-${ASYNC_MODE}" \
   -f "$PLAYGROUND_REPO/packages/php-wasm/compile-extension/docker/Dockerfile.ext" \
-  "$PLAYGROUND_REPO/packages/php-wasm" \
   --tag="$BASE_IMAGE" \
   --progress=plain \
   --build-arg "PHP_VERSION=$PHP_RELEASE" \
-  --build-arg "JSPI=yes"
+  --build-arg "JSPI=yes" \
+  "$PLAYGROUND_REPO/packages/php-wasm"
 
 echo "==> Stage 0: building $RUST_IMAGE"
-docker build \
+docker_build "rust-php${PHP_VERSION//./-}-${ASYNC_MODE}" \
   --build-arg "BASE_IMAGE=$BASE_IMAGE" \
   --build-arg "HOST_PHP_VERSION=$PHP_VERSION" \
   --build-arg "HOST_PHP_API_VERSION=$PHP_API_VERSION" \


### PR DESCRIPTION
## What it does

Runs the WASM extension PHP-version matrix concurrently and shares the expensive Playground base image across the matrix. Both the PR smoke workflow and the publish workflow now build `playground-php-wasm:base` once, upload it as a short-lived internal artifact, then fan out all six PHP 8.x builds in parallel.

## Rationale

The publish workflow was running one PHP build at a time. In the observed trunk run, PHP 8.5 finished before PHP 8.4 started, and the build spent about 24m30s inside `build-in-docker-rust.sh` for that one PHP version.

Blindly running all six jobs in parallel exposed another bottleneck: every job rebuilt the same Ubuntu-based Playground base image and hit `apt-get update` at the same time. Sharing that base image keeps the wall-time win while avoiding six duplicate apt/install passes.

A later CI run showed one more duplicate path: `@php-wasm/compile-extension@3.1.27` rebuilt the Playground base image and PHP-specific compile-extension image again during Stage 2. The build script now reuses the images prepared in Stage 0, so each matrix job does one Docker image preparation pass instead of two.

## Implementation

- Add a `base-image` job to `.github/workflows/wasm-spike.yml` and `.github/workflows/publish-wasm-extension-artifact.yml`
- Upload the saved `playground-php-wasm:base` image with `retention-days: 1`
- Make each PHP matrix job download and `docker load` that base image before building its PHP-specific compile-extension image
- Set `max-parallel: 6` for both PHP matrices
- Add `SKIP_BASE_IMAGE_BUILD=1` support to `build-in-docker-rust.sh` so CI can require a preloaded base image while local runs still build it normally
- Patch the pinned compile-extension CLI at install time to skip its duplicate Docker image build and use the Stage 0 images; the patch fails loudly if the package shape changes

I also tried wiring `docker buildx build --cache-to type=gha`, but dropped it. The GHA cache backend requires a non-default Buildx driver, and that driver does not automatically expose locally tagged intermediate images like `playground-php-wasm:base` to later Dockerfile `FROM` lines. The internal image artifact is simpler and matches this build's local image chain.

Follow-up: `@php-wasm/compile-extension` should expose a first-class way to use already-prepared images so this repo does not need to patch the pinned CLI at runtime.

## Testing instructions

- `bash -n packages/php-ext-wp-mysql-parser/wasm-spike/build-in-docker-rust.sh`
- `actionlint .github/workflows/publish-wasm-extension-artifact.yml .github/workflows/wasm-spike.yml`
- `git diff --check`
- Verified in PR CI run `25348528195`: shared base image job passed in 4m18s, all six PHP matrix jobs passed in 9m30s-11m55s, and the workflow completed successfully