### PR TITLE
GitHub Actions workflow updates

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -35,6 +35,7 @@ jobs:
   checkcs:
     name: 'Check code style'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read # Required to clone the repo.
 

--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -21,6 +21,10 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.
@@ -31,6 +35,8 @@ jobs:
   checkcs:
     name: 'Check code style'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout code

--- a/.github/workflows/end-to-end-tests.yml
+++ b/.github/workflows/end-to-end-tests.yml
@@ -6,11 +6,17 @@ on:
       - main
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: End-to-end Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/mysql-parser-extension-tests.yml
+++ b/.github/workflows/mysql-parser-extension-tests.yml
@@ -19,11 +19,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   extension-tests:
     name: PHP ${{ matrix.php }} / ${{ matrix.coverage }} / ubuntu-latest
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read # Required to clone the repo.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/mysql-proxy-tests.yml
+++ b/.github/workflows/mysql-proxy-tests.yml
@@ -6,11 +6,17 @@ on:
       - main
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: MySQL Proxy Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpunit-tests-run.yml
+++ b/.github/workflows/phpunit-tests-run.yml
@@ -20,11 +20,17 @@ on:
 env:
   LOCAL_PHP: ${{ inputs.php }}-fpm
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpunit-tests:
     name: ${{ inputs.os }}
     runs-on: ${{ inputs.os }}
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -6,12 +6,16 @@ on:
       - main
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: PHP ${{ matrix.php }} / SQLite ${{ matrix.sqlite || 'latest' }}
     uses: ./.github/workflows/phpunit-tests-run.yml
     permissions:
-      contents: read
+      contents: read # Required to clone the repo.
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -18,8 +18,9 @@ on:
         required: false
         default: '30'
 
-permissions:
-  contents: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,6 +31,8 @@ jobs:
     name: Build shared Playground base image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the wordpress-playground repo.
 
     steps:
       - name: Check out wordpress-playground
@@ -64,6 +67,8 @@ jobs:
     needs: base-image
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read # Required to clone the repo.
     strategy:
       fail-fast: false
       max-parallel: 6
@@ -159,6 +164,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 10
+    permissions:
+      contents: write # Required to push the built extension to the gh-pages branch.
 
     steps:
       - name: Check out sqlite-database-integration

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,6 +21,7 @@ jobs:
       && github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write # Required to clone the repo, create the GitHub release, and delete the release branch.
     outputs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,6 +24,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write # Required to clone the repo, create the GitHub release, and delete the release branch.
+      pull-requests: read # Required for gh api graphql queries that read pull request author data.
     outputs:
       tag: ${{ steps.version.outputs.tag }}
       prerelease: ${{ steps.version.outputs.prerelease }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,6 +9,10 @@ concurrency:
   group: release-publish
   cancel-in-progress: false
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   publish-release:
     name: Build plugin and create GitHub release
@@ -18,7 +22,7 @@ jobs:
       && startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # Required to clone the repo, create the GitHub release, and delete the release branch.
     outputs:
       tag: ${{ steps.version.outputs.tag }}
       prerelease: ${{ steps.version.outputs.prerelease }}
@@ -130,6 +134,8 @@ jobs:
     needs: publish-release
     if: needs.publish-release.outputs.prerelease == 'false'
     uses: ./.github/workflows/release-wporg.yml
+    permissions:
+      contents: read # Required to clone the repo and download the release asset.
     with:
       tag: ${{ needs.publish-release.outputs.tag }}
     secrets: inherit

--- a/.github/workflows/release-wporg.yml
+++ b/.github/workflows/release-wporg.yml
@@ -17,13 +17,17 @@ concurrency:
   group: release-wporg
   cancel-in-progress: false
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   deploy:
     name: Deploy plugin to WordPress.org
     if: github.repository == 'WordPress/sqlite-database-integration'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: read # Required to clone the repo and download the release asset via gh.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-wporg.yml
+++ b/.github/workflows/release-wporg.yml
@@ -26,6 +26,7 @@ jobs:
     name: Deploy plugin to WordPress.org
     if: github.repository == 'WordPress/sqlite-database-integration'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read # Required to clone the repo and download the release asset via gh.
 

--- a/.github/workflows/verify-version.yml
+++ b/.github/workflows/verify-version.yml
@@ -14,6 +14,7 @@ jobs:
   verify-version:
     name: Assert release metadata is internally consistent
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read # Required to clone the repo.
     steps:

--- a/.github/workflows/verify-version.yml
+++ b/.github/workflows/verify-version.yml
@@ -6,10 +6,16 @@ on:
       - trunk
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   verify-version:
     name: Assert release metadata is internally consistent
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo.
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -18,11 +18,17 @@ on:
         required: false
         default: 'trunk'
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   base-image:
     name: Build shared Playground base image
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the wordpress-playground repo.
 
     steps:
       - name: Check out wordpress-playground
@@ -57,6 +63,8 @@ jobs:
     needs: base-image
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read # Required to clone the repo.
     strategy:
       fail-fast: false
       max-parallel: 6

--- a/.github/workflows/wp-tests-end-to-end.yml
+++ b/.github/workflows/wp-tests-end-to-end.yml
@@ -6,11 +6,17 @@ on:
       - main
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: WordPress End-to-end Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/wp-tests-phpunit.yml
+++ b/.github/workflows/wp-tests-phpunit.yml
@@ -6,11 +6,17 @@ on:
       - main
   pull_request:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   test:
     name: WordPress PHPUnit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository
@@ -35,6 +41,8 @@ jobs:
     name: WordPress PHPUnit Tests / Rust extension
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    permissions:
+      contents: read # Required to clone the repo.
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/sqlite-database-integration/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Claude Code was used to create the initial changes. All permissions and timeouts changes were reviewed and adjusted by me where necessary.
