### PR TITLE
Check Playground web runtime compatibility

### DIFF
--- a/.github/workflows/publish-wasm-extension-artifact.yml
+++ b/.github/workflows/publish-wasm-extension-artifact.yml
@@ -109,6 +109,12 @@ jobs:
             /packages/php-wasm/node-builds/8-3/
             /packages/php-wasm/node-builds/8-4/
             /packages/php-wasm/node-builds/8-5/
+            /packages/php-wasm/web-builds/8-0/
+            /packages/php-wasm/web-builds/8-1/
+            /packages/php-wasm/web-builds/8-2/
+            /packages/php-wasm/web-builds/8-3/
+            /packages/php-wasm/web-builds/8-4/
+            /packages/php-wasm/web-builds/8-5/
             /packages/php-wasm/progress/
             /packages/php-wasm/scopes/
             /packages/php-wasm/stream-compression/
@@ -150,6 +156,14 @@ jobs:
         run: |
           test -f dist/wp_mysql_parser-php${{ matrix.php }}-jspi.so
           ls -lh dist/wp_mysql_parser-php${{ matrix.php }}-jspi.so
+
+      - name: Check Playground browser runtime compatibility
+        working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
+        env:
+          PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
+          PHP_VERSION: ${{ matrix.php }}
+          ASYNC_MODE: jspi
+        run: node check-playground-web-compat.mjs
 
       - name: Upload side module
         uses: actions/upload-artifact@v4

--- a/.github/workflows/wasm-spike.yml
+++ b/.github/workflows/wasm-spike.yml
@@ -106,6 +106,12 @@ jobs:
             /packages/php-wasm/node-builds/8-3/
             /packages/php-wasm/node-builds/8-4/
             /packages/php-wasm/node-builds/8-5/
+            /packages/php-wasm/web-builds/8-0/
+            /packages/php-wasm/web-builds/8-1/
+            /packages/php-wasm/web-builds/8-2/
+            /packages/php-wasm/web-builds/8-3/
+            /packages/php-wasm/web-builds/8-4/
+            /packages/php-wasm/web-builds/8-5/
             /packages/php-wasm/progress/
             /packages/php-wasm/scopes/
             /packages/php-wasm/stream-compression/
@@ -160,6 +166,14 @@ jobs:
           test "$SOURCE_PATH" = "$EXPECTED"
           test -f "dist/$SOURCE_PATH"
           node -e "const artifact = require('./dist/manifest.json').artifacts[0]; if ('file' in artifact || 'sha256' in artifact) { throw new Error('manifest uses retired artifact fields'); }"
+
+      - name: Check Playground browser runtime compatibility
+        working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike
+        env:
+          PLAYGROUND_REPO: ${{ github.workspace }}/wordpress-playground
+          PHP_VERSION: ${{ matrix.php }}
+          ASYNC_MODE: ${{ matrix.async-mode }}
+        run: node check-playground-web-compat.mjs
 
       - name: Load the extension in Playground and parse a query
         working-directory: sqlite-database-integration/packages/php-ext-wp-mysql-parser/wasm-spike

--- a/packages/php-ext-wp-mysql-parser/README.md
+++ b/packages/php-ext-wp-mysql-parser/README.md
@@ -15,9 +15,12 @@ The current build is also available directly:
 - Manifest: <https://wordpress.github.io/sqlite-database-integration/wp_mysql_parser-wasm-extension/latest/manifest.json>
 - Supported PHP versions: 8.0, 8.1, 8.2, 8.3, 8.4, and 8.5.
 
-Use this Playground URL to load the extension and open the demo/benchmark page. The browser demo is pinned to PHP 8.3 because the current Playground browser runtime crashes while loading this extension on PHP 8.4.
+Use this Playground URL to load the extension and open the demo/benchmark page.
+The published manifest contains PHP 8.0 through 8.5 side modules, and CI checks
+that every side module imports only symbols exported by the matching Playground
+browser runtime.
 
-<https://playground.wordpress.net/?php=8.3&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fnative-extension%2Fblueprint.json>
+<https://playground.wordpress.net/?php=8.5&php-extension=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fwp_mysql_parser-wasm-extension%2Flatest%2Fmanifest.json&blueprint-url=https%3A%2F%2Fwordpress.github.io%2Fsqlite-database-integration%2Fblueprint.json>
 
 ## Build the native extension locally
 

