### PR TITLE
Increase WASM extension build timeout

### DIFF
--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -63,7 +63,7 @@ jobs:
     name: Build wp_mysql_parser.so (PHP ${{ matrix.php }})
     needs: base-image
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 6

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -56,7 +56,7 @@ jobs:
     name: Build wp_mysql_parser.so and load it in Playground (PHP ${{ matrix.php }})
     needs: base-image
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       max-parallel: 6


### PR DESCRIPTION
## What changed

- Raises the WASM extension matrix build timeout from 45 to 60 minutes in the publish workflow.
- Keeps the same timeout in the interactive WASM spike workflow, which runs the same build shape.

## Why

The first publish run after merging #399 built the PHP 8.3 side module successfully, but hit the 45-minute job timeout before the verify/upload steps could run. The log ended with the artifact written and then the job cancellation.