### PR TITLE
Fix native extension Playground docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ composer run wp-test-clean              # Clean up WordPress environment (Docker
 The default code path is pure PHP. For environments that can load PHP extensions, the optional `wp_mysql_parser` extension accelerates the MySQL lexer/parser used by the SQLite driver.
 
 - [Published WASM release list, manifest links, Playground links, and native extension overview](https://wordpress.github.io/sqlite-database-integration/)
-- [Build, verification, and benchmark docs](packages/php-ext-wp-mysql-parser/README.md)
+- [Build, load, and benchmark docs](packages/php-ext-wp-mysql-parser/README.md)
 
 Latest local measurement (Apple Silicon macOS, PHP 8.4.5 CLI, 2026-05-26): the native lexer path processed the MySQL test corpus at ~343k QPS versus ~72k QPS for pure PHP (~4.80x), and the native parser path processed it at ~108k QPS versus ~7k QPS for pure PHP (~15.45x).
 

--- a/packages/php-ext-wp-mysql-parser/README.md
+++ b/packages/php-ext-wp-mysql-parser/README.md
@@ -6,19 +6,18 @@ When the extension is loaded before `packages/mysql-on-sqlite/src/load.php`, it 
 
 ## Published WASM build for Playground
 
-Published WASM builds are listed on this repository's GitHub Pages site, with manifest links, checksums, and a “Run in Playground” link for each release:
+Published WASM builds are listed on this repository's GitHub Pages site, with manifest links and a “Run in Playground” link for each release:
 
 <https://wordpress.github.io/sqlite-database-integration/>
 
 The current build is also available directly:
 
 - Manifest: <https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json>
-- Checksums: <https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/SHA256SUMS>
 - Supported PHP versions: 8.0, 8.1, 8.2, 8.3, 8.4, and 8.5.
 
-Use this Playground URL to load the extension and open the demo/benchmark page:
+Use this Playground URL to load the extension and open the demo/benchmark page. The browser demo is pinned to PHP 8.3 because the current Playground browser runtime crashes while loading this extension on PHP 8.4.
 
-<https://playground.wordpress.net/?php=8.4&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json>
+<https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json>
 
 ## Build the native extension locally
 
@@ -56,22 +55,6 @@ From the repository root, load it for local verification or benchmarks:
 ```bash
 php -d extension=/absolute/path/to/libwp_mysql_parser.so -m | grep wp_mysql_parser
 php -d extension=/absolute/path/to/libwp_mysql_parser.so packages/mysql-on-sqlite/tests/tools/verify-native-parser-extension.php
-```
-
-## Verify the WASM artifacts
-
-Download the manifest and checksums:
-
-```bash
-curl -O https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json
-curl -O https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/SHA256SUMS
-```
-
-Each `.so` listed in the manifest is published next to the manifest and can be checked against `SHA256SUMS`:
-
-```bash
-curl -O https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/wp_mysql_parser-php8.4-jspi.so
-shasum -a 256 -c SHA256SUMS --ignore-missing
 ```
 
 ## Benchmarks


### PR DESCRIPTION
## Summary
- remove SHA/checksum references from the native extension docs
- switch the documented browser Playground link to PHP 8.3
- note why the browser demo is pinned to PHP 8.3 for now

## Why
The PHP 8.4 browser Playground URL currently crashes while loading the published `wp_mysql_parser` extension (`TypeError: n is not a function`). PHP 8.3 loads the same manifest successfully in the browser. The CLI path still works with `--php-extension`.

## Testing
- `composer validate --no-check-all`
- Opened the PHP 8.4 browser URL and reproduced the crash
- Opened the PHP 8.3 browser URL and verified the demo reports `extension_loaded('wp_mysql_parser')`: yes
- `npx @wp-playground/cli@latest run-blueprint --php=8.3 --php-extension=https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json --blueprint=https://wordpress.github.io/sqlite-database-integration/native-extension/blueprint.json --verbosity=quiet`