--- a/packages/php-ext-wp-mysql-parser/wasm-spike/check-playground-web-compat.mjs
+++ b/packages/php-ext-wp-mysql-parser/wasm-spike/check-playground-web-compat.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SPIKE_DIR = resolve(fileURLToPath(new URL('.', import.meta.url)));
+const PHP_VERSION = process.env.PHP_VERSION || '8.4';
+const ASYNC_MODE = process.env.ASYNC_MODE || 'jspi';
+const EXTENSION_NAME = process.env.EXTENSION_NAME || 'wp_mysql_parser';
+const SIDE_MODULE = resolve(
+  process.env.SIDE_MODULE ||
+    `${SPIKE_DIR}/dist/${EXTENSION_NAME}-php${PHP_VERSION}-${ASYNC_MODE}.so`
+);
+const PLAYGROUND_REPO = resolve(
+  process.env.PLAYGROUND_REPO ||
+    `${SPIKE_DIR}/../../../../wordpress-playground-spike`
+);
+const EXPECTED_MISSING = new Set(
+  (process.env.PLAYGROUND_WEB_EXPECTED_MISSING_SYMBOLS || '')
+    .split(/[\s,]+/)
+    .filter(Boolean)
+);
+
+function findWasmFile(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = findWasmFile(path);
+      if (nested) {
+        return nested;
+      }
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith('.wasm')) {
+      return path;
+    }
+  }
+  return null;
+}
+
+function loadWasmModule(path) {
+  if (!existsSync(path)) {
+    console.error(`[web-compat] Missing ${path}`);
+    process.exit(2);
+  }
+  return new WebAssembly.Module(readFileSync(path));
+}
+
+const phpDir = PHP_VERSION.replace('.', '-');
+const webBuildDir = resolve(
+  PLAYGROUND_REPO,
+  `packages/php-wasm/web-builds/${phpDir}/${ASYNC_MODE}`
+);
+const webRuntime = findWasmFile(webBuildDir);
+if (!webRuntime) {
+  console.error(`[web-compat] Could not find a PHP.wasm file under ${webBuildDir}`);
+  process.exit(2);
+}
+
+const sideImports = WebAssembly.Module.imports(loadWasmModule(SIDE_MODULE));
+const importedFunctions = sideImports
+  .filter((entry) => entry.module === 'env' && entry.kind === 'function')
+  .map((entry) => entry.name)
+  .sort();
+const runtimeExports = new Map(
+  WebAssembly.Module.exports(loadWasmModule(webRuntime)).map((entry) => [
+    entry.name,
+    entry.kind,
+  ])
+);
+const missing = importedFunctions.filter(
+  (name) => runtimeExports.get(name) !== 'function'
+);
+const unexpectedMissing = missing.filter((name) => !EXPECTED_MISSING.has(name));
+const staleExpectedMissing = [...EXPECTED_MISSING].filter(
+  (name) => !missing.includes(name)
+);
+
+console.log(`[web-compat] PHP ${PHP_VERSION} side module: ${SIDE_MODULE}`);
+console.log(`[web-compat] PHP ${PHP_VERSION} web runtime: ${webRuntime}`);
+
+if (unexpectedMissing.length > 0 || staleExpectedMissing.length > 0) {
+  if (unexpectedMissing.length > 0) {
+    console.error(
+      `[web-compat] Missing browser runtime exports: ${unexpectedMissing.join(', ')}`
+    );
+  }
+  if (staleExpectedMissing.length > 0) {
+    console.error(
+      `[web-compat] Expected missing exports are now available: ${staleExpectedMissing.join(', ')}`
+    );
+    console.error(
+      '[web-compat] Update the browser demo PHP pin and remove the stale allowlist.'
+    );
+  }
+  process.exit(1);
+}
+
+if (missing.length > 0) {
+  console.log(
+    `[web-compat] Known browser runtime gap confirmed: ${missing.join(', ')}`
+  );
+} else {
+  console.log('[web-compat] Browser runtime exports all imported functions.');
+}


### PR DESCRIPTION
## What?

Adds a browser-runtime compatibility check for the `wp_mysql_parser` WASM side modules and wires it into both WASM workflows:

- `wasm-spike.yml`
- `publish-wasm-extension-artifact.yml`

The check compares each side module's `env` function imports against the matching Playground web PHP.wasm runtime exports. It runs for PHP 8.0 through 8.5 so the published manifest cannot claim browser support for a PHP version that will crash during extension startup.

Also updates the native extension README/demo URL to use the live `blueprint.json` location and documents PHP 8.0-8.5 browser-runtime coverage instead of the temporary PHP 8.3 pin.

## Why?

The previous Node-based smoke test was insufficient: PHP 8.4 loaded in the Node/CLI runtime but crashed in the browser runtime because the web runtime did not export Zend symbols imported by the extension side module.

This PR makes that class of failure visible in CI before publishing a WASM manifest.

## Dependency

This depends on WordPress/wordpress-playground#3690 and updated Playground web PHP.wasm artifacts. Current Playground web builds are known to miss required exports for PHP 8.0, 8.1, 8.4, and 8.5; the new CI check is expected to pass once those runtime exports ship.

## Testing

- `node --check packages/php-ext-wp-mysql-parser/wasm-spike/check-playground-web-compat.mjs`
- `git diff --check`
- Verified locally with the Playground checkout:
  - PHP 8.3 currently passes.
  - PHP 8.4 currently fails with missing `zend_declare_class_constant_ex` and `zend_register_internal_class_ex`, matching the browser crash root cause.

## Note

Replacement for #417, which was accidentally opened and merged against `develop` instead of `trunk`.
