### PR TITLE
Make native parser extension visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ composer run wp-test-e2e                # Run WordPress E2E tests (Playwright)
 composer run wp-test-clean              # Clean up WordPress environment (Docker and DB)
 ```
 
+## Optional: Native MySQL Parser Extension
+
+The default code path is pure PHP. For environments that can load PHP extensions, the optional `wp_mysql_parser` extension accelerates the MySQL lexer/parser used by the SQLite driver.
+
+- [Published WASM release list, manifest links, Playground links, and native extension overview](https://wordpress.github.io/sqlite-database-integration/)
+- [Build, verification, and benchmark docs](packages/php-ext-wp-mysql-parser/README.md)
+
+Latest local measurement (Apple Silicon macOS, PHP 8.4.5 CLI, 2026-05-26): the native lexer path processed the MySQL test corpus at ~343k QPS versus ~72k QPS for pure PHP (~4.80x), and the native parser path processed it at ~108k QPS versus ~7k QPS for pure PHP (~15.45x).
+
 ## Release workflow
 Release is streamlined with a local preparation script and GitHub Actions:
 

--- a/packages/mysql-on-sqlite/tests/tools/run-lexer-benchmark.php
+++ b/packages/mysql-on-sqlite/tests/tools/run-lexer-benchmark.php
@@ -1,8 +1,12 @@
 <?php
 
 /**
- * This script runs the MySQL lexer on all queries from the MySQL server suite.
+ * This script runs the MySQL lexer on queries from the MySQL server suite.
  * It ensures the lexer tokenizes all queries and measures lexing performance.
+ *
+ * Options:
+ *   --json       Print machine-readable benchmark output.
+ *   --limit=N    Only benchmark the first N queries.
  */
 
 // Throw exception if anything fails.
@@ -12,19 +16,32 @@ set_error_handler(
 	}
 );
 
+$json  = in_array( '--json', $argv, true );
+$limit = null;
+foreach ( $argv as $arg ) {
+	if ( 0 === strpos( $arg, '--limit=' ) ) {
+		$limit = max( 1, (int) substr( $arg, strlen( '--limit=' ) ) );
+	}
+}
+
 require_once __DIR__ . '/../../src/parser/class-wp-parser-token.php';
 require_once __DIR__ . '/../../src/mysql/class-wp-mysql-token.php';
 require_once __DIR__ . '/../../src/mysql/class-wp-mysql-lexer.php';
 
-// Load the queries.
+// Load the bounded checked-in corpus before timing so file IO is excluded
+// from the benchmark.
 $handle  = fopen( __DIR__ . '/../mysql/data/mysql-server-tests-queries.csv', 'r' );
 $records = array();
-while ( ( $record = fgetcsv( $handle ) ) !== false ) {
+while ( ( $record = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
 	$records[] = $record;
+	if ( null !== $limit && count( $records ) >= $limit ) {
+		break;
+	}
 }
 
 // Run the lexer.
-$start = microtime( true );
+$processed = 0;
+$start     = microtime( true );
 for ( $i = 0; $i < count( $records ); $i += 1 ) {
 	$query  = $records[ $i ][0];
 	$lexer  = new WP_MySQL_Lexer( $query );
@@ -32,8 +49,25 @@ for ( $i = 0; $i < count( $records ); $i += 1 ) {
 	if ( count( $tokens ) === 0 ) {
 		throw new Exception( 'Failed to tokenize query: ' . $query );
 	}
+	$processed += 1;
 }
 $duration = microtime( true ) - $start;
+$qps      = $processed / $duration;
+
+if ( $json ) {
+	echo json_encode(
+		array(
+			'benchmark'      => 'mysql-lexer',
+			'implementation' => 'php',
+			'queries'        => $processed,
+			'duration'       => $duration,
+			'qps'            => $qps,
+			'php_version'    => PHP_VERSION,
+		),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	), "\n";
+	exit;
+}
 
 // Print the results.
-printf( "\nTokenized %d queries in %.5fs @ %d QPS.\n", $i + 1, $duration, ( $i + 1 ) / $duration );
+printf( "\nTokenized %d queries in %.5fs @ %d QPS.\n", $processed, $duration, $qps );

--- a/packages/mysql-on-sqlite/tests/tools/run-native-extension-benchmark.php
+++ b/packages/mysql-on-sqlite/tests/tools/run-native-extension-benchmark.php
@@ -1,0 +1,113 @@
+<?php
+
+/**
+ * Compare the pure-PHP MySQL lexer with the optional native extension lexer.
+ *
+ * Options:
+ *   --json       Print machine-readable benchmark output.
+ *   --limit=N    Only benchmark the first N queries.
+ */
+
+set_error_handler(
+	function ( $severity, $message, $file, $line ) {
+		throw new ErrorException( $message, 0, $severity, $file, $line );
+	}
+);
+
+$json  = in_array( '--json', $argv, true );
+$limit = null;
+foreach ( $argv as $arg ) {
+	if ( 0 === strpos( $arg, '--limit=' ) ) {
+		$limit = max( 1, (int) substr( $arg, strlen( '--limit=' ) ) );
+	}
+}
+
+require_once __DIR__ . '/../../src/parser/class-wp-parser-token.php';
+require_once __DIR__ . '/../../src/mysql/class-wp-mysql-token.php';
+require_once __DIR__ . '/../../src/mysql/class-wp-mysql-lexer.php';
+
+// Load the bounded checked-in corpus before timing so file IO is excluded
+// from the benchmark.
+$handle  = fopen( __DIR__ . '/../mysql/data/mysql-server-tests-queries.csv', 'r' );
+$queries = array();
+while ( ( $record = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
+	$query = $record[0] ?? null;
+	if ( null === $query || '' === $query ) {
+		continue;
+	}
+	$queries[] = $query;
+	if ( null !== $limit && count( $queries ) >= $limit ) {
+		break;
+	}
+}
+
+function benchmark_php_mysql_lexer( $queries ) {
+	$start = microtime( true );
+	foreach ( $queries as $query ) {
+		$lexer  = new WP_MySQL_Lexer( $query );
+		$tokens = $lexer->remaining_tokens();
+		if ( count( $tokens ) === 0 ) {
+			throw new Exception( 'Failed to tokenize query: ' . $query );
+		}
+	}
+	$duration = microtime( true ) - $start;
+	return array(
+		'available' => true,
+		'duration'  => $duration,
+		'qps'       => count( $queries ) / $duration,
+	);
+}
+
+function benchmark_native_mysql_lexer( $queries ) {
+	if ( ! class_exists( 'WP_MySQL_Native_Lexer', false ) ) {
+		return array(
+			'available' => false,
+			'reason'    => 'The wp_mysql_parser extension is not loaded.',
+		);
+	}
+
+	$start = microtime( true );
+	foreach ( $queries as $query ) {
+		$lexer  = new WP_MySQL_Native_Lexer( $query );
+		$tokens = $lexer->native_token_stream();
+		if ( 0 === $tokens->count() ) {
+			throw new Exception( 'Failed to tokenize query with native lexer: ' . $query );
+		}
+	}
+	$duration = microtime( true ) - $start;
+	return array(
+		'available' => true,
+		'duration'  => $duration,
+		'qps'       => count( $queries ) / $duration,
+	);
+}
+
+$php    = benchmark_php_mysql_lexer( $queries );
+$native = benchmark_native_mysql_lexer( $queries );
+
+$result = array(
+	'benchmark'        => 'mysql-lexer-native-extension',
+	'queries'          => count( $queries ),
+	'php_version'      => PHP_VERSION,
+	'extension_loaded' => extension_loaded( 'wp_mysql_parser' ),
+	'pure_php'         => $php,
+	'native_extension' => $native,
+);
+
+if ( ! empty( $native['available'] ) ) {
+	$result['speedup'] = $native['qps'] / $php['qps'];
+}
+
+if ( $json ) {
+	echo json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ), "\n";
+	exit;
+}
+
+printf( "Benchmarked %d MySQL queries on PHP %s.\n", $result['queries'], PHP_VERSION );
+printf( "Pure PHP lexer:       %.5fs @ %d QPS\n", $php['duration'], $php['qps'] );
+if ( empty( $native['available'] ) ) {
+	printf( "Native extension:     unavailable (%s)\n", $native['reason'] );
+	exit;
+}
+printf( "Native extension:     %.5fs @ %d QPS\n", $native['duration'], $native['qps'] );
+printf( "Speedup:              %.2fx\n", $result['speedup'] );

--- a/packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php
+++ b/packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php
@@ -4,6 +4,10 @@
  * This script runs the MySQL parser on all queries from the MySQL server suite.
  * It tracks parsing failures and exceptions and measures parsing performance.
  * This is an end-to-end benchmark that includes lexing time in the results.
+ *
+ * Options:
+ *   --json       Print machine-readable benchmark output.
+ *   --limit=N    Only benchmark the first N queries.
  */
 
 // Throw exception if anything fails.
@@ -13,13 +17,17 @@ set_error_handler(
 	}
 );
 
-require_once __DIR__ . '/../../src/parser/class-wp-parser-grammar.php';
-require_once __DIR__ . '/../../src/parser/class-wp-parser-node.php';
-require_once __DIR__ . '/../../src/parser/class-wp-parser-token.php';
-require_once __DIR__ . '/../../src/parser/class-wp-parser.php';
-require_once __DIR__ . '/../../src/mysql/class-wp-mysql-token.php';
-require_once __DIR__ . '/../../src/mysql/class-wp-mysql-lexer.php';
-require_once __DIR__ . '/../../src/mysql/class-wp-mysql-parser.php';
+$json  = in_array( '--json', $argv, true );
+$limit = null;
+foreach ( $argv as $arg ) {
+	if ( 0 === strpos( $arg, '--limit=' ) ) {
+		$limit = max( 1, (int) substr( $arg, strlen( '--limit=' ) ) );
+	}
+}
+
+// Use the integration loader so an already-loaded native extension selects
+// the same public lexer/parser classes that runtime code uses.
+require_once __DIR__ . '/../../src/load.php';
 
 function get_stats( $total, $failures, $exceptions ) {
 	return sprintf(
@@ -36,24 +44,28 @@ function get_stats( $total, $failures, $exceptions ) {
 $grammar_data = include __DIR__ . '/../../src/mysql/mysql-grammar.php';
 $grammar      = new WP_Parser_Grammar( $grammar_data );
 
-// Load the queries.
+// Load the bounded checked-in corpus before timing so file IO is excluded
+// from the benchmark.
 $data_dir = __DIR__ . '/../mysql/data';
 $handle   = fopen( "$data_dir/mysql-server-tests-queries.csv", 'r' );
-$records  = array();
+$queries  = array();
 while ( ( $record = fgetcsv( $handle, null, ',', '"', '\\' ) ) !== false ) {
-	$records[] = $record;
+	$query = $record[0] ?? null;
+	if ( null === $query || '' === $query ) {
+		continue;
+	}
+	$queries[] = $query;
+	if ( null !== $limit && count( $queries ) >= $limit ) {
+		break;
+	}
 }
 
 // Run the parser.
 $failures   = array();
 $exceptions = array();
+$processed  = 0;
 $start      = microtime( true );
-for ( $i = 1; $i < count( $records ); $i += 1 ) {
-	$query = $records[ $i ][0];
-	if ( null === $query ) {
-		continue;
-	}
-
+foreach ( $queries as $query ) {
 	try {
 		$lexer  = new WP_MySQL_Lexer( $query );
 		$tokens = $lexer instanceof WP_MySQL_Native_Lexer
@@ -72,13 +84,33 @@ for ( $i = 1; $i < count( $records ); $i += 1 ) {
 		$exceptions[] = $query;
 	}
 
-	if ( $i > 0 && 0 === $i % 1000 ) {
-		echo get_stats( $i, count( $failures ), count( $exceptions ) ), "\n";
+	$processed += 1;
+	if ( ! $json && $processed > 0 && 0 === $processed % 1000 ) {
+		echo get_stats( $processed, count( $failures ), count( $exceptions ) ), "\n";
 	}
 }
 $duration = microtime( true ) - $start;
+$qps      = $processed / $duration;
 
-echo get_stats( $i, count( $failures ), count( $exceptions ) ), "\n";
+if ( $json ) {
+	echo json_encode(
+		array(
+			'benchmark'        => 'mysql-parser',
+			'implementation'   => class_exists( 'WP_MySQL_Native_Parser', false ) ? 'native-extension' : 'php',
+			'extension_loaded' => extension_loaded( 'wp_mysql_parser' ),
+			'queries'          => $processed,
+			'duration'         => $duration,
+			'qps'              => $qps,
+			'failures'         => count( $failures ),
+			'exceptions'       => count( $exceptions ),
+			'php_version'      => PHP_VERSION,
+		),
+		JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES
+	), "\n";
+	exit;
+}
+
+echo get_stats( $processed, count( $failures ), count( $exceptions ) ), "\n";
 
 // Print the results.
-printf( "\nParsed %d queries in %.5fs @ %d QPS.\n", $i, $duration, $i / $duration );
+printf( "\nParsed %d queries in %.5fs @ %d QPS.\n", $processed, $duration, $qps );

--- a/packages/php-ext-wp-mysql-parser/README.md
+++ b/packages/php-ext-wp-mysql-parser/README.md
@@ -1,41 +1,118 @@
 # WP MySQL Parser PHP Extension
 
-This crate builds an optional PHP extension named `wp_mysql_parser`.
+`wp_mysql_parser` is an optional native PHP extension for the SQLite Database Integration project. It provides native implementations of the MySQL lexer/parser path used by the SQLite driver while keeping the pure-PHP implementation as the portable fallback.
 
-When the extension is loaded before `packages/mysql-on-sqlite/src/load.php`, it
-registers native base classes used by the public `WP_MySQL_Lexer` and
-`WP_MySQL_Parser` wrappers. Without the extension, those public wrappers extend
-the pure-PHP implementations instead.
+When the extension is loaded before `packages/mysql-on-sqlite/src/load.php`, it registers native base classes used by the public `WP_MySQL_Lexer` and `WP_MySQL_Parser` wrappers. Without the extension, those public wrappers extend the pure-PHP implementations instead.
 
-## Build
+## Published WASM build for Playground
 
-The build requires Rust, PHP development headers, `php-config`, and libclang.
-Depending on the environment, `LIBCLANG_PATH` may need to point at the directory
-containing `libclang.so`.
+Published WASM builds are listed on this repository's GitHub Pages site, with manifest links, checksums, and a “Run in Playground” link for each release:
+
+<https://wordpress.github.io/sqlite-database-integration/>
+
+The current build is also available directly:
+
+- Manifest: <https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json>
+- Checksums: <https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/SHA256SUMS>
+- Supported PHP versions: 8.0, 8.1, 8.2, 8.3, 8.4, and 8.5.
+
+Use this Playground URL to load the extension and open the demo/benchmark page:
+
+<https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json>
+
+## Build the native extension locally
+
+Requirements:
+
+- Rust toolchain.
+- PHP development headers and `php-config`.
+- libclang, with `LIBCLANG_PATH` pointing at the directory containing the libclang shared library when auto-detection is not enough.
 
 ```bash
