### PR TITLE
Fix native extension Playground links

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,51 +37,51 @@ th { background: #f0f0f1; }
 <p class="badge">WordPress + SQLite</p>
 <h1>SQLite Database Integration</h1>
 <p>Run WordPress on SQLite. If you want to try the optional native MySQL parser extension, use a published WASM build below or open the ready-made Playground demo.</p>
-<a class="button" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Test latest in Playground</a>
+<a class="button" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Test latest in Playground</a>
 <a class="button secondary" href="native-extension/">Native extension details</a>
 </section>
 
 <section class="grid">
 <div class="card"><h2>Quick start</h2><p>Use the plugin to run WordPress with SQLite instead of MySQL. The native parser extension is optional and the pure-PHP parser remains the fallback.</p></div>
-<div class="card"><h2>WASM builds</h2><p>Each release below has a manifest URL for WordPress Playground and checksums for the published side modules.</p></div>
+<div class="card"><h2>WASM builds</h2><p>Each release below has a manifest URL for WordPress Playground.</p></div>
 <div class="card"><h2>Benchmarks</h2><p>The demo verifies <code>extension_loaded('wp_mysql_parser')</code>, runs a browser benchmark, and links to the latest published benchmark data.</p></div>
 </section>
 
 <h2>Published WASM extension releases</h2>
 <p>Pick a release, inspect its manifest, or launch WordPress Playground with that exact <code>wp_mysql_parser</code> WASM extension.</p>
 <table>
-<thead><tr><th>Release</th><th>PHP builds</th><th>Links</th><th>Try it</th></tr></thead>
+<thead><tr><th>Release</th><th>PHP builds</th><th>Manifest</th><th>Try it</th></tr></thead>
 <tbody>
 <tr>
 <td><strong>latest</strong><br><span class="muted">Current pointer to b31fc53ea599</span></td>
 <td><code>8.5, 8.4, 8.3, 8.2, 8.1, 8.0</code></td>
-<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json">manifest.json</a><br><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/SHA256SUMS">SHA256SUMS</a></td>
-<td><a class="button small" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
+<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json">manifest.json</a></td>
+<td><a class="button small" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
 </tr>
 <tr>
 <td><strong>b31fc53ea599</strong><br><span class="muted">Pinned build b31fc53ea599</span></td>
 <td><code>8.5, 8.4, 8.3, 8.2, 8.1, 8.0</code></td>
-<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/b31fc53ea599d1a2211b75f4a3486b39e63ce01f/manifest.json">manifest.json</a><br><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/b31fc53ea599d1a2211b75f4a3486b39e63ce01f/SHA256SUMS">SHA256SUMS</a></td>
-<td><a class="button small" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Fb31fc53ea599d1a2211b75f4a3486b39e63ce01f%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
+<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/b31fc53ea599d1a2211b75f4a3486b39e63ce01f/manifest.json">manifest.json</a></td>
+<td><a class="button small" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Fb31fc53ea599d1a2211b75f4a3486b39e63ce01f%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
 </tr>
 <tr>
 <td><strong>4f3aab1a5b03</strong><br><span class="muted">Pinned build 4f3aab1a5b03</span></td>
 <td><code>8.5, 8.4, 8.3, 8.2, 8.1, 8.0</code></td>
-<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/4f3aab1a5b03b00f42d7b5141ac6a11f9c752256/manifest.json">manifest.json</a><br><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/4f3aab1a5b03b00f42d7b5141ac6a11f9c752256/SHA256SUMS">SHA256SUMS</a></td>
-<td><a class="button small" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2F4f3aab1a5b03b00f42d7b5141ac6a11f9c752256%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
+<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/4f3aab1a5b03b00f42d7b5141ac6a11f9c752256/manifest.json">manifest.json</a></td>
+<td><a class="button small" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2F4f3aab1a5b03b00f42d7b5141ac6a11f9c752256%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
 </tr>
 </tbody>
 </table>
 
 <h2>Run with Playground CLI</h2>
-<p>The browser links use Playground's <code>php-extension</code> query parameter. Locally, pass the same manifest URL to <code>@wp-playground/cli</code> with <code>--php-extension</code> before PHP starts.</p>
+<p>The browser links use Playground's <code>php-extension</code> query parameter and are pinned to PHP 8.3, which currently loads this extension reliably in the browser runtime. Locally, pass the same manifest URL to <code>@wp-playground/cli</code> with <code>--php-extension</code> before PHP starts.</p>
 <pre><code>npx @wp-playground/cli@latest server \
-  --php=8.4 \
+  --php=8.3 \
   --php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
   --blueprint=https://wordpress.github.io/sqlite-database-integration/native-extension/blueprint.json</code></pre>
 <p>For CI or a headless smoke test, run the Blueprint without starting a server:</p>
 <pre><code>npx @wp-playground/cli@latest run-blueprint \
-  --php=8.4 \
+  --php=8.3 \
   --php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
   --blueprint=https://wordpress.github.io/sqlite-database-integration/native-extension/blueprint.json</code></pre>
 <p>Replace the manifest URL with any pinned release from the table to test that exact build.</p>

--- a/native-extension/blueprint.json
+++ b/native-extension/blueprint.json
@@ -7,7 +7,7 @@
     "author": "WordPress"
   },
   "preferredVersions": {
-    "php": "8.4",
+    "php": "8.3",
     "wp": "latest"
   },
   "features": {

--- a/native-extension/index.html
+++ b/native-extension/index.html
@@ -37,7 +37,7 @@ th { background: #f0f0f1; }
 <p class="badge">wp_mysql_parser</p>
 <h1>Native MySQL Parser Extension</h1>
 <p>Load a published WASM build in WordPress Playground, verify the extension, and run a lightweight parser benchmark without installing anything locally.</p>
-<a class="button" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Test latest in Playground</a>
+<a class="button" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Test latest in Playground</a>
 <a class="button secondary" href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json">View latest manifest</a>
 <a class="button secondary" href="../">All releases</a>
 </section>
@@ -51,38 +51,38 @@ th { background: #f0f0f1; }
 
 <h2>Published WASM extension releases</h2>
 <table>
-<thead><tr><th>Release</th><th>PHP builds</th><th>Links</th><th>Try it</th></tr></thead>
+<thead><tr><th>Release</th><th>PHP builds</th><th>Manifest</th><th>Try it</th></tr></thead>
 <tbody>
 <tr>
 <td><strong>latest</strong><br><span class="muted">Current pointer to b31fc53ea599</span></td>
 <td><code>8.5, 8.4, 8.3, 8.2, 8.1, 8.0</code></td>
-<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json">manifest.json</a><br><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/SHA256SUMS">SHA256SUMS</a></td>
-<td><a class="button small" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
+<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json">manifest.json</a></td>
+<td><a class="button small" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
 </tr>
 <tr>
 <td><strong>b31fc53ea599</strong><br><span class="muted">Pinned build b31fc53ea599</span></td>
 <td><code>8.5, 8.4, 8.3, 8.2, 8.1, 8.0</code></td>
-<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/b31fc53ea599d1a2211b75f4a3486b39e63ce01f/manifest.json">manifest.json</a><br><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/b31fc53ea599d1a2211b75f4a3486b39e63ce01f/SHA256SUMS">SHA256SUMS</a></td>
-<td><a class="button small" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Fb31fc53ea599d1a2211b75f4a3486b39e63ce01f%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
+<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/b31fc53ea599d1a2211b75f4a3486b39e63ce01f/manifest.json">manifest.json</a></td>
+<td><a class="button small" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Fb31fc53ea599d1a2211b75f4a3486b39e63ce01f%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
 </tr>
 <tr>
 <td><strong>4f3aab1a5b03</strong><br><span class="muted">Pinned build 4f3aab1a5b03</span></td>
 <td><code>8.5, 8.4, 8.3, 8.2, 8.1, 8.0</code></td>
-<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/4f3aab1a5b03b00f42d7b5141ac6a11f9c752256/manifest.json">manifest.json</a><br><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/4f3aab1a5b03b00f42d7b5141ac6a11f9c752256/SHA256SUMS">SHA256SUMS</a></td>
-<td><a class="button small" href="https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2F4f3aab1a5b03b00f42d7b5141ac6a11f9c752256%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
+<td><a href="https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/4f3aab1a5b03b00f42d7b5141ac6a11f9c752256/manifest.json">manifest.json</a></td>
+<td><a class="button small" href="https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2F4f3aab1a5b03b00f42d7b5141ac6a11f9c752256%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json">Run in Playground</a></td>
 </tr>
 </tbody>
 </table>
 
 <h2>Run with Playground CLI</h2>
-<p>Use the same manifest URL as the browser demo. The important part is <code>--php-extension</code>; the extension must be loaded before PHP starts.</p>
+<p>Use the same manifest URL as the browser demo. The browser demo is pinned to PHP 8.3, which currently loads this extension reliably in Playground's browser runtime. The important part is <code>--php-extension</code>; the extension must be loaded before PHP starts.</p>
 <pre><code>npx @wp-playground/cli@latest server \
-  --php=8.4 \
+  --php=8.3 \
   --php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
   --blueprint=https://wordpress.github.io/sqlite-database-integration/native-extension/blueprint.json</code></pre>
 <p>Headless version:</p>
 <pre><code>npx @wp-playground/cli@latest run-blueprint \
-  --php=8.4 \
+  --php=8.3 \
   --php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json \
   --blueprint=https://wordpress.github.io/sqlite-database-integration/native-extension/blueprint.json</code></pre>
 


### PR DESCRIPTION
## Summary
- remove SHA256SUMS links from the GitHub Pages release tables
- pin browser Playground links and the demo Blueprint to PHP 8.3, which currently loads the native extension in the browser runtime
- update Playground CLI examples to match the browser-safe PHP version

## Why
The PHP 8.4 browser Playground link currently crashes while loading the `wp_mysql_parser` extension with `TypeError: n is not a function`. The same manifest works with PHP 8.3 in the browser and the extension still works via Playground CLI.

## Testing
- Opened the PHP 8.4 browser link and reproduced the crash
- Opened the PHP 8.3 browser link and verified the demo reports `extension_loaded('wp_mysql_parser')`: yes
- `npx @wp-playground/cli@latest run-blueprint --php=8.3 --php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json --blueprint=.context/gh-pages-update/native-extension/blueprint.json --verbosity=quiet`
