### PR TITLE
Default SQLite connections to WAL

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -669,11 +669,16 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		$db_name = $args['dbname'] ?? 'sqlite_database';
 
 		// Create a new SQLite connection.
+		$connection_options = array(
+			'journal_mode' => $options['journal_mode'] ?? null,
+			'synchronous'  => $options['synchronous'] ?? null,
+		);
 		if ( isset( $options['pdo'] ) ) {
-			$this->connection = new WP_SQLite_Connection( array( 'pdo' => $options['pdo'] ) );
+			$connection_options['pdo'] = $options['pdo'];
 		} else {
-			$this->connection = new WP_SQLite_Connection( array( 'path' => $path ) );
+			$connection_options['path'] = $path;
 		}
+		$this->connection = new WP_SQLite_Connection( $connection_options );
 
 		$this->mysql_version = $options['mysql_version'] ?? 80038;
 		$this->main_db_name  = $db_name;

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
@@ -113,18 +113,21 @@ class WP_SQLite_Connection {
 		if ( is_string( $journal_mode ) ) {
 			$journal_mode = strtoupper( $journal_mode );
 		}
-		if ( $journal_mode && in_array( $journal_mode, self::SQLITE_JOURNAL_MODES, true ) ) {
-			try {
-				$effective_journal_mode = strtoupper(
-					(string) $this->query( 'PRAGMA journal_mode = ' . $journal_mode )->fetchColumn()
-				);
-			} catch ( PDOException $e ) {
-				// WAL may be unavailable in some environments, such as on network
-				// filesystems. When it is explicitly configured, surface the error.
-				// Otherwise, fall back to the default SQLite behavior.
-				if ( isset( $options['journal_mode'] ) ) {
-					throw $e;
-				}
+		if ( ! in_array( $journal_mode, self::SQLITE_JOURNAL_MODES, true ) ) {
+			throw new InvalidArgumentException(
+				sprintf( 'Invalid SQLite journal mode: %s.', $options['journal_mode'] )
+			);
+		}
+		try {
+			$effective_journal_mode = strtoupper(
+				(string) $this->query( 'PRAGMA journal_mode = ' . $journal_mode )->fetchColumn()
+			);
+		} catch ( PDOException $e ) {
+			// WAL may be unavailable in some environments, such as on network
+			// filesystems. When it is explicitly configured, surface the error.
+			// Otherwise, fall back to the default SQLite behavior.
+			if ( isset( $options['journal_mode'] ) ) {
+				throw $e;
 			}
 		}
 
@@ -154,6 +157,11 @@ class WP_SQLite_Connection {
 				$synchronous = self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ];
 			} elseif ( is_string( $synchronous ) ) {
 				$synchronous = strtoupper( $synchronous );
+			}
+			if ( ! in_array( $synchronous, self::SQLITE_SYNCHRONOUS_SETTINGS, true ) ) {
+				throw new InvalidArgumentException(
+					sprintf( 'Invalid SQLite synchronous setting: %s.', $options['synchronous'] )
+				);
 			}
 		} elseif ( 'WAL' === $effective_journal_mode ) {
 			// Default to NORMAL for WAL mode.

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
@@ -46,6 +46,8 @@ class WP_SQLite_Connection {
 	/**
 	 * The supported SQLite synchronous settings.
 	 *
+	 * The list is indexed by the corresponding numeric setting values (0 to 3).
+	 *
 	 * See: https://www.sqlite.org/pragma.html#pragma_synchronous
 	 */
 	const SQLITE_SYNCHRONOUS_SETTINGS = array(
@@ -77,16 +79,16 @@ class WP_SQLite_Connection {
 	 * @param array $options {
 	 *     An array of options.
 	 *
-	 *     @type string|null $path         Optional. SQLite database path.
-	 *                                     For in-memory database, use ':memory:'.
-	 *                                     Must be set when PDO instance is not provided.
-	 *     @type PDO|null    $pdo          Optional. PDO instance with SQLite connection.
-	 *                                     If not provided, a new PDO instance will be created.
-	 *     @type int|null    $timeout      Optional. SQLite timeout in seconds.
-	 *                                     The time to wait for a writable lock.
-	 *     @type string|null $journal_mode Optional. SQLite journal mode. Defaults to WAL.
-	 *     @type string|null $synchronous  Optional. SQLite synchronous setting. Defaults to
-	 *                                     NORMAL when the effective journal mode is WAL.
+	 *     @type string|null     $path         Optional. SQLite database path.
+	 *                                         For in-memory database, use ':memory:'.
+	 *                                         Must be set when PDO instance is not provided.
+	 *     @type PDO|null        $pdo          Optional. PDO instance with SQLite connection.
+	 *                                         If not provided, a new PDO instance will be created.
+	 *     @type int|null        $timeout      Optional. SQLite timeout in seconds.
+	 *                                         The time to wait for a writable lock.
+	 *     @type string|null     $journal_mode Optional. SQLite journal mode. Defaults to WAL.
+	 *     @type string|int|null $synchronous  Optional. SQLite synchronous setting. Defaults to
+	 *                                         NORMAL when the effective journal mode is WAL.
 	 * }
 	 *
 	 * @throws InvalidArgumentException When some connection options are invalid.
@@ -141,8 +143,9 @@ class WP_SQLite_Connection {
 		$synchronous = $options['synchronous'] ?? null;
 		if ( null === $synchronous && 'WAL' === $effective_journal_mode ) {
 			$synchronous = self::DEFAULT_SQLITE_WAL_SYNCHRONOUS;
-		}
-		if ( is_string( $synchronous ) ) {
+		} elseif ( is_int( $synchronous ) && isset( self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ] ) ) {
+			$synchronous = self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ];
+		} elseif ( is_string( $synchronous ) ) {
 			$synchronous = strtoupper( $synchronous );
 		}
 		if ( $synchronous && in_array( $synchronous, self::SQLITE_SYNCHRONOUS_SETTINGS, true ) ) {

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
@@ -122,9 +122,18 @@ class WP_SQLite_Connection {
 			$journal_mode = strtoupper( $journal_mode );
 		}
 		if ( $journal_mode && in_array( $journal_mode, self::SQLITE_JOURNAL_MODES, true ) ) {
-			$effective_journal_mode = strtoupper(
-				(string) $this->query( 'PRAGMA journal_mode = ' . $journal_mode )->fetchColumn()
-			);
+			try {
+				$effective_journal_mode = strtoupper(
+					(string) $this->query( 'PRAGMA journal_mode = ' . $journal_mode )->fetchColumn()
+				);
+			} catch ( PDOException $e ) {
+				// WAL may be unavailable in some environments, such as on network
+				// filesystems. When it is explicitly configured, surface the error.
+				// Otherwise, fall back to the default SQLite behavior.
+				if ( isset( $options['journal_mode'] ) ) {
+					throw $e;
+				}
+			}
 		}
 
 		// Configure SQLite synchronous setting. In WAL mode, default to NORMAL.

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
@@ -20,16 +20,6 @@ class WP_SQLite_Connection {
 	const DEFAULT_SQLITE_TIMEOUT = 10;
 
 	/**
-	 * The default SQLite journal mode.
-	 */
-	const DEFAULT_SQLITE_JOURNAL_MODE = 'WAL';
-
-	/**
-	 * The default SQLite synchronous setting for WAL mode.
-	 */
-	const DEFAULT_SQLITE_WAL_SYNCHRONOUS = 'NORMAL';
-
-	/**
 	 * The supported SQLite journal modes.
 	 *
 	 * See: https://www.sqlite.org/pragma.html#pragma_journal_mode
@@ -117,9 +107,9 @@ class WP_SQLite_Connection {
 		}
 		$this->pdo->setAttribute( PDO::ATTR_TIMEOUT, $timeout );
 
-		// Configure SQLite journal mode.
+		// Configure SQLite journal mode. Default to WAL for best throughput.
 		$effective_journal_mode = null;
-		$journal_mode           = $options['journal_mode'] ?? self::DEFAULT_SQLITE_JOURNAL_MODE;
+		$journal_mode           = $options['journal_mode'] ?? 'WAL';
 		if ( is_string( $journal_mode ) ) {
 			$journal_mode = strtoupper( $journal_mode );
 		}
@@ -138,17 +128,38 @@ class WP_SQLite_Connection {
 			}
 		}
 
-		// Configure SQLite synchronous setting. In WAL mode, default to NORMAL.
-		// Otherwise, use SQLite's default value.
+		/*
+		 * Configure SQLite synchronous setting. Default to NORMAL for WAL mode.
+		 *
+		 * WAL improves read/write concurrency and "synchronous = NORMAL" avoids
+		 * frequent sync to the main database, which could become a bottleneck.
+		 * In WAL mode, NORMAL is safe and recommended. From the SQLite docs:
+		 *
+		 *   The synchronous=NORMAL setting provides the best balance between
+		 *   performance and safety for most applications running in WAL mode.
+		 *   You lose durability across power lose with synchronous NORMAL in WAL
+		 *   mode, but that is not important for most applications. Transactions
+		 *   are still atomic, consistent, and isolated, which are the most
+		 *   important characteristics in most use cases.
+		 *
+		 * SQLite defaults to "synchronous = FULL" to avoid data corruption with
+		 * other journal modes. With WAL, this is not necessary.
+		 *
+		 * See: https://sqlite.org/pragma.html#pragma_synchronous
+		 */
 		$synchronous = $options['synchronous'] ?? null;
-		if ( null === $synchronous && 'WAL' === $effective_journal_mode ) {
-			$synchronous = self::DEFAULT_SQLITE_WAL_SYNCHRONOUS;
-		} elseif ( is_int( $synchronous ) && isset( self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ] ) ) {
-			$synchronous = self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ];
-		} elseif ( is_string( $synchronous ) ) {
-			$synchronous = strtoupper( $synchronous );
+		if ( isset( $synchronous ) ) {
+			// Validate and normalize explicitly provided synchronous value.
+			if ( is_int( $synchronous ) && isset( self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ] ) ) {
+				$synchronous = self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ];
+			} elseif ( is_string( $synchronous ) ) {
+				$synchronous = strtoupper( $synchronous );
+			}
+		} elseif ( 'WAL' === $effective_journal_mode ) {
+			// Default to NORMAL for WAL mode.
+			$synchronous = 'NORMAL';
 		}
-		if ( $synchronous && in_array( $synchronous, self::SQLITE_SYNCHRONOUS_SETTINGS, true ) ) {
+		if ( in_array( $synchronous, self::SQLITE_SYNCHRONOUS_SETTINGS, true ) ) {
 			$this->query( 'PRAGMA synchronous = ' . $synchronous );
 		}
 	}

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
@@ -20,6 +20,16 @@ class WP_SQLite_Connection {
 	const DEFAULT_SQLITE_TIMEOUT = 10;
 
 	/**
+	 * The default SQLite journal mode.
+	 */
+	const DEFAULT_SQLITE_JOURNAL_MODE = 'WAL';
+
+	/**
+	 * The default SQLite synchronous setting for WAL mode.
+	 */
+	const DEFAULT_SQLITE_WAL_SYNCHRONOUS = 'NORMAL';
+
+	/**
 	 * The supported SQLite journal modes.
 	 *
 	 * See: https://www.sqlite.org/pragma.html#pragma_journal_mode
@@ -31,6 +41,18 @@ class WP_SQLite_Connection {
 		'MEMORY',
 		'WAL',
 		'OFF',
+	);
+
+	/**
+	 * The supported SQLite synchronous settings.
+	 *
+	 * See: https://www.sqlite.org/pragma.html#pragma_synchronous
+	 */
+	const SQLITE_SYNCHRONOUS_SETTINGS = array(
+		'OFF',
+		'NORMAL',
+		'FULL',
+		'EXTRA',
 	);
 
 	/**
@@ -62,7 +84,9 @@ class WP_SQLite_Connection {
 	 *                                     If not provided, a new PDO instance will be created.
 	 *     @type int|null    $timeout      Optional. SQLite timeout in seconds.
 	 *                                     The time to wait for a writable lock.
-	 *     @type string|null $journal_mode Optional. SQLite journal mode.
+	 *     @type string|null $journal_mode Optional. SQLite journal mode. Defaults to WAL.
+	 *     @type string|null $synchronous  Optional. SQLite synchronous setting. Defaults to
+	 *                                     NORMAL when the effective journal mode is WAL.
 	 * }
 	 *
 	 * @throws InvalidArgumentException When some connection options are invalid.
@@ -92,9 +116,28 @@ class WP_SQLite_Connection {
 		$this->pdo->setAttribute( PDO::ATTR_TIMEOUT, $timeout );
 
 		// Configure SQLite journal mode.
-		$journal_mode = $options['journal_mode'] ?? null;
+		$effective_journal_mode = null;
+		$journal_mode           = $options['journal_mode'] ?? self::DEFAULT_SQLITE_JOURNAL_MODE;
+		if ( is_string( $journal_mode ) ) {
+			$journal_mode = strtoupper( $journal_mode );
+		}
 		if ( $journal_mode && in_array( $journal_mode, self::SQLITE_JOURNAL_MODES, true ) ) {
-			$this->query( 'PRAGMA journal_mode = ' . $journal_mode );
+			$effective_journal_mode = strtoupper(
+				(string) $this->query( 'PRAGMA journal_mode = ' . $journal_mode )->fetchColumn()
+			);
+		}
+
+		// Configure SQLite synchronous setting. In WAL mode, default to NORMAL.
+		// Otherwise, use SQLite's default value.
+		$synchronous = $options['synchronous'] ?? null;
+		if ( null === $synchronous && 'WAL' === $effective_journal_mode ) {
+			$synchronous = self::DEFAULT_SQLITE_WAL_SYNCHRONOUS;
+		}
+		if ( is_string( $synchronous ) ) {
+			$synchronous = strtoupper( $synchronous );
+		}
+		if ( $synchronous && in_array( $synchronous, self::SQLITE_SYNCHRONOUS_SETTINGS, true ) ) {
+			$this->query( 'PRAGMA synchronous = ' . $synchronous );
 		}
 	}
 

--- a/packages/mysql-on-sqlite/tests/WP_PDO_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_PDO_MySQL_On_SQLite_PDO_API_Tests.php
@@ -68,6 +68,54 @@ class WP_PDO_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertSame( 'w', $driver->query( 'SELECT DATABASE()' )->fetch()[0] );
 	}
 
+	public function test_journal_mode_defaults_to_wal(): void {
+		$path = tempnam( sys_get_temp_dir(), 'wp_sqlite_' );
+		unlink( $path );
+
+		try {
+			$driver     = new WP_PDO_MySQL_On_SQLite( 'mysql-on-sqlite:path=' . $path . ';dbname=wp' );
+			$connection = $driver->get_connection();
+			$this->assertSame(
+				'wal',
+				strtolower( (string) $connection->query( 'PRAGMA journal_mode' )->fetchColumn() )
+			);
+			$this->assertSame(
+				'1',
+				(string) $connection->query( 'PRAGMA synchronous' )->fetchColumn()
+			);
+		} finally {
+			$this->remove_database_files( $path );
+		}
+	}
+
+	public function test_journal_mode_and_synchronous_driver_options(): void {
+		$path = tempnam( sys_get_temp_dir(), 'wp_sqlite_' );
+		unlink( $path );
+
+		try {
+			$driver     = new WP_PDO_MySQL_On_SQLite(
+				'mysql-on-sqlite:path=' . $path . ';dbname=wp',
+				null,
+				null,
+				array(
+					'journal_mode' => 'DELETE',
+					'synchronous'  => 'FULL',
+				)
+			);
+			$connection = $driver->get_connection();
+			$this->assertSame(
+				'delete',
+				strtolower( (string) $connection->query( 'PRAGMA journal_mode' )->fetchColumn() )
+			);
+			$this->assertSame(
+				'2',
+				(string) $connection->query( 'PRAGMA synchronous' )->fetchColumn()
+			);
+		} finally {
+			$this->remove_database_files( $path );
+		}
+	}
+
 	public function test_query(): void {
 		$result = $this->driver->query( "SELECT 1, 'abc'" );
 		$this->assertInstanceOf( PDOStatement::class, $result );
@@ -547,5 +595,13 @@ class WP_PDO_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 				2     => 'two',
 			),
 		);
+	}
+
+	private function remove_database_files( string $path ): void {
+		foreach ( array( $path, $path . '-wal', $path . '-shm', $path . '-journal' ) as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
 	}
 }

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
@@ -117,6 +117,29 @@ class WP_SQLite_Connection_Tests extends TestCase {
 		$this->assertSame( '2', $this->get_synchronous( $connection ) );
 	}
 
+	public function testSynchronousAcceptsIntegerValues(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'        => $this->db_path,
+				'synchronous' => 3,
+			)
+		);
+
+		$this->assertSame( '3', $this->get_synchronous( $connection ) );
+	}
+
+	public function testSynchronousAcceptsIntegerZero(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'DELETE',
+				'synchronous'  => 0,
+			)
+		);
+
+		$this->assertSame( '0', $this->get_synchronous( $connection ) );
+	}
+
 	public function testDefaultJournalModeFallsBackWhenWalIsUnavailable(): void {
 		$this->make_database_directory_read_only();
 

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
@@ -104,17 +104,34 @@ class WP_SQLite_Connection_Tests extends TestCase {
 		$this->assertSame( '3', $this->get_synchronous( $connection ) );
 	}
 
-	public function testInvalidJournalModeAndSynchronousAreIgnored(): void {
-		$connection = new WP_SQLite_Connection(
+	public function testInvalidJournalModeThrows(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new WP_SQLite_Connection(
 			array(
 				'path'         => $this->db_path,
 				'journal_mode' => 'INVALID',
-				'synchronous'  => 'INVALID',
 			)
 		);
+	}
 
-		$this->assertSame( 'delete', $this->get_journal_mode( $connection ) );
-		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	public function testInvalidSynchronousThrows(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new WP_SQLite_Connection(
+			array(
+				'path'        => $this->db_path,
+				'synchronous' => 'INVALID',
+			)
+		);
+	}
+
+	public function testOutOfRangeIntegerSynchronousThrows(): void {
+		$this->expectException( InvalidArgumentException::class );
+		new WP_SQLite_Connection(
+			array(
+				'path'        => $this->db_path,
+				'synchronous' => 5,
+			)
+		);
 	}
 
 	public function testSynchronousAcceptsIntegerValues(): void {

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
@@ -7,6 +7,13 @@ use PHPUnit\Framework\TestCase;
  */
 class WP_SQLite_Connection_Tests extends TestCase {
 	/**
+	 * Path to the temporary directory holding the SQLite database file.
+	 *
+	 * @var string|null
+	 */
+	private $db_dir;
+
+	/**
 	 * Path to the temporary SQLite database file used in file-based tests.
 	 *
 	 * @var string|null
@@ -14,11 +21,14 @@ class WP_SQLite_Connection_Tests extends TestCase {
 	private $db_path;
 
 	public function setUp(): void {
-		$this->db_path = tempnam( sys_get_temp_dir(), 'wp_sqlite_' );
-		unlink( $this->db_path );
+		$this->db_dir = tempnam( sys_get_temp_dir(), 'wp_sqlite_' );
+		unlink( $this->db_dir );
+		mkdir( $this->db_dir );
+		$this->db_path = $this->db_dir . '/database.sqlite';
 	}
 
 	public function tearDown(): void {
+		chmod( $this->db_dir, 0755 ); // Restore permissions changed by read-only tests.
 		foreach ( array(
 			$this->db_path,
 			$this->db_path . '-wal',
@@ -29,6 +39,8 @@ class WP_SQLite_Connection_Tests extends TestCase {
 				unlink( $path );
 			}
 		}
+		rmdir( $this->db_dir );
+		$this->db_dir  = null;
 		$this->db_path = null;
 	}
 
@@ -103,6 +115,47 @@ class WP_SQLite_Connection_Tests extends TestCase {
 
 		$this->assertSame( 'delete', $this->get_journal_mode( $connection ) );
 		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	}
+
+	public function testDefaultJournalModeFallsBackWhenWalIsUnavailable(): void {
+		$this->make_database_directory_read_only();
+
+		$connection = new WP_SQLite_Connection( array( 'path' => $this->db_path ) );
+
+		$this->assertSame( 'delete', $this->get_journal_mode( $connection ) );
+		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	}
+
+	public function testExplicitJournalModeSurfacesFailureWhenWalIsUnavailable(): void {
+		$this->make_database_directory_read_only();
+
+		$this->expectException( PDOException::class );
+		new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'WAL',
+			)
+		);
+	}
+
+	/**
+	 * Create the database file first, and then make its directory read-only,
+	 * so that the WAL sidecar files ("-wal", "-shm") cannot be created.
+	 */
+	private function make_database_directory_read_only(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'DELETE',
+			)
+		);
+		$connection->query( 'CREATE TABLE t ( id INTEGER )' );
+		$connection = null;
+
+		chmod( $this->db_dir, 0555 );
+		if ( is_writable( $this->db_dir ) ) {
+			$this->markTestSkipped( 'The test requires a non-writable database directory.' );
+		}
 	}
 
 	private function get_journal_mode( WP_SQLite_Connection $connection ): string {

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
@@ -1,0 +1,115 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the SQLite connection setup.
+ */
+class WP_SQLite_Connection_Tests extends TestCase {
+	/**
+	 * Path to the temporary SQLite database file used in file-based tests.
+	 *
+	 * @var string|null
+	 */
+	private $db_path;
+
+	public function setUp(): void {
+		$this->db_path = tempnam( sys_get_temp_dir(), 'wp_sqlite_' );
+		unlink( $this->db_path );
+	}
+
+	public function tearDown(): void {
+		foreach ( array(
+			$this->db_path,
+			$this->db_path . '-wal',
+			$this->db_path . '-shm',
+			$this->db_path . '-journal',
+		) as $path ) {
+			if ( is_string( $path ) && file_exists( $path ) ) {
+				unlink( $path );
+			}
+		}
+		$this->db_path = null;
+	}
+
+	public function testDefaultJournalModeUsesWal(): void {
+		$connection = new WP_SQLite_Connection( array( 'path' => $this->db_path ) );
+
+		$this->assertSame( 'wal', $this->get_journal_mode( $connection ) );
+		$this->assertSame( '1', $this->get_synchronous( $connection ) );
+	}
+
+	public function testJournalModeCanBeOverridden(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'DELETE',
+			)
+		);
+
+		$this->assertSame( 'delete', $this->get_journal_mode( $connection ) );
+	}
+
+	public function testSynchronousCanBeOverridden(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'        => $this->db_path,
+				'synchronous' => 'FULL',
+			)
+		);
+
+		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	}
+
+	public function testRollbackJournalModeKeepsDefaultSynchronous(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'DELETE',
+			)
+		);
+
+		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	}
+
+	public function testInMemoryDatabaseKeepsDefaultSynchronous(): void {
+		$connection = new WP_SQLite_Connection( array( 'path' => ':memory:' ) );
+
+		$this->assertSame( 'memory', $this->get_journal_mode( $connection ) );
+		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	}
+
+	public function testJournalModeAndSynchronousAreCaseInsensitive(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'delete',
+				'synchronous'  => 'extra',
+			)
+		);
+
+		$this->assertSame( 'delete', $this->get_journal_mode( $connection ) );
+		$this->assertSame( '3', $this->get_synchronous( $connection ) );
+	}
+
+	public function testInvalidJournalModeAndSynchronousAreIgnored(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'INVALID',
+				'synchronous'  => 'INVALID',
+			)
+		);
+
+		$this->assertSame( 'delete', $this->get_journal_mode( $connection ) );
+		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	}
+
+	private function get_journal_mode( WP_SQLite_Connection $connection ): string {
+		return strtolower( (string) $connection->query( 'PRAGMA journal_mode' )->fetchColumn() );
+	}
+
+	private function get_synchronous( WP_SQLite_Connection $connection ): string {
+		return (string) $connection->query( 'PRAGMA synchronous' )->fetchColumn();
+	}
+}

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/install-functions.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/install-functions.php
@@ -25,25 +25,25 @@ function sqlite_make_db_sqlite() {
 	$table_schemas = wp_get_db_schema();
 	$queries       = explode( ';', $table_schemas );
 	try {
-		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class; // phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
-		$pdo       = new $pdo_class( 'sqlite:' . FQDB, null, null, array( PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION ) ); // phpcs:ignore WordPress.DB.RestrictedClasses
+		$pdo_class  = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class; // phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
+		$pdo        = new $pdo_class( 'sqlite:' . FQDB, null, null, array( PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION ) ); // phpcs:ignore WordPress.DB.RestrictedClasses
+		$translator = new WP_SQLite_Driver(
+			new WP_SQLite_Connection(
+				array(
+					'pdo'          => $pdo,
+					'journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
+				)
+			),
+			$wpdb->dbname
+		);
 	} catch ( PDOException $err ) {
 		$err_data = $err->errorInfo; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$message  = 'Database connection error!<br />';
-		$message .= sprintf( 'Error message is: %s', $err_data[2] );
+		$message .= sprintf( 'Error message is: %s', $err_data[2] ?? $err->getMessage() );
 		wp_die( $message, 'Database Error!' );
 	}
 
-	$translator = new WP_SQLite_Driver(
-		new WP_SQLite_Connection(
-			array(
-				'pdo'          => $pdo,
-				'journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
-			)
-		),
-		$wpdb->dbname
-	);
-	$query      = null;
+	$query = null;
 
 	try {
 		$translator->begin_transaction();

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/install-functions.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/install-functions.php
@@ -35,7 +35,12 @@ function sqlite_make_db_sqlite() {
 	}
 
 	$translator = new WP_SQLite_Driver(
-		new WP_SQLite_Connection( array( 'pdo' => $pdo ) ),
+		new WP_SQLite_Connection(
+			array(
+				'pdo'          => $pdo,
+				'journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
+			)
+		),
 		$wpdb->dbname
 	);
 	$query      = null;


### PR DESCRIPTION
## What changed

**[Journal mode:](https://sqlite.org/pragma.html#pragma_journal_mode)**
  - Default new SQLite connections to **`journal_mode = WAL`**.
  - Skip defaulting to WAL when unavailable (e.g., on network filesystems).

**[Synchronous flag:](https://sqlite.org/pragma.html#pragma_synchronous)**
  - Apply **`synchronous = NORMAL`** when WAL is used.
  - Otherwise, use the SQLite default.

**Other changes:**
- Wire the `SQLITE_JOURNAL_MODE` override through the WordPress plugin connection paths.
- Accept `journal_mode` and `synchronous` in the `WP_PDO_MySQL_On_SQLite` driver options.
- Add connection setup tests for the defaults, overrides, invalid values, and the WAL fallback.

## Why

`WAL` improves read/write concurrency for SQLite-backed WordPress installs, and `synchronous = NORMAL` avoids frequent sync to the main database. In WAL mode, `NORMAL` is safe. [From the SQLite docs](https://sqlite.org/pragma.html#pragma_synchronous):

> [WAL mode](https://sqlite.org/wal.html) is safe from corruption with synchronous=NORMAL, and probably DELETE mode is safe too on modern filesystems. WAL mode is always consistent with synchronous=NORMAL, but WAL mode does lose durability. A transaction committed in WAL mode with synchronous=NORMAL might roll back following a power loss or system crash. Transactions are durable across application crashes regardless of the synchronous setting or journal mode.

> The synchronous=NORMAL setting provides the best balance between performance and safety for most applications running in [WAL mode](https://sqlite.org/wal.html). You lose durability across power lose with synchronous NORMAL in WAL mode, but that is not important for most applications. Transactions are still atomic, consistent, and isolated, which are the most important characteristics in most use cases.

## Benchmark

A local benchmark ran a WordPress-like 90% read / 10% write workload against the same database file with 4, 8, and 16 concurrent workers, comparing the trunk defaults with WAL + NORMAL (median of 3 runs, PHP 8.5.5, SQLite 3.53.0).

| Workers | Config | Ops/s | p50 | p95 | p99 |
|---|---|---:|---:|---:|---:|
| 4 | default | 4,985 | 0.21 ms | 3.94 ms | 10.2 ms |
| 4 | WAL + NORMAL | 15,982 (3.2×) | 0.19 ms | 0.73 ms | 1.2 ms |
| 8 | default | 5,249 | 0.24 ms | 4.22 ms | 22.6 ms |
| 8 | WAL + NORMAL | 25,371 (4.8×) | 0.20 ms | 1.02 ms | 1.5 ms |
| 16 | default | 5,226 | 0.25 ms | 10.25 ms | 59.0 ms |
| 16 | WAL + NORMAL | 30,300 (5.8×) | 0.22 ms | 1.43 ms | 4.0 ms |

This was run on an M4 MacBook Pro Max.