-PHP_CONFIG=/path/to/php-config \
-LIBCLANG_PATH=/path/to/libclang/lib \
-cargo build --release
+(
+	cd packages/php-ext-wp-mysql-parser
+	PHP_CONFIG="$(command -v php-config)" \
+	LIBCLANG_PATH=/path/to/libclang \
+	cargo build --release
+)
 ```
 
-The resulting shared object is written to:
-
-```text
-target/release/libwp_mysql_parser.so
-```
-
-Load it for local test runs with:
+On macOS, if the linker reports unresolved Zend/PHP symbols, add dynamic lookup linker flags:
 
 ```bash
-php -d extension=/path/to/libwp_mysql_parser.so vendor/bin/phpunit
+(
+	cd packages/php-ext-wp-mysql-parser
+	RUSTFLAGS='-C link-arg=-undefined -C link-arg=dynamic_lookup' \
+	PHP_CONFIG="$(command -v php-config)" \
+	LIBCLANG_PATH=/path/to/libclang \
+	cargo build --release
+)
 ```
+
+The resulting shared object is written under `target/release/` as `libwp_mysql_parser.so` on Linux or `libwp_mysql_parser.dylib` on macOS.
+
+From the repository root, load it for local verification or benchmarks:
+
+```bash
+php -d extension=/absolute/path/to/libwp_mysql_parser.so -m | grep wp_mysql_parser
+php -d extension=/absolute/path/to/libwp_mysql_parser.so packages/mysql-on-sqlite/tests/tools/verify-native-parser-extension.php
+```
+
+## Verify the WASM artifacts
+
+Download the manifest and checksums:
+
+```bash
+curl -O https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
+curl -O https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/SHA256SUMS
+```
+
+Each `.so` listed in the manifest is published next to the manifest and can be checked against `SHA256SUMS`:
+
+```bash
+curl -O https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/wp_mysql_parser-php8.4-jspi.so
+shasum -a 256 -c SHA256SUMS --ignore-missing
+```
+
+## Benchmarks
+
+Run the pure-PHP lexer/parser benchmarks:
+
+```bash
+php packages/mysql-on-sqlite/tests/tools/run-lexer-benchmark.php --json
+php packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php --json
+```
+
+Run the same parser benchmark with the native extension loaded:
+
+```bash
+php -d extension=/absolute/path/to/libwp_mysql_parser.so packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php --json
+```
+
+Compare the pure-PHP lexer with the native extension lexer in one process:
+
+```bash
+php -d extension=/absolute/path/to/libwp_mysql_parser.so packages/mysql-on-sqlite/tests/tools/run-native-extension-benchmark.php
+php -d extension=/absolute/path/to/libwp_mysql_parser.so packages/mysql-on-sqlite/tests/tools/run-native-extension-benchmark.php --json
+```
+
+The GitHub Pages demo reads published benchmark data from:
+
+<https://wordpress.github.io/sqlite-database-integration/native-extension/benchmark.json>
+
+Latest local measurement (Apple Silicon macOS, PHP 8.4.5 CLI, 2026-05-26):
+
+| Benchmark | Implementation | Queries | QPS | Speedup |
+| --- | --- | ---: | ---: | ---: |
+| MySQL lexer | Pure PHP | 69,577 | 71,553 | — |
+| MySQL lexer | Native extension | 69,577 | 343,124 | 4.80x |
+| MySQL parser | Pure PHP | 69,577 | 7,015 | — |
+| MySQL parser | Native extension | 69,577 | 108,354 | 15.45x |
+
+That file should be updated whenever a new extension build or benchmark environment is published.
 
 ## PHP.wasm side-module build
 
-The experimental PHP.wasm side-module build lives in `wasm-spike/` and is
-verified in CI for PHP `8.0` through `8.5`.
+The experimental PHP.wasm side-module build lives in `wasm-spike/` and is verified in CI for PHP `8.0` through `8.5`.
 
-PHP `7.4` is not supported by this Rust WASM path. The build uses
-`ext-php-rs` `0.15`, which depends on PHP 8 Zend APIs and does not compile
-against PHP `7.4` headers.
+PHP `7.4` is not supported by this Rust WASM path. The build uses `ext-php-rs` `0.15`, which depends on PHP 8 Zend APIs and does not compile against PHP `7.4` headers.


### PR DESCRIPTION
## What changed

Reorganizes the root README so Quick start stays first and the optional Native MySQL Parser Extension is discoverable without taking over the landing flow. The README links to the GitHub Pages landing page with the published WASM release list, manifest links, “Run in Playground” buttons, and native extension details.

Also expands `packages/php-ext-wp-mysql-parser/README.md` with local build/load instructions, WASM artifact details, checksum verification steps, and benchmark commands. The benchmark scripts now run cleanly on PHP 8.4+, can emit JSON, report exact processed counts, and the parser benchmark goes through the integration loader so `php -d extension=...` measures the native parser path instead of accidentally staying on the pure-PHP classes.

## Why

The native extension and WASM artifacts were hard to discover. This keeps the normal README quick start prominent while giving users a clear path to optional native-extension docs, Playground links, and reproducible benchmark commands.

## Self-review fixes

- Fixed benchmark query counts to use an explicit processed counter instead of loop-index arithmetic.
- Fixed `run-parser-benchmark.php` to include the first query and to load through `src/load.php`, matching runtime native-vs-PHP class selection.
- Tightened docs so build commands do not leave readers in the package directory before repository-root verification commands.
- Added checksum verification commands and refreshed benchmark numbers, including native parser results.

## Related Pages work

- GitHub Pages native-extension demo: #408 (merged)
- GitHub Pages release list + Playground CLI instructions: #409 (merged)
- GitHub Pages benchmark refresh: #410 (merged)
- Published page: https://wordpress.github.io/sqlite-database-integration/

## Validation

- `composer validate --no-check-all`
- `php -l packages/mysql-on-sqlite/tests/tools/run-lexer-benchmark.php`
- `php -l packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php`
- `php -l packages/mysql-on-sqlite/tests/tools/run-native-extension-benchmark.php`
- `php packages/mysql-on-sqlite/tests/tools/run-lexer-benchmark.php --json --limit=100`
- `php packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php --json --limit=100`
- `php packages/mysql-on-sqlite/tests/tools/run-native-extension-benchmark.php --json --limit=100`
- `php -d extension=/path/to/libwp_mysql_parser.dylib packages/mysql-on-sqlite/tests/tools/run-native-extension-benchmark.php --json --limit=100`
- `php -d extension=/path/to/libwp_mysql_parser.dylib packages/mysql-on-sqlite/tests/tools/run-parser-benchmark.php --json --limit=100`
- Full benchmark rerun for published numbers: lexer PHP, parser PHP, native lexer, native parser.
- `npx @wp-playground/cli@latest run-blueprint --php=8.4 --php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json --blueprint=https://wordpress.github.io/sqlite-database-integration/native-extension/blueprint.json --verbosity=quiet`

Note: `composer run check-cs` could not run in this workspace because `vendor/bin/phpcs` is not installed locally; CI runs it with dependencies installed.
