### PR TITLE
Accelerate MySQL-on-SQLite query execution with translation templates

### DIFF
--- a/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php
+++ b/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php
@@ -15,6 +15,7 @@ class WP_MySQL_Parser extends WP_Parser {
 	 */
 	public function reset_tokens( array $tokens ): void {
 		$this->tokens      = $tokens;
+		$this->token_count = count( $tokens );
 		$this->position    = 0;
 		$this->current_ast = null;
 	}

--- a/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-token.php
+++ b/packages/mysql-on-sqlite/src/mysql/class-wp-mysql-token.php
@@ -15,6 +15,17 @@ class WP_MySQL_Token extends WP_Parser_Token {
 	private $sql_mode_no_backslash_escapes_enabled;
 
 	/**
+	 * Memoized result of the "get_value()" method.
+	 *
+	 * Computing the token value requires unquoting and unescaping the token
+	 * bytes, which is expensive when done repeatedly. Since the token data
+	 * is immutable, the value is computed only once and then cached here.
+	 *
+	 * @var string|null
+	 */
+	private $value;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int    $id                                    Token type.
@@ -30,11 +41,12 @@ class WP_MySQL_Token extends WP_Parser_Token {
 		string $input,
 		bool $sql_mode_no_backslash_escapes_enabled
 	) {
-		$this->id     = $id;
-		$this->start  = $start;
-		$this->length = $length;
-		$this->input  = $input;
-
+		// All properties are initialized directly, avoiding an extra parent
+		// constructor call on the hot tokenization path.
+		$this->id                                    = $id;
+		$this->start                                 = $start;
+		$this->length                                = $length;
+		$this->input                                 = $input;
 		$this->sql_mode_no_backslash_escapes_enabled = $sql_mode_no_backslash_escapes_enabled;
 	}
 
@@ -61,6 +73,9 @@ class WP_MySQL_Token extends WP_Parser_Token {
 	 * @return string The token value.
 	 */
 	public function get_value(): string {
+		if ( null !== $this->value ) {
+			return $this->value;
+		}
 		$value = $this->get_bytes();
 		if (
 			WP_MySQL_Lexer::SINGLE_QUOTED_TEXT === $this->id
@@ -77,7 +92,8 @@ class WP_MySQL_Token extends WP_Parser_Token {
 			 * their literal values.
 			 */
 			if ( $this->sql_mode_no_backslash_escapes_enabled ) {
-				return str_replace( $quote . $quote, $quote, $value );
+				$this->value = str_replace( $quote . $quote, $quote, $value );
+				return $this->value;
 			}
 
 			/**
@@ -169,6 +185,7 @@ class WP_MySQL_Token extends WP_Parser_Token {
 			$preg_quoted_backslash = preg_quote( $backslash );
 			$value                 = preg_replace( "/$preg_quoted_backslash(.)/u", '$1', $value );
 		}
+		$this->value = $value;
 		return $value;
 	}
 

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
@@ -28,8 +28,21 @@ class WP_Parser_Grammar {
 	 */
 	public $rules;
 	public $rule_names;
+	public $rule_ids;
 	public $fragment_ids;
 	public $lookahead_is_match_possible = array();
+
+	/**
+	 * Per-branch FIRST sets: rule_id => branch_index => array<token_id, true>.
+	 *
+	 * An entry exists only when the branch's FIRST set is fully computable and
+	 * does not contain the empty "ε" rule. A missing entry means the branch
+	 * must always be attempted.
+	 *
+	 * @var array
+	 */
+	public $branch_first = array();
+
 	public $lowest_non_terminal_id;
 	public $highest_terminal_id;
 	public $native_grammar;
@@ -43,7 +56,7 @@ class WP_Parser_Grammar {
 	}
 
 	public function get_rule_id( $rule_name ) {
-		return array_search( $rule_name, $this->rule_names, true );
+		return $this->rule_ids[ $rule_name ] ?? false;
 	}
 
 	/**
@@ -79,6 +92,7 @@ class WP_Parser_Grammar {
 				$this->fragment_ids[ $rule_index + $grammar['rules_offset'] ] = true;
 			}
 		}
+		$this->rule_ids = array_flip( $this->rule_names );
 
 		$this->rules = array();
 		foreach ( $grammar['grammar'] as $rule_index => $branches ) {
@@ -133,6 +147,43 @@ class WP_Parser_Grammar {
 				}
 				if ( $first_symbol_can_be_expanded_to_all_terminals ) {
 					$this->lookahead_is_match_possible[ $rule_id ] = $rule_lookup;
+				}
+			}
+		}
+
+		/**
+		 * Compute per-branch FIRST sets.
+		 *
+		 * For each branch, compute the set of tokens its first symbol can start
+		 * with. A branch with a known, epsilon-free FIRST set can be skipped
+		 * when the current token is not in the set. Branches whose first symbol
+		 * can derive the empty "ε" rule, or whose FIRST set is not computable,
+		 * get no entry and are always attempted.
+		 *
+		 * While the rule-level lookahead table above answers "can this rule
+		 * match the current token at all?", this table answers the finer
+		 * question "which branches of this rule are worth trying?", letting
+		 * the parser skip non-viable branches without recursing into them.
+		 */
+		// Branches starting with the same terminal share a single FIRST set
+		// array to keep the memory footprint of the table low.
+		$terminal_first_sets = array();
+		foreach ( $grammar['grammar'] as $rule_index => $branches ) {
+			$rule_id = $rule_index + $grammar['rules_offset'];
+			foreach ( $branches as $branch_index => $branch ) {
+				$first_symbol = $branch[0];
+				if ( $first_symbol < $this->lowest_non_terminal_id ) {
+					if ( self::EMPTY_RULE_ID !== $first_symbol ) {
+						if ( ! isset( $terminal_first_sets[ $first_symbol ] ) ) {
+							$terminal_first_sets[ $first_symbol ] = array( $first_symbol => true );
+						}
+						$this->branch_first[ $rule_id ][ $branch_index ] = $terminal_first_sets[ $first_symbol ];
+					}
+				} elseif (
+					isset( $this->lookahead_is_match_possible[ $first_symbol ] ) &&
+					! isset( $this->lookahead_is_match_possible[ $first_symbol ][ self::EMPTY_RULE_ID ] )
+				) {
+					$this->branch_first[ $rule_id ][ $branch_index ] = $this->lookahead_is_match_possible[ $first_symbol ];
 				}
 			}
 		}

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php
@@ -100,6 +100,12 @@ class WP_Parser_Grammar {
 			$this->rules[ $rule_id ] = $branches;
 		}
 
+		/*
+		 * Inline single-branch fragments before computing the lookup tables
+		 * below, so that the tables reflect the compressed grammar.
+		 */
+		$this->inline_single_branch_fragments();
+
 		/**
 		 * Compute a rule => [token => true] lookup table for each rule
 		 * that starts with a terminal OR with another rule that already
@@ -121,8 +127,7 @@ class WP_Parser_Grammar {
 		 */
 		// 5 iterations seem to give us all the speed gains we can get from this.
 		for ( $i = 0; $i < 5; $i++ ) {
-			foreach ( $grammar['grammar'] as $rule_index => $branches ) {
-				$rule_id = $rule_index + $grammar['rules_offset'];
+			foreach ( $this->rules as $rule_id => $branches ) {
 				if ( isset( $this->lookahead_is_match_possible[ $rule_id ] ) ) {
 					continue;
 				}
@@ -168,8 +173,7 @@ class WP_Parser_Grammar {
 		// Branches starting with the same terminal share a single FIRST set
 		// array to keep the memory footprint of the table low.
 		$terminal_first_sets = array();
-		foreach ( $grammar['grammar'] as $rule_index => $branches ) {
-			$rule_id = $rule_index + $grammar['rules_offset'];
+		foreach ( $this->rules as $rule_id => $branches ) {
 			foreach ( $branches as $branch_index => $branch ) {
 				$first_symbol = $branch[0];
 				if ( $first_symbol < $this->lowest_non_terminal_id ) {
@@ -187,5 +191,96 @@ class WP_Parser_Grammar {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Inline single-branch fragment rules into the branches that reference them.
+	 *
+	 * Fragment rules (names prefixed with "%") never appear in the final parse
+	 * tree — the parser splices their children directly into the parent node.
+	 * A reference to a fragment with a single branch is therefore pure call
+	 * overhead: the parser recurses into the fragment only to match its one
+	 * branch and splice the matched children back into the parent. Replacing
+	 * the reference with the fragment's symbol sequence ahead of time produces
+	 * a byte-identical parse tree while saving a recursive call per reference.
+	 *
+	 * Multi-branch fragments are left intact, as they encode alternation.
+	 * Fragment references that are part of a recursion cycle through
+	 * single-branch fragments are also left intact, which guarantees that
+	 * the expansion terminates.
+	 */
+	private function inline_single_branch_fragments() {
+		$inlinable = array();
+		foreach ( $this->fragment_ids as $rule_id => $unused ) {
+			if ( isset( $this->rules[ $rule_id ] ) && 1 === count( $this->rules[ $rule_id ] ) ) {
+				$inlinable[ $rule_id ] = true;
+			}
+		}
+		if ( ! $inlinable ) {
+			return;
+		}
+
+		/*
+		 * Fully expand every inlinable fragment first (fragments can reference
+		 * other fragments), so that the splicing pass below is a single pass
+		 * that doesn't depend on the order in which rules are processed.
+		 */
+		$expanded    = array();
+		$in_progress = array();
+		foreach ( $inlinable as $rule_id => $unused ) {
+			$this->expand_fragment( $rule_id, $inlinable, $expanded, $in_progress );
+		}
+
+		foreach ( $this->rules as $rule_id => $branches ) {
+			foreach ( $branches as $branch_index => $branch ) {
+				$new_branch  = array();
+				$has_changes = false;
+				foreach ( $branch as $symbol ) {
+					if ( isset( $expanded[ $symbol ] ) ) {
+						foreach ( $expanded[ $symbol ] as $expanded_symbol ) {
+							$new_branch[] = $expanded_symbol;
+						}
+						$has_changes = true;
+					} else {
+						$new_branch[] = $symbol;
+					}
+				}
+				if ( $has_changes ) {
+					$this->rules[ $rule_id ][ $branch_index ] = $new_branch;
+				}
+			}
+		}
+	}
+
+	/**
+	 * Compute the fully inlined symbol sequence of a single-branch fragment.
+	 *
+	 * @param int   $rule_id     ID of the fragment rule to expand.
+	 * @param array $inlinable   Set of all single-branch fragment rule IDs.
+	 * @param array $expanded    Memoized expansions, keyed by fragment rule ID.
+	 * @param array $in_progress Fragments on the current expansion path.
+	 *                           A reference to one of these is part of a
+	 *                           recursion cycle and is kept as-is so that
+	 *                           the expansion is guaranteed to terminate.
+	 * @return array The expanded symbol sequence of the fragment's branch.
+	 */
+	private function expand_fragment( $rule_id, $inlinable, &$expanded, &$in_progress ) {
+		if ( isset( $expanded[ $rule_id ] ) ) {
+			return $expanded[ $rule_id ];
+		}
+		$in_progress[ $rule_id ] = true;
+		$result                  = array();
+		foreach ( $this->rules[ $rule_id ][0] as $symbol ) {
+			if ( isset( $inlinable[ $symbol ] ) && ! isset( $in_progress[ $symbol ] ) ) {
+				foreach ( $this->expand_fragment( $symbol, $inlinable, $expanded, $in_progress ) as $expanded_symbol ) {
+					$result[] = $expanded_symbol;
+				}
+			} else {
+				$result[] = $symbol;
+			}
+		}
+		unset( $in_progress[ $rule_id ] );
+		$expanded[ $rule_id ] = $result;
+		return $result;
 	}
 }

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
@@ -17,9 +17,10 @@ class WP_Parser_Node {
 	public $rule_name;
 	protected $children = array();
 
-	public function __construct( $rule_id, $rule_name ) {
+	public function __construct( $rule_id, $rule_name, array $children = array() ) {
 		$this->rule_id   = $rule_id;
 		$this->rule_name = $rule_name;
+		$this->children  = $children;
 	}
 
 	public function append_child( $node ) {

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php
@@ -204,8 +204,7 @@ class WP_Parser_Node {
 	 * @return WP_Parser_Node|null    The first matching descendant node; null when no descendants are found.
 	 */
 	public function get_first_descendant_node( ?string $rule_name = null ): ?WP_Parser_Node {
-		for ( $i = 0; $i < count( $this->children ); $i++ ) {
-			$child = $this->children[ $i ];
+		foreach ( $this->children as $child ) {
 			if ( ! $child instanceof WP_Parser_Node ) {
 				continue;
 			}
@@ -230,8 +229,7 @@ class WP_Parser_Node {
 	 * @return WP_Parser_Token|null The first matching descendant token; null when no descendants are found.
 	 */
 	public function get_first_descendant_token( ?int $token_id = null ): ?WP_Parser_Token {
-		for ( $i = 0; $i < count( $this->children ); $i++ ) {
-			$child = $this->children[ $i ];
+		foreach ( $this->children as $child ) {
 			if ( $child instanceof WP_Parser_Token ) {
 				if ( null === $token_id || $child->id === $token_id ) {
 					return $child;
@@ -303,15 +301,22 @@ class WP_Parser_Node {
 	 */
 	public function get_descendants(): array {
 		$descendants = array();
+		$this->collect_descendants( $descendants );
+		return $descendants;
+	}
+
+	/**
+	 * Collect all descendants of this node into an accumulator array.
+	 *
+	 * @param array<WP_Parser_Node|WP_Parser_Token> $descendants The accumulator array to collect descendants into.
+	 */
+	private function collect_descendants( array &$descendants ): void {
 		foreach ( $this->children as $child ) {
+			$descendants[] = $child;
 			if ( $child instanceof WP_Parser_Node ) {
-				$descendants[] = $child;
-				$descendants   = array_merge( $descendants, $child->get_descendants() );
-			} else {
-				$descendants[] = $child;
+				$child->collect_descendants( $descendants );
 			}
 		}
-		return $descendants;
 	}
 
 	/**
@@ -326,6 +331,17 @@ class WP_Parser_Node {
 	 */
 	public function get_descendant_nodes( ?string $rule_name = null ): array {
 		$nodes = array();
+		$this->collect_descendant_nodes( $rule_name, $nodes );
+		return $nodes;
+	}
+
+	/**
+	 * Collect all matching descendant nodes into an accumulator array.
+	 *
+	 * @param string|null      $rule_name A node rule name to check for; null to match all nodes.
+	 * @param WP_Parser_Node[] $nodes     The accumulator array to collect nodes into.
+	 */
+	private function collect_descendant_nodes( ?string $rule_name, array &$nodes ): void {
 		foreach ( $this->children as $child ) {
 			if ( ! $child instanceof WP_Parser_Node ) {
 				continue;
@@ -333,9 +349,8 @@ class WP_Parser_Node {
 			if ( null === $rule_name || $child->rule_name === $rule_name ) {
 				$nodes[] = $child;
 			}
-			$nodes = array_merge( $nodes, $child->get_descendant_nodes( $rule_name ) );
+			$child->collect_descendant_nodes( $rule_name, $nodes );
 		}
-		return $nodes;
 	}
 
 	/**
@@ -350,16 +365,26 @@ class WP_Parser_Node {
 	 */
 	public function get_descendant_tokens( ?int $token_id = null ): array {
 		$tokens = array();
+		$this->collect_descendant_tokens( $token_id, $tokens );
+		return $tokens;
+	}
+
+	/**
+	 * Collect all matching descendant tokens into an accumulator array.
+	 *
+	 * @param int|null          $token_id A token ID to check for; null to match all tokens.
+	 * @param WP_Parser_Token[] $tokens   The accumulator array to collect tokens into.
+	 */
+	private function collect_descendant_tokens( ?int $token_id, array &$tokens ): void {
 		foreach ( $this->children as $child ) {
 			if ( $child instanceof WP_Parser_Token ) {
 				if ( null === $token_id || $child->id === $token_id ) {
 					$tokens[] = $child;
 				}
 			} else {
-				$tokens = array_merge( $tokens, $child->get_descendant_tokens( $token_id ) );
+				$child->collect_descendant_tokens( $token_id, $tokens );
 			}
 		}
-		return $tokens;
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser-token.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser-token.php
@@ -33,6 +33,10 @@ class WP_Parser_Token {
 	/**
 	 * Input bytes from which the token was parsed.
 	 *
+	 * This property is protected rather than private, so that subclasses can
+	 * initialize all properties directly, avoiding an extra constructor call
+	 * on the hot tokenization path.
+	 *
 	 * @var string
 	 */
 	protected $input;

--- a/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
+++ b/packages/mysql-on-sqlite/src/parser/class-wp-parser.php
@@ -5,6 +5,21 @@
  *
  * This is a dynamic recursive descent parser that can parse LL grammars.
  *
+ * To keep parsing fast, the hot recursive routine applies these techniques:
+ *
+ *   1. Lazy node creation: children are accumulated in a local array, and
+ *      a WP_Parser_Node is allocated only when a branch fully matches.
+ *      Discarded branches therefore allocate no nodes at all. Fragment
+ *      rules return plain children arrays that are spliced into the parent,
+ *      so no intermediate fragment nodes are ever created.
+ *   2. Per-branch FIRST sets: branches that cannot possibly match the
+ *      current token are skipped without recursing into them.
+ *   3. Grammar tables and rule IDs are cached in properties to avoid
+ *      repeated property-chain and rule-name lookups in the hot path.
+ *
+ * The produced parse tree is identical to the one a naive implementation
+ * would produce: WP_Parser_Node instances with token leaves.
+ *
  * @TODO: Add a detailed description and list the properties that a grammar must
  *        satisfy in order to be supported by this parser (e.g., no left recursion).
  */
@@ -13,23 +28,42 @@ class WP_Parser {
 	protected $tokens;
 	protected $position;
 
+	protected $token_count;
+	protected $rules;
+	protected $rule_names;
+	protected $fragment_ids;
+	protected $lookahead;
+	protected $branch_first;
+	protected $highest_terminal_id;
+	protected $query_rule_id;
+	protected $select_statement_rule_id;
+
 	public function __construct( WP_Parser_Grammar $grammar, array $tokens ) {
 		$this->grammar  = $grammar;
 		$this->tokens   = $tokens;
 		$this->position = 0;
+
+		$this->token_count         = count( $tokens );
+		$this->rules               = $grammar->rules;
+		$this->rule_names          = $grammar->rule_names;
+		$this->fragment_ids        = $grammar->fragment_ids;
+		$this->lookahead           = $grammar->lookahead_is_match_possible;
+		$this->branch_first        = $grammar->branch_first;
+		$this->highest_terminal_id = $grammar->highest_terminal_id;
+
+		// @TODO: Make the starting rule lookup non-grammar-specific.
+		$this->query_rule_id            = $grammar->get_rule_id( 'query' );
+		$this->select_statement_rule_id = $grammar->get_rule_id( 'selectStatement' );
 	}
 
 	public function parse() {
-		// @TODO: Make the starting rule lookup non-grammar-specific.
-		$query_rule_id = $this->grammar->get_rule_id( 'query' );
-		$ast           = $this->parse_recursive( $query_rule_id );
+		$ast = $this->parse_recursive( $this->query_rule_id );
 		return false === $ast ? null : $ast;
 	}
 
 	private function parse_recursive( $rule_id ) {
-		$is_terminal = $rule_id <= $this->grammar->highest_terminal_id;
-		if ( $is_terminal ) {
-			if ( $this->position >= count( $this->tokens ) ) {
+		if ( $rule_id <= $this->highest_terminal_id ) {
+			if ( $this->position >= $this->token_count ) {
 				return false;
 			}
 
@@ -44,28 +78,42 @@ class WP_Parser {
 			return false;
 		}
 
-		$branches = $this->grammar->rules[ $rule_id ];
-		if ( ! count( $branches ) ) {
+		$branches = $this->rules[ $rule_id ];
+		if ( ! $branches ) {
 			return false;
 		}
 
-		// Bale out from processing the current branch if none of its rules can
-		// possibly match the current token.
-		if ( isset( $this->grammar->lookahead_is_match_possible[ $rule_id ] ) ) {
-			$token_id = $this->tokens[ $this->position ]->id;
-			if (
-				! isset( $this->grammar->lookahead_is_match_possible[ $rule_id ][ $token_id ] ) &&
-				! isset( $this->grammar->lookahead_is_match_possible[ $rule_id ][ WP_Parser_Grammar::EMPTY_RULE_ID ] )
-			) {
-				return false;
-			}
+		$starting_position = $this->position;
+		$branch_first      = $this->branch_first[ $rule_id ] ?? null;
+		$current_token     = $this->tokens[ $starting_position ] ?? null;
+		$current_token_id  = null !== $current_token ? $current_token->id : -1;
+
+		// Bale out from processing the current rule if none of its branches can
+		// possibly match the current token. When the token stream is exhausted,
+		// the prune is skipped and terminals fail the match instead.
+		if (
+			null !== $current_token &&
+			isset( $this->lookahead[ $rule_id ] ) &&
+			! isset( $this->lookahead[ $rule_id ][ $current_token_id ] ) &&
+			! isset( $this->lookahead[ $rule_id ][ WP_Parser_Grammar::EMPTY_RULE_ID ] )
+		) {
+			return false;
 		}
 
-		$rule_name         = $this->grammar->rule_names[ $rule_id ];
-		$starting_position = $this->position;
-		foreach ( $branches as $branch ) {
+		$branch_matches = false;
+		$children       = array();
+		foreach ( $branches as $branch_index => $branch ) {
+			// Skip branches that cannot possibly match the current token.
+			if (
+				null !== $branch_first &&
+				isset( $branch_first[ $branch_index ] ) &&
+				! isset( $branch_first[ $branch_index ][ $current_token_id ] )
+			) {
+				continue;
+			}
+
 			$this->position = $starting_position;
-			$node           = new WP_Parser_Node( $rule_id, $rule_name );
+			$children       = array();
 			$branch_matches = true;
 			foreach ( $branch as $subrule_id ) {
 				$subnode = $this->parse_recursive( $subrule_id );
@@ -80,16 +128,13 @@ class WP_Parser {
 					 * It is used to represent optional grammar productions.
 					 */
 					continue;
-				} elseif ( is_array( $subnode ) && 0 === count( $subnode ) ) {
-					continue;
-				}
-				if ( is_array( $subnode ) && ! count( $subnode ) ) {
-					continue;
-				}
-				if ( isset( $this->grammar->fragment_ids[ $subrule_id ] ) ) {
-					$node->merge_fragment( $subnode );
+				} elseif ( is_array( $subnode ) ) {
+					// A fragment rule matched: splice its children inline.
+					foreach ( $subnode as $subnode_child ) {
+						$children[] = $subnode_child;
+					}
 				} else {
-					$node->append_child( $subnode );
+					$children[] = $subnode;
 				}
 			}
 
@@ -100,9 +145,11 @@ class WP_Parser {
 			//        for right-associative rules, which could solve this.
 			//        See: https://github.com/mysql/mysql-workbench/blob/8.0.38/library/parsers/grammars/MySQLParser.g4#L994
 			//        See: https://github.com/antlr/antlr4/issues/488
-			$la = $this->tokens[ $this->position ] ?? null;
-			if ( $la && 'selectStatement' === $rule_name && WP_MySQL_Lexer::INTO_SYMBOL === $la->id ) {
-				$branch_matches = false;
+			if ( $rule_id === $this->select_statement_rule_id ) {
+				$la = $this->tokens[ $this->position ] ?? null;
+				if ( $la && WP_MySQL_Lexer::INTO_SYMBOL === $la->id ) {
+					$branch_matches = false;
+				}
 			}
 
 			if ( true === $branch_matches ) {
@@ -115,10 +162,16 @@ class WP_Parser {
 			return false;
 		}
 
-		if ( ! $node->has_child() ) {
+		if ( ! $children ) {
 			return true;
 		}
 
-		return $node;
+		if ( isset( $this->fragment_ids[ $rule_id ] ) ) {
+			// Fragments are inlined into the parent rule, so no node is needed.
+			// The children array is spliced directly into the parent's children.
+			return $children;
+		}
+
+		return new WP_Parser_Node( $rule_id, $this->rule_names[ $rule_id ], $children );
 	}
 }

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -458,11 +458,45 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	private $information_schema_builder;
 
 	/**
+	 * A cache of table column metadata used for INSERT and UPDATE translation.
+	 *
+	 * The structure is: [ <database> => [ <table-name> => <column records> ] ].
+	 *
+	 * The cache must be cleared whenever the database schema may change.
+	 * See the "clear_table_metadata_cache()" method for more details.
+	 *
+	 * @var array<string, array<string, array>>
+	 */
+	private $table_metadata_cache = array();
+
+	/**
 	 * Last executed MySQL query.
 	 *
 	 * @var string
 	 */
 	private $last_mysql_query;
+
+	/**
+	 * The "selectItemList" AST node for which the last SELECT item
+	 * disambiguation map was created.
+	 *
+	 * A single SELECT statement can require the same disambiguation map for
+	 * its ORDER BY, GROUP BY, and HAVING clauses. This property, along with
+	 * "$last_select_item_map", serves as a single-entry cache to avoid
+	 * recreating the map multiple times for the same SELECT item list node.
+	 *
+	 * @var WP_Parser_Node|null
+	 */
+	private $last_select_item_map_node;
+
+	/**
+	 * The last created SELECT item disambiguation map.
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$last_select_item_map_node
+	 *
+	 * @var array|null
+	 */
+	private $last_select_item_map;
 
 	/**
 	 * A list of SQLite queries executed for the last MySQL query.
@@ -526,6 +560,24 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @var bool
 	 */
 	private $is_readonly;
+
+	/**
+	 * A memoization cache for AST node translation results.
+	 *
+	 * When set, the "translate()" method caches and reuses translation results
+	 * per AST node object. Some statement handlers translate the same subtrees
+	 * multiple times — e.g., the SQL_CALC_FOUND_ROWS emulation translates the
+	 * query expression both for the data query and for the COUNT(*) query —
+	 * and the cache avoids re-walking identical subtrees.
+	 *
+	 * The cache is only valid within a single statement execution, while the
+	 * session state (SQL modes, user variables, etc.) and the database schema
+	 * are guaranteed not to change. It is created when a statement handler
+	 * starts and discarded when it ends.
+	 *
+	 * @var SplObjectStorage|null
+	 */
+	private $translation_memo;
 
 	/**
 	 * Type of wrapper transaction that is active for the MySQL query emulation.
@@ -1420,14 +1472,30 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				$this->execute_transaction_or_locking_statement( $node );
 				break;
 			case 'selectStatement':
-				$this->execute_select_statement( $node );
+				$this->is_readonly      = true;
+				$this->translation_memo = new SplObjectStorage();
+				try {
+					$this->execute_select_statement( $node );
+				} finally {
+					$this->translation_memo = null;
+				}
 				break;
 			case 'insertStatement':
 			case 'replaceStatement':
-				$this->execute_insert_or_replace_statement( $node );
+				$this->translation_memo = new SplObjectStorage();
+				try {
+					$this->execute_insert_or_replace_statement( $node );
+				} finally {
+					$this->translation_memo = null;
+				}
 				break;
 			case 'updateStatement':
-				$this->execute_update_statement( $node );
+				$this->translation_memo = new SplObjectStorage();
+				try {
+					$this->execute_update_statement( $node );
+				} finally {
+					$this->translation_memo = null;
+				}
 				break;
 			case 'deleteStatement':
 				$this->execute_delete_statement( $node );
@@ -1486,6 +1554,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 						$this->execute_drop_index_statement( $node );
 						break;
 					default:
+						$this->clear_table_metadata_cache();
 						$query                       = $this->translate( $node );
 						$this->last_result_statement = $this->execute_sqlite_query( $query );
 				}
@@ -1673,6 +1742,9 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		}
 		$this->connection->query( 'ROLLBACK' );
 		$this->in_transaction = false;
+
+		// The rollback may have reverted some DDL statements.
+		$this->clear_table_metadata_cache();
 	}
 
 	/**
@@ -1709,6 +1781,9 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 						$this->rollback_user_transaction();
 					} else {
 						$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
+
+						// The rollback may have reverted some DDL statements.
+						$this->clear_table_metadata_cache();
 					}
 					return;
 				}
@@ -2383,6 +2458,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_create_table_statement( WP_Parser_Node $node ): void {
+		$this->clear_table_metadata_cache();
+
 		$subnode = $node->get_first_child_node();
 
 		// Handle TEMPORARY keyword.
@@ -2454,6 +2531,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_alter_table_statement( WP_Parser_Node $node ): void {
+		$this->clear_table_metadata_cache();
+
 		$table_ref  = $node->get_first_descendant_node( 'tableRef' );
 		$database   = $this->get_database_name( $table_ref );
 		$table_name = $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
@@ -2542,6 +2621,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_drop_table_statement( WP_Parser_Node $node ): void {
+		$this->clear_table_metadata_cache();
+
 		// Record the changes in the information schema.
 		$this->information_schema_builder->record_drop_table( $node );
 
@@ -2594,6 +2675,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_truncate_table_statement( WP_Parser_Node $node ): void {
+		$this->clear_table_metadata_cache();
+
 		$table_ref  = $node->get_first_child_node( 'tableRef' );
 		$database   = $this->get_database_name( $table_ref );
 		$table_name = $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
@@ -2625,6 +2708,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_create_index_statement( WP_Parser_Node $node ): void {
+		$this->clear_table_metadata_cache();
+
 		$create_index = $node->get_first_child_node( 'createIndex' );
 		$target       = $create_index->get_first_child_node( 'createIndexTarget' );
 		$table_ref    = $target->get_first_child_node( 'tableRef' );
@@ -2683,6 +2768,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_drop_index_statement( WP_Parser_Node $node ): void {
+		$this->clear_table_metadata_cache();
+
 		$drop_index = $node->get_first_child_node( 'dropIndex' );
 		$table_ref  = $drop_index->get_first_child_node( 'tableRef' );
 		$database   = $this->get_database_name( $table_ref );
@@ -3300,6 +3387,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 
 		if ( $this->main_db_name === $database_name || 'information_schema' === $database_name ) {
 			$this->db_name = $database_name;
+			$this->clear_table_metadata_cache();
 		} else {
 			throw $this->new_not_supported_exception(
 				sprintf(
@@ -3547,6 +3635,9 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_administration_statement( WP_Parser_Node $node ): void {
+		// OPTIMIZE and REPAIR statements recreate the underlying SQLite tables.
+		$this->clear_table_metadata_cache();
+
 		$first_token    = $node->get_first_child_token();
 		$table_ref_list = $node->get_first_child_node( 'tableRefList' );
 		$results        = array();
@@ -3698,15 +3789,16 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception          When the translation fails.
 	 */
 	private function translate( $node ): ?string {
-		if ( null === $node ) {
-			return null;
-		}
-
-		if ( $node instanceof WP_MySQL_Token ) {
-			return $this->translate_token( $node );
-		}
-
+		// The most common case (a parser node) is checked first for performance.
 		if ( ! $node instanceof WP_Parser_Node ) {
+			if ( $node instanceof WP_MySQL_Token ) {
+				return $this->translate_token( $node );
+			}
+
+			if ( null === $node ) {
+				return null;
+			}
+
 			throw $this->new_driver_exception(
 				sprintf(
 					'Expected a WP_Parser_Node or WP_MySQL_Token instance, got: %s',
@@ -3715,6 +3807,31 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			);
 		}
 
+		$memo = $this->translation_memo;
+		if ( null === $memo ) {
+			return $this->translate_parser_node( $node );
+		}
+
+		if ( $memo->contains( $node ) ) {
+			return $memo[ $node ];
+		}
+
+		$result        = $this->translate_parser_node( $node );
+		$memo[ $node ] = $result;
+		return $result;
+	}
+
+	/**
+	 * Translate a MySQL AST parser node to an SQLite query fragment.
+	 *
+	 * This method must be used only via the "translate()" method, which adds
+	 * support for memoization of the translation results.
+	 *
+	 * @param  WP_Parser_Node $node       The AST node to translate.
+	 * @return string|null                The translated query fragment.
+	 * @throws WP_SQLite_Driver_Exception When the translation fails.
+	 */
+	private function translate_parser_node( WP_Parser_Node $node ): ?string {
 		$rule_name = $node->rule_name;
 		switch ( $rule_name ) {
 			case 'queryExpression':
@@ -4017,22 +4134,28 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception                      When the translation fails.
 	 */
 	private function translate_sequence( array $nodes, string $separator = ' ' ): ?string {
-		$parts = array();
+		$result = null;
 		foreach ( $nodes as $node ) {
 			if ( null === $node ) {
 				continue;
 			}
 
-			$translated = $this->translate( $node );
+			// Dispatch tokens directly, avoiding the "translate()" call overhead.
+			if ( $node instanceof WP_MySQL_Token ) {
+				$translated = $this->translate_token( $node );
+			} else {
+				$translated = $this->translate( $node );
+			}
 			if ( null === $translated ) {
 				continue;
 			}
-			$parts[] = $translated;
+			if ( null === $result ) {
+				$result = $translated;
+			} else {
+				$result .= $separator . $translated;
+			}
 		}
-		if ( 0 === count( $parts ) ) {
-			return null;
-		}
-		return implode( $separator, $parts );
+		return $result;
 	}
 
 	/**
@@ -5170,6 +5293,62 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	}
 
 	/**
+	 * Get column metadata of a table for INSERT and UPDATE statement translation.
+	 *
+	 * The metadata are loaded from the information schema and cached per table,
+	 * so that repeated INSERT and UPDATE statements against the same table can
+	 * avoid re-querying the information schema.
+	 *
+	 * The cache must be cleared whenever the database schema may change.
+	 * See the "clear_table_metadata_cache()" method for more details.
+	 *
+	 * @param  string $database   The database name (a saved "table_schema" value).
+	 * @param  string $table_name The table name.
+	 * @return array              Column metadata records ordered by ordinal
+	 *                            position, or an empty array when the table
+	 *                            doesn't exist.
+	 */
+	private function get_table_column_metadata( string $database, string $table_name ): array {
+		$columns = $this->table_metadata_cache[ $database ][ $table_name ] ?? null;
+		if ( null !== $columns ) {
+			return $columns;
+		}
+
+		$is_temporary  = $this->information_schema_builder->temporary_table_exists( $table_name );
+		$columns_table = $this->information_schema_builder->get_table_name( $is_temporary, 'columns' );
+		$columns       = $this->execute_sqlite_query(
+			'
+				SELECT LOWER(column_name) AS COLUMN_NAME, is_nullable, column_default, data_type, extra
+				FROM ' . $this->quote_sqlite_identifier( $columns_table ) . '
+				WHERE table_schema = ?
+				AND table_name = ?
+				ORDER BY ordinal_position
+			',
+			array( $database, $table_name )
+		)->fetchAll( PDO::FETCH_ASSOC );
+
+		// Don't cache an empty result. It means that the table doesn't exist,
+		// and it's safer to re-check that than to risk a stale negative entry.
+		if ( count( $columns ) > 0 ) {
+			$this->table_metadata_cache[ $database ][ $table_name ] = $columns;
+		}
+
+		return $columns;
+	}
+
+	/**
+	 * Clear the cache of table column metadata.
+	 *
+	 * This must be called whenever the database schema may change. That is,
+	 * on DDL statements (CREATE, ALTER, DROP, TRUNCATE, OPTIMIZE, etc.), on
+	 * database change (USE), and on transaction rollbacks, which may revert
+	 * previously executed DDL statements.
+	 */
+	private function clear_table_metadata_cache(): void {
+		$this->table_metadata_cache = array();
+	}
+
+	/**
 	 * Translate INSERT or REPLACE statement body to SQLite, while emulating
 	 * MySQL column type casting and implicit default values when saving data.
 	 *
@@ -5238,18 +5417,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		);
 
 		// Get column metadata for the target table from the information schema.
-		$is_temporary  = $this->information_schema_builder->temporary_table_exists( $table_name );
-		$columns_table = $this->information_schema_builder->get_table_name( $is_temporary, 'columns' );
-		$columns       = $this->execute_sqlite_query(
-			'
-				SELECT LOWER(column_name) AS COLUMN_NAME, is_nullable, column_default, data_type, extra
-				FROM ' . $this->quote_sqlite_identifier( $columns_table ) . '
-				WHERE table_schema = ?
-				AND table_name = ?
-				ORDER BY ordinal_position
-			',
-			array( $database, $table_name )
-		)->fetchAll( PDO::FETCH_ASSOC );
+		$columns = $this->get_table_column_metadata( $database, $table_name );
 
 		// Check if the table exists.
 		if ( 0 === count( $columns ) ) {
@@ -5553,17 +5721,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		);
 
 		// Get column metadata from the information schema.
-		$is_temporary  = $this->information_schema_builder->temporary_table_exists( $table_name );
-		$columns_table = $this->information_schema_builder->get_table_name( $is_temporary, 'columns' );
-		$columns       = $this->execute_sqlite_query(
-			'
-				SELECT LOWER(column_name) AS COLUMN_NAME, is_nullable, data_type, column_default
-				FROM ' . $this->quote_sqlite_identifier( $columns_table ) . '
-				WHERE table_schema = ?
-				AND table_name = ?
-			',
-			array( $database, $table_name )
-		)->fetchAll( PDO::FETCH_ASSOC );
+		$columns = $this->get_table_column_metadata( $database, $table_name );
 
 		// Check if the table exists.
 		if ( 0 === count( $columns ) ) {
@@ -5766,8 +5924,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		}
 
 		// Look for SELECT items that match the column reference.
-		$column_name         = $this->translate( $column_ref );
-		$select_item_matches = $disambiguation_map[ $column_name ] ?? array();
+		$select_item_matches = $disambiguation_map[ $column_value ] ?? array();
 
 		// When we find exactly one matching SELECT list item, we can disambiguate
 		// the column reference. Otherwise, fall back to the original expression.
@@ -5787,6 +5944,12 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @return array                            The SELECT item disambiguation map (column name => array of select items).
 	 */
 	private function create_select_item_disambiguation_map( WP_Parser_Node $select_item_list ): array {
+		// The same map can be required multiple times for a single SELECT
+		// statement (ORDER BY, GROUP BY, HAVING). Use a single-entry cache.
+		if ( $select_item_list === $this->last_select_item_map_node ) {
+			return $this->last_select_item_map;
+		}
+
 		// Create a map of SELECT item column names to their qualified values.
 		$disambiguation_map = array();
 		foreach ( $select_item_list->get_child_nodes() as $select_item ) {
@@ -5837,6 +6000,9 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			$disambiguation_map[ $key ]   = $disambiguation_map[ $key ] ?? array();
 			$disambiguation_map[ $key ][] = $column_value;
 		}
+
+		$this->last_select_item_map_node = $select_item_list;
+		$this->last_select_item_map      = $disambiguation_map;
 		return $disambiguation_map;
 	}
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -52,6 +52,51 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	const DRIVER_VERSION_VARIABLE_NAME = self::RESERVED_PREFIX . 'driver_version';
 
 	/**
+	 * The maximum number of entries in the translation template cache.
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 */
+	const TRANSLATION_CACHE_CAPACITY = 512;
+
+	/**
+	 * The maximum number of literals in a query for the translation cache.
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 */
+	const TRANSLATION_CACHE_MAX_LITERALS = 200;
+
+	/**
+	 * Tokens that prevent caching a query in the translation template cache.
+	 *
+	 * These are nondeterministic functions whose repeated evaluation may yield
+	 * different results (RAND, NOW, UUID, etc.), functions whose values depend
+	 * on the driver state that can change between two executions of the same
+	 * query (FOUND_ROWS), and functions whose translated output depends on the
+	 * values of their string literal arguments (DATE_FORMAT).
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 */
+	const TRANSLATION_CACHE_BLOCKED_TOKENS = array(
+		'RAND'              => true,
+		'NOW'               => true,
+		'SYSDATE'           => true,
+		'CURDATE'           => true,
+		'CURTIME'           => true,
+		'CURRENT_TIMESTAMP' => true,
+		'CURRENT_DATE'      => true,
+		'CURRENT_TIME'      => true,
+		'LOCALTIME'         => true,
+		'LOCALTIMESTAMP'    => true,
+		'UTC_DATE'          => true,
+		'UTC_TIME'          => true,
+		'UTC_TIMESTAMP'     => true,
+		'UUID'              => true,
+		'UUID_SHORT'        => true,
+		'FOUND_ROWS'        => true,
+		'DATE_FORMAT'       => true,
+	);
+
+	/**
 	 * A map of MySQL tokens to SQLite data types.
 	 *
 	 * This is used to translate a MySQL data type to an SQLite data type.
@@ -666,6 +711,64 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	private $user_variables = array();
 
 	/**
+	 * An LRU cache of literal-normalized translation templates.
+	 *
+	 * The cache maps query shapes to translation templates, so that repeated
+	 * SELECT, INSERT, REPLACE, UPDATE, and DELETE statements that differ only
+	 * in literal values can skip the parsing and translation steps entirely.
+	 *
+	 * A query shape is derived from the token stream of a MySQL query - it is
+	 * a concatenation of all token IDs together with the raw bytes of all
+	 * non-literal tokens. String and number literals are excluded, and their
+	 * positions are stored as slots in the translation templates.
+	 *
+	 * Each cached template is self-validating. The first two occurrences of
+	 * a query shape run the full translation pipeline, and the template is
+	 * trusted only after its rendered output byte-matches the full pipeline
+	 * translation on both occurrences. Any mismatch marks the query shape as
+	 * uncacheable forever. Only from the third occurrence on, the rendered
+	 * template is executed in place of the full pipeline.
+	 *
+	 * Cached templates must not depend on any state that can change between
+	 * the executions of the same query shape. Therefore:
+	 *
+	 *   1. Statements that use nondeterministic or driver-state-dependent
+	 *      functions, and statements referencing information schema tables
+	 *      are never cached. See "self::get_translation_cache_shape()".
+	 *   2. The whole cache is cleared on any statement other than a SELECT
+	 *      or a DML statement (INSERT, REPLACE, UPDATE, DELETE), as other
+	 *      statements may change table metadata or session state on which
+	 *      the translations depend. See "self::execute_mysql_query()".
+	 *
+	 * @var array<string, array{
+	 *   uncacheable: bool,
+	 *   trusted?: bool,
+	 *   is_select?: bool,
+	 *   has_count?: bool,
+	 *   templates?: array{ parts: string[], slots: int[] }[],
+	 *   db_name?: string,
+	 *   main_db_name?: string|null,
+	 * }>
+	 */
+	private $translation_cache = array();
+
+	/**
+	 * The translation produced for the currently executed MySQL statement.
+	 *
+	 * This is recorded by the SELECT, INSERT, REPLACE, UPDATE, and DELETE
+	 * statement handlers, and consumed by the translation template cache.
+	 * For other statement types, the value is null.
+	 *
+	 * @var array{
+	 *   is_select: bool,
+	 *   has_count: bool,
+	 *   queries: string[],
+	 *   cacheable: bool
+	 * }|null
+	 */
+	private $last_translated_statement;
+
+	/**
 	 * PDO API: Constructor.
 	 *
 	 * Set up an SQLite connection and the MySQL-on-SQLite driver.
@@ -924,8 +1027,20 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		$this->last_mysql_query = $query;
 
 		try {
-			// Parse the MySQL query.
-			$parser = $this->create_parser( $query );
+			// Try to reuse a cached translation template for this query shape.
+			$shape = $this->get_translation_cache_shape( $query );
+			if ( null !== $shape ) {
+				$cached_stmt = $this->replay_cached_translation( $shape );
+				if ( null !== $cached_stmt ) {
+					$cached_stmt->setFetchMode( $fetch_mode, ...$fetch_mode_args );
+					return $cached_stmt;
+				}
+			}
+
+			// Parse the MySQL query (reusing tokens from the shape computation).
+			$parser = null === $shape
+				? $this->create_parser( $query )
+				: new WP_MySQL_Parser( self::$mysql_grammar, $shape['tokens'] );
 			$parser->next_query();
 			$ast = $parser->get_query_ast();
 			if ( null === $ast ) {
@@ -985,6 +1100,11 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 
 			if ( $wrap_in_transaction ) {
 				$this->commit_wrapper_transaction();
+			}
+
+			// Build or validate a translation template for this query shape.
+			if ( null !== $shape && null !== $child_node && 'simpleStatement' === $child_node->rule_name ) {
+				$this->update_translation_cache( $shape, $child_node );
 			}
 
 			if ( null === $this->last_result_statement ) {
@@ -1429,6 +1549,526 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	}
 
 	/**
+	 * Compute the shape of a MySQL query for the translation template cache.
+	 *
+	 * The query shape is a concatenation of all token IDs together with the
+	 * raw bytes of all non-literal tokens. String and number literals are
+	 * excluded from the shape and collected separately, so that queries that
+	 * differ only in literal values share the same shape.
+	 *
+	 * Returns null when the query must not be cached. That is the case for:
+	 *
+	 *   1. Queries referencing information schema tables, whose translation
+	 *      executes metadata lookup queries that must run on every execution.
+	 *   2. Queries using nondeterministic functions, driver-state-dependent
+	 *      functions, or functions whose translation depends on the values
+	 *      of their string literal arguments.
+	 *      See "self::TRANSLATION_CACHE_BLOCKED_TOKENS".
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 *
+	 * @param  string $query The MySQL query.
+	 * @return array{
+	 *   key: string,
+	 *   tokens: WP_MySQL_Token[],
+	 *   literals: array{0: 'string'|'number', 1: WP_MySQL_Token}[]
+	 * }|null The query shape, or null when the query must not be cached.
+	 */
+	private function get_translation_cache_shape( string $query ): ?array {
+		if (
+			'information_schema' === $this->db_name
+			|| false !== stripos( $query, 'information_schema' )
+		) {
+			return null;
+		}
+
+		$lexer  = new WP_MySQL_Lexer(
+			$query,
+			80038,
+			$this->active_sql_modes
+		);
+		$tokens = $lexer->remaining_tokens();
+		if ( 0 === count( $tokens ) ) {
+			return null;
+		}
+
+		/*
+		 * The shape key is the raw query text with only the literal spans
+		 * replaced by typed placeholders. Raw bytes (including whitespace
+		 * and comments, which are hidden at the token level) must be part
+		 * of the key: the translation derives implicit column aliases from
+		 * raw query bytes, so queries differing only in hidden bytes can
+		 * translate differently and must not share a template.
+		 */
+		$key      = '';
+		$position = 0;
+		$literals = array();
+		foreach ( $tokens as $token ) {
+			$id = $token->id;
+			if (
+				WP_MySQL_Lexer::SINGLE_QUOTED_TEXT === $id
+				|| WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT === $id
+			) {
+				$literals[] = array( 'string', $token );
+				$key       .= substr( $query, $position, $token->start - $position ) . '#' . $id . "\x1F";
+				$position   = $token->start + $token->length;
+				continue;
+			}
+			if (
+				WP_MySQL_Lexer::INT_NUMBER === $id
+				|| WP_MySQL_Lexer::LONG_NUMBER === $id
+				|| WP_MySQL_Lexer::ULONGLONG_NUMBER === $id
+				|| WP_MySQL_Lexer::DECIMAL_NUMBER === $id
+				|| WP_MySQL_Lexer::FLOAT_NUMBER === $id
+			) {
+				$literals[] = array( 'number', $token );
+				$key       .= substr( $query, $position, $token->start - $position ) . '#' . $id . "\x1F";
+				$position   = $token->start + $token->length;
+				continue;
+			}
+
+			$bytes = $token->get_bytes();
+			if ( isset( self::TRANSLATION_CACHE_BLOCKED_TOKENS[ strtoupper( $bytes ) ] ) ) {
+				return null;
+			}
+		}
+		$key .= substr( $query, $position );
+
+		if ( count( $literals ) > self::TRANSLATION_CACHE_MAX_LITERALS ) {
+			return null;
+		}
+
+		return array(
+			'key'      => $key,
+			'tokens'   => $tokens,
+			'literals' => $literals,
+		);
+	}
+
+	/**
+	 * Try to execute a MySQL query using a cached translation template.
+	 *
+	 * When a trusted translation template exists for the given query shape,
+	 * the translated SQLite queries are rendered from the template using the
+	 * literals of the current query, and executed directly, replicating the
+	 * normal execution path while skipping only the parsing and translation.
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 *
+	 * @param  array $shape              The query shape.
+	 *                                   See "self::get_translation_cache_shape()".
+	 * @return WP_PDO_Proxy_Statement|null The result statement, or null when
+	 *                                     no trusted template is available.
+	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
+	 */
+	private function replay_cached_translation( array $shape ): ?WP_PDO_Proxy_Statement {
+		$entry = $this->translation_cache[ $shape['key'] ] ?? null;
+		if ( null === $entry ) {
+			return null;
+		}
+
+		if ( $entry['uncacheable'] ) {
+			return null;
+		}
+
+		// Refresh the position of the entry for the LRU eviction order.
+		unset( $this->translation_cache[ $shape['key'] ] );
+		$this->translation_cache[ $shape['key'] ] = $entry;
+
+		if (
+			! $entry['trusted']
+			|| $entry['db_name'] !== $this->db_name
+			|| $entry['main_db_name'] !== $this->main_db_name
+		) {
+			return null;
+		}
+
+		// Render the translated SQLite queries from the cached templates.
+		$queries = array();
+		foreach ( $entry['templates'] as $template ) {
+			$queries[] = $this->render_translation_template( $template, $shape['literals'] );
+		}
+
+		/*
+		 * Replicate the normal execution path below, skipping only the parsing
+		 * and translation steps. For SELECT statements, the "$this->is_readonly"
+		 * flag is set only after the wrapper transaction is begun.
+		 * See "self::query()" and "self::execute_mysql_query()".
+		 *
+		 * The wrapper transaction must follow the same skip decision the normal
+		 * path makes: SELECT statements are already read-only, while other
+		 * replayable statements still use the wrapper transaction.
+		 */
+		$wrap_in_transaction = ! $entry['is_select'];
+		if ( $wrap_in_transaction ) {
+			$this->begin_wrapper_transaction();
+		}
+		if ( $entry['is_select'] ) {
+			$this->is_readonly = true;
+			if ( $entry['has_count'] ) {
+				$this->execute_translated_select_statement( $queries[1], $queries[0] );
+			} else {
+				$this->execute_translated_select_statement( $queries[0], null );
+			}
+		} else {
+			$this->last_result_statement = $this->execute_sqlite_query( $queries[0] );
+		}
+		if ( $wrap_in_transaction ) {
+			$this->commit_wrapper_transaction();
+		}
+
+		return new WP_PDO_Proxy_Statement( $this->last_result_statement, $this->last_affected_rows );
+	}
+
+	/**
+	 * Build or validate a translation template for the given query shape.
+	 *
+	 * This must be called after a MySQL query was successfully executed using
+	 * the full translation pipeline. On the first occurrence of a query shape,
+	 * a translation template is built. On the second occurrence, the template
+	 * is validated against the full pipeline translation, and is trusted only
+	 * when the rendered queries are byte-identical (this catches translations
+	 * that branch on literal values). On any failure or mismatch, the query
+	 * shape is marked as uncacheable forever.
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 *
+	 * @param array          $shape          The query shape.
+	 *                                       See "self::get_translation_cache_shape()".
+	 * @param WP_Parser_Node $statement_node The "simpleStatement" AST node of the
+	 *                                       executed query.
+	 */
+	private function update_translation_cache( array $shape, WP_Parser_Node $statement_node ): void {
+		$info = $this->last_translated_statement;
+		$key  = $shape['key'];
+
+		// Mark statements that can't be replayed from a translation template
+		// as uncacheable, so the template construction is never re-attempted.
+		if ( null === $info || ! $info['cacheable'] ) {
+			$this->save_translation_cache_entry( $key, array( 'uncacheable' => true ) );
+			return;
+		}
+
+		$entry = $this->translation_cache[ $key ] ?? null;
+		if ( null !== $entry && $entry['uncacheable'] ) {
+			return;
+		}
+
+		// Second occurrence: validate the template against the full pipeline.
+		if (
+			null !== $entry
+			&& $entry['db_name'] === $this->db_name
+			&& $entry['main_db_name'] === $this->main_db_name
+		) {
+			if ( $entry['trusted'] ) {
+				return;
+			}
+			if ( $this->translation_templates_match( $entry, $info, $shape['literals'] ) ) {
+				$entry['trusted'] = true;
+				$this->save_translation_cache_entry( $key, $entry );
+			} else {
+				$this->save_translation_cache_entry( $key, array( 'uncacheable' => true ) );
+			}
+			return;
+		}
+
+		// First occurrence: build templates by translating the statement again
+		// with all literals substituted by unique sentinel values.
+		$templates = $this->build_translation_templates( $shape, count( $info['queries'] ) );
+		if ( null === $templates ) {
+			$this->save_translation_cache_entry( $key, array( 'uncacheable' => true ) );
+			return;
+		}
+
+		$entry = array(
+			'uncacheable'  => false,
+			'trusted'      => false,
+			'is_select'    => $info['is_select'],
+			'has_count'    => $info['has_count'],
+			'templates'    => $templates,
+			'db_name'      => $this->db_name,
+			'main_db_name' => $this->main_db_name,
+		);
+
+		// Sanity check: the new templates rendered with the literals of the
+		// current query must reproduce the full pipeline translation.
+		if ( ! $this->translation_templates_match( $entry, $info, $shape['literals'] ) ) {
+			$this->save_translation_cache_entry( $key, array( 'uncacheable' => true ) );
+			return;
+		}
+
+		$this->save_translation_cache_entry( $key, $entry );
+	}
+
+	/**
+	 * Check whether rendered translation templates match a full translation.
+	 *
+	 * @param  array $entry    The translation cache entry.
+	 * @param  array $info     The full pipeline translation record.
+	 *                         See "self::$last_translated_statement".
+	 * @param  array $literals The literals of the current query.
+	 * @return bool            Whether the rendered templates are byte-identical
+	 *                         to the full pipeline translation.
+	 */
+	private function translation_templates_match( array $entry, array $info, array $literals ): bool {
+		if (
+			$entry['is_select'] !== $info['is_select']
+			|| $entry['has_count'] !== $info['has_count']
+			|| count( $entry['templates'] ) !== count( $info['queries'] )
+		) {
+			return false;
+		}
+		foreach ( $entry['templates'] as $i => $template ) {
+			if ( $this->render_translation_template( $template, $literals ) !== $info['queries'][ $i ] ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Save an entry to the translation template cache with LRU eviction.
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 *
+	 * @param string $key   The query shape key.
+	 * @param array  $entry The translation cache entry.
+	 */
+	private function save_translation_cache_entry( string $key, array $entry ): void {
+		if ( isset( $this->translation_cache[ $key ] ) ) {
+			unset( $this->translation_cache[ $key ] );
+		} elseif ( count( $this->translation_cache ) >= self::TRANSLATION_CACHE_CAPACITY ) {
+			// Evict the least recently used entry (the first one in the array).
+			array_shift( $this->translation_cache );
+		}
+		$this->translation_cache[ $key ] = $entry;
+	}
+
+	/**
+	 * Build translation templates for the current MySQL query.
+	 *
+	 * The current MySQL query is translated a second time, with each literal
+	 * substituted by a unique sentinel value. The sentinels are then located
+	 * in the translated output to produce templates with literal slots.
+	 *
+	 * When any sentinel does not appear intact at most once in each translated
+	 * query, or the translation of the sentinel query fails, null is returned
+	 * and the query shape must be marked as uncacheable.
+	 *
+	 * @see WP_PDO_MySQL_On_SQLite::$translation_cache
+	 *
+	 * @param  array $shape          The query shape.
+	 *                               See "self::get_translation_cache_shape()".
+	 * @param  int   $expected_count The expected number of translated queries.
+	 * @return array{ parts: string[], slots: int[] }[]|null The templates,
+	 *                               or null when a template can't be built.
+	 */
+	private function build_translation_templates( array $shape, int $expected_count ): ?array {
+		$query    = $this->last_mysql_query;
+		$literals = $shape['literals'];
+
+		// Compose a sentinel query, replacing literals with sentinel values.
+		$sentinels      = array();
+		$sentinel_query = '';
+		$position       = 0;
+		foreach ( $literals as $index => $literal ) {
+			list( $type, $token ) = $literal;
+			if ( 'string' === $type ) {
+				$bare     = '~~WPLIT' . $index . '~~';
+				$sentinel = "'" . $bare . "'";
+			} else {
+				$bare     = (string) ( 8000000000000000 + $index );
+				$sentinel = $bare;
+			}
+			$sentinels[ $index ] = array( $type, $bare );
+			$sentinel_query     .= substr( $query, $position, $token->start - $position ) . $sentinel;
+			$position            = $token->start + $token->length;
+		}
+		$sentinel_query .= substr( $query, $position );
+
+		/*
+		 * Translate the sentinel query without executing it.
+		 *
+		 * Some translations execute SQLite metadata lookup queries. They are
+		 * read-only and harmless, but they must be removed from the query log
+		 * to keep "self::get_last_sqlite_queries()" unchanged. Additionally,
+		 * the original MySQL query reference must be temporarily replaced, as
+		 * the translation of SELECT item aliases reads the original query text
+		 * from "$this->last_mysql_query" using sentinel query AST offsets.
+		 */
+		$saved_sqlite_queries = $this->last_sqlite_queries;
+		$saved_mysql_query    = $this->last_mysql_query;
+		try {
+			$this->last_mysql_query = $sentinel_query;
+
+			$parser = $this->create_parser( $sentinel_query );
+			$parser->next_query();
+			$ast = $parser->get_query_ast();
+			if ( null === $ast || $parser->next_query() ) {
+				return null;
+			}
+
+			$child = $ast->get_first_child_node();
+			if ( null === $child || 'simpleStatement' !== $child->rule_name ) {
+				return null;
+			}
+
+			$queries = $this->translate_statement_for_template( $child->get_first_child_node() );
+		} catch ( Throwable $e ) {
+			return null;
+		} finally {
+			$this->last_mysql_query    = $saved_mysql_query;
+			$this->last_sqlite_queries = $saved_sqlite_queries;
+		}
+
+		if ( null === $queries || count( $queries ) !== $expected_count ) {
+			return null;
+		}
+
+		// Locate the sentinels in each translated query to build the templates.
+		$templates = array();
+		foreach ( $queries as $sql ) {
+			$template = $this->create_template_from_sentinels( $sql, $sentinels );
+			if ( null === $template ) {
+				return null;
+			}
+			$templates[] = $template;
+		}
+		return $templates;
+	}
+
+	/**
+	 * Translate a MySQL statement without executing the translated queries.
+	 *
+	 * This mirrors the translation parts of the SELECT, INSERT, REPLACE,
+	 * UPDATE, and DELETE statement handlers, and is used to translate the
+	 * sentinel queries for the translation template cache.
+	 *
+	 * @param  WP_Parser_Node $node The statement AST node (a "simpleStatement" child).
+	 * @return string[]|null        The translated queries in execution order,
+	 *                              or null when the statement type can't be
+	 *                              replayed from a translation template.
+	 * @throws WP_SQLite_Driver_Exception When the translation fails.
+	 */
+	private function translate_statement_for_template( WP_Parser_Node $node ): ?array {
+		switch ( $node->rule_name ) {
+			case 'selectStatement':
+				list( $query, $count_query ) = $this->translate_select_statement( $node );
+				return null === $count_query ? array( $query ) : array( $count_query, $query );
+			case 'insertStatement':
+			case 'replaceStatement':
+				list( $query, $on_conflict_update_list ) = $this->translate_insert_or_replace_statement( $node );
+				// The ON CONFLICT fallback for SQLite < 3.35.0 is data-dependent.
+				return null === $on_conflict_update_list ? array( $query ) : null;
+			case 'updateStatement':
+				return array( $this->translate_update_statement( $node ) );
+			case 'deleteStatement':
+				// A multi-table DELETE executes data-dependent queries.
+				if ( null !== $node->get_first_child_node( 'tableAliasRefList' ) ) {
+					return null;
+				}
+				return array( $this->translate( $node ) );
+		}
+		return null;
+	}
+
+	/**
+	 * Create a translation template by locating sentinels in a translated query.
+	 *
+	 * Each sentinel must appear intact at most once in the translated query.
+	 * A string sentinel must appear as a complete single-quoted SQLite string
+	 * literal, and a number sentinel must appear as a standalone number. When
+	 * any sentinel violates these rules, the template can't be created.
+	 *
+	 * @param  string $sql       The translated SQLite query with sentinels.
+	 * @param  array  $sentinels The sentinels (literal index => type and bare value).
+	 * @return array{ parts: string[], slots: int[] }|null The template, or null
+	 *                           when the template can't be created.
+	 */
+	private function create_template_from_sentinels( string $sql, array $sentinels ): ?array {
+		$slot_positions = array();
+		foreach ( $sentinels as $index => $sentinel ) {
+			list( $type, $bare ) = $sentinel;
+
+			$count = substr_count( $sql, $bare );
+			if ( 0 === $count ) {
+				// This literal does not occur in this translated query.
+				continue;
+			}
+			if ( 1 !== $count ) {
+				return null;
+			}
+
+			if ( 'string' === $type ) {
+				// The sentinel must occur as a complete string literal ('...').
+				$span     = "'" . $bare . "'";
+				$position = strpos( $sql, $span );
+				if ( false === $position ) {
+					return null;
+				}
+			} else {
+				// The sentinel must occur as a standalone number.
+				$span     = $bare;
+				$position = strpos( $sql, $span );
+				$before   = $position > 0 ? $sql[ $position - 1 ] : '';
+				$after    = $sql[ $position + strlen( $span ) ] ?? '';
+				if (
+					1 === preg_match( '/[0-9A-Za-z_.$\'"`]/', $before )
+					|| 1 === preg_match( '/[0-9A-Za-z_.$\'"`]/', $after )
+				) {
+					return null;
+				}
+			}
+
+			$slot_positions[ $position ] = array( $index, strlen( $span ) );
+		}
+
+		ksort( $slot_positions );
+
+		$parts    = array();
+		$slots    = array();
+		$position = 0;
+		foreach ( $slot_positions as $start => $slot ) {
+			list( $index, $length ) = $slot;
+
+			$parts[]  = substr( $sql, $position, $start - $position );
+			$slots[]  = $index;
+			$position = $start + $length;
+		}
+		$parts[] = substr( $sql, $position );
+
+		return array(
+			'parts' => $parts,
+			'slots' => $slots,
+		);
+	}
+
+	/**
+	 * Render a translated SQLite query from a translation template.
+	 *
+	 * String literals are rendered exactly the way the translator renders them.
+	 * Number literals pass through with their raw bytes as written.
+	 *
+	 * @param  array $template The translation template.
+	 * @param  array $literals The literals of the current query.
+	 * @return string          The rendered SQLite query.
+	 */
+	private function render_translation_template( array $template, array $literals ): string {
+		$parts = $template['parts'];
+		$sql   = $parts[0];
+		foreach ( $template['slots'] as $i => $literal_index ) {
+			list( $type, $token ) = $literals[ $literal_index ];
+			if ( 'string' === $type ) {
+				$sql .= $this->render_translated_string_literal( $token->get_value() );
+			} else {
+				$sql .= $token->get_bytes();
+			}
+			$sql .= $parts[ $i + 1 ];
+		}
+		return $sql;
+	}
+
+	/**
 	 * Translate and execute a MySQL query in SQLite.
 	 *
 	 * @param  WP_Parser_Node $node       The "query" AST node with "simpleStatement" child.
@@ -1455,6 +2095,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		}
 
 		if ( 'beginWork' === $children[0]->rule_name ) {
+			$this->translation_cache = array();
 			$this->begin_user_transaction();
 			return;
 		}
@@ -1467,6 +2108,21 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 
 		// Process the "simpleStatement" AST node.
 		$node = $children[0]->get_first_child_node();
+
+		/*
+		 * Cached translation templates can depend on table metadata and session
+		 * state. Clear the cache on any statement that may change them - that
+		 * is, anything other than a SELECT or a DML statement. This includes
+		 * transaction statements, since a ROLLBACK can revert DDL changes.
+		 */
+		if ( ! in_array(
+			$node->rule_name,
+			array( 'selectStatement', 'insertStatement', 'replaceStatement', 'updateStatement', 'deleteStatement' ),
+			true
+		) ) {
+			$this->translation_cache = array();
+		}
+
 		switch ( $node->rule_name ) {
 			case 'transactionOrLockingStatement':
 				$this->execute_transaction_or_locking_statement( $node );
@@ -1745,6 +2401,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 
 		// The rollback may have reverted some DDL statements.
 		$this->clear_table_metadata_cache();
+		$this->translation_cache = array();
 	}
 
 	/**
@@ -1874,6 +2531,29 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_select_statement( WP_Parser_Node $node ): void {
+		list( $query, $count_query ) = $this->translate_select_statement( $node );
+
+		// Record the translation for the translation template cache.
+		$this->last_translated_statement = array(
+			'is_select' => true,
+			'has_count' => null !== $count_query,
+			'queries'   => null === $count_query ? array( $query ) : array( $count_query, $query ),
+			'cacheable' => true,
+		);
+
+		$this->execute_translated_select_statement( $query, $count_query );
+	}
+
+	/**
+	 * Translate a MySQL SELECT statement to SQLite.
+	 *
+	 * @param  WP_Parser_Node $node       The "selectStatement" AST node.
+	 * @return array{0: string, 1: string|null} The translated query, and a query
+	 *                                          emulating SQL_CALC_FOUND_ROWS when
+	 *                                          it is used (null otherwise).
+	 * @throws WP_SQLite_Driver_Exception When the translation fails.
+	 */
+	private function translate_select_statement( WP_Parser_Node $node ): array {
 		/*
 		 * [GRAMMAR]
 		 * selectStatement:
@@ -1888,7 +2568,8 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			WP_MySQL_Lexer::SQL_CALC_FOUND_ROWS_SYMBOL
 		);
 
-		// Handle SQL_CALC_FOUND_ROWS.
+		// Translate a count query to emulate SQL_CALC_FOUND_ROWS.
+		$count_query = null;
 		if ( true === $has_sql_calc_found_rows ) {
 			// Recursively find a query expression with the first LIMIT or SELECT.
 			$query_expr = $node->get_first_descendant_node( 'queryExpression' );
@@ -1928,10 +2609,25 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				}
 			}
 
+			$count_query = 'SELECT COUNT(*) AS cnt FROM (' . $this->translate( $count_expr ) . ')';
+		}
+
+		return array( $query, $count_query );
+	}
+
+	/**
+	 * Execute a translated MySQL SELECT statement in SQLite.
+	 *
+	 * @param  string      $query       The translated SQLite query.
+	 * @param  string|null $count_query A translated SQLite query emulating
+	 *                                  SQL_CALC_FOUND_ROWS, when it is used.
+	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
+	 */
+	private function execute_translated_select_statement( string $query, ?string $count_query ): void {
+		// Handle SQL_CALC_FOUND_ROWS.
+		if ( null !== $count_query ) {
 			// Get count of all the rows.
-			$result = $this->execute_sqlite_query(
-				'SELECT COUNT(*) AS cnt FROM (' . $this->translate( $count_expr ) . ')'
-			);
+			$result = $this->execute_sqlite_query( $count_query );
 
 			$this->found_rows = (int) $result->fetchColumn();
 		} else {
@@ -1954,66 +2650,21 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_insert_or_replace_statement( WP_Parser_Node $node ): void {
-		$parts                   = array();
-		$on_conflict_update_list = null;
-		foreach ( $node->get_children() as $child ) {
-			$is_token = $child instanceof WP_MySQL_Token;
-			$is_node  = $child instanceof WP_Parser_Node;
+		list( $query, $on_conflict_update_list, $table_name ) = $this->translate_insert_or_replace_statement( $node );
 
-			if ( $child instanceof WP_Parser_Node && 'tableRef' === $child->rule_name ) {
-				// MySQL supports INSERT without the INTO keyword; SQLite requires it.
-				if ( ! $node->has_child_token( WP_MySQL_Lexer::INTO_SYMBOL ) ) {
-					$parts[] = 'INTO';
-				}
-
-				$database = $this->get_database_name( $child );
-				if ( 'information_schema' === strtolower( $database ) ) {
-					throw $this->new_access_denied_to_information_schema_exception();
-				}
-			}
-
-			// Skip the SET keyword in "INSERT INTO ... SET ..." syntax.
-			if ( $is_token && WP_MySQL_Lexer::SET_SYMBOL === $child->id ) {
-				continue;
-			}
-
-			if ( $is_token && WP_MySQL_Lexer::IGNORE_SYMBOL === $child->id ) {
-				// Translate "UPDATE IGNORE" to "UPDATE OR IGNORE".
-				$parts[] = 'OR IGNORE';
-			} elseif (
-				$is_node
-				&& (
-					'insertFromConstructor' === $child->rule_name
-					|| 'insertQueryExpression' === $child->rule_name
-					|| 'updateList' === $child->rule_name
-				)
-			) {
-				$table_ref  = $node->get_first_child_node( 'tableRef' );
-				$table_name = $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
-				$parts[]    = $this->translate_insert_or_replace_body( $table_name, $child );
-			} elseif ( $is_node && 'insertUpdateList' === $child->rule_name ) {
-				/*
-				 * Translate "ON DUPLICATE KEY UPDATE" to "ON CONFLICT DO UPDATE SET".
-				 *
-				 * For SQLite versions older than 3.35.0, we need to handle the
-				 * ON CONFLICT clause differently, and at this stage, we only
-				 * save the translated update list to a variable.
-				 *
-				 * See bellow at "Handle ON CONFLICT clause for SQLite < 3.35.0".
-				 */
-				$sqlite_version = $this->get_sqlite_version();
-				if ( version_compare( $sqlite_version, '3.35.0', '<' ) ) {
-					$on_conflict_update_list = $this->translate_update_list( $table_name, $child );
-				} else {
-					$parts[] = 'ON CONFLICT DO UPDATE SET ';
-					$parts[] = $this->translate_update_list( $table_name, $child );
-				}
-			} else {
-				$parts[] = $this->translate( $child );
-			}
-		}
-
-		$query = implode( ' ', $parts );
+		/*
+		 * Record the translation for the translation template cache.
+		 *
+		 * The fallback path for SQLite < 3.35.0 below is data-dependent (it may
+		 * re-execute the query with an ON CONFLICT clause derived from a
+		 * constraint violation error), so it can't be replayed from a template.
+		 */
+		$this->last_translated_statement = array(
+			'is_select' => false,
+			'has_count' => false,
+			'queries'   => array( $query ),
+			'cacheable' => null === $on_conflict_update_list,
+		);
 
 		/*
 		 * Handle ON CONFLICT clause for SQLite < 3.35.0.
@@ -2075,12 +2726,108 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	}
 
 	/**
+	 * Translate a MySQL INSERT or REPLACE statement to SQLite.
+	 *
+	 * @param  WP_Parser_Node $node       The "insertStatement" or "replaceStatement" AST node.
+	 * @return array{0: string, 1: string|null, 2: string|null} The translated query, the translated
+	 *                                                          ON CONFLICT update list for SQLite < 3.35.0
+	 *                                                          (null otherwise), and the target table name.
+	 * @throws WP_SQLite_Driver_Exception When the translation fails.
+	 */
+	private function translate_insert_or_replace_statement( WP_Parser_Node $node ): array {
+		$parts                   = array();
+		$on_conflict_update_list = null;
+		$table_name              = null;
+		foreach ( $node->get_children() as $child ) {
+			$is_token = $child instanceof WP_MySQL_Token;
+			$is_node  = $child instanceof WP_Parser_Node;
+
+			if ( $child instanceof WP_Parser_Node && 'tableRef' === $child->rule_name ) {
+				// MySQL supports INSERT without the INTO keyword; SQLite requires it.
+				if ( ! $node->has_child_token( WP_MySQL_Lexer::INTO_SYMBOL ) ) {
+					$parts[] = 'INTO';
+				}
+
+				$database = $this->get_database_name( $child );
+				if ( 'information_schema' === strtolower( $database ) ) {
+					throw $this->new_access_denied_to_information_schema_exception();
+				}
+			}
+
+			// Skip the SET keyword in "INSERT INTO ... SET ..." syntax.
+			if ( $is_token && WP_MySQL_Lexer::SET_SYMBOL === $child->id ) {
+				continue;
+			}
+
+			if ( $is_token && WP_MySQL_Lexer::IGNORE_SYMBOL === $child->id ) {
+				// Translate "UPDATE IGNORE" to "UPDATE OR IGNORE".
+				$parts[] = 'OR IGNORE';
+			} elseif (
+				$is_node
+				&& (
+					'insertFromConstructor' === $child->rule_name
+					|| 'insertQueryExpression' === $child->rule_name
+					|| 'updateList' === $child->rule_name
+				)
+			) {
+				$table_ref  = $node->get_first_child_node( 'tableRef' );
+				$table_name = $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
+				$parts[]    = $this->translate_insert_or_replace_body( $table_name, $child );
+			} elseif ( $is_node && 'insertUpdateList' === $child->rule_name ) {
+				/*
+				 * Translate "ON DUPLICATE KEY UPDATE" to "ON CONFLICT DO UPDATE SET".
+				 *
+				 * For SQLite versions older than 3.35.0, we need to handle the
+				 * ON CONFLICT clause differently, and at this stage, we only
+				 * save the translated update list to a variable.
+				 *
+				 * See bellow at "Handle ON CONFLICT clause for SQLite < 3.35.0".
+				 */
+				$sqlite_version = $this->get_sqlite_version();
+				if ( version_compare( $sqlite_version, '3.35.0', '<' ) ) {
+					$on_conflict_update_list = $this->translate_update_list( $table_name, $child );
+				} else {
+					$parts[] = 'ON CONFLICT DO UPDATE SET ';
+					$parts[] = $this->translate_update_list( $table_name, $child );
+				}
+			} else {
+				$parts[] = $this->translate( $child );
+			}
+		}
+
+		$query = implode( ' ', $parts );
+
+		return array( $query, $on_conflict_update_list, $table_name );
+	}
+
+	/**
 	 * Translate and execute a MySQL UPDATE statement in SQLite.
 	 *
 	 * @param  WP_Parser_Node $node       The "updateStatement" AST node.
 	 * @throws WP_SQLite_Driver_Exception When the query execution fails.
 	 */
 	private function execute_update_statement( WP_Parser_Node $node ): void {
+		$query = $this->translate_update_statement( $node );
+
+		// Record the translation for the translation template cache.
+		$this->last_translated_statement = array(
+			'is_select' => false,
+			'has_count' => false,
+			'queries'   => array( $query ),
+			'cacheable' => true,
+		);
+
+		$this->last_result_statement = $this->execute_sqlite_query( $query );
+	}
+
+	/**
+	 * Translate a MySQL UPDATE statement to SQLite.
+	 *
+	 * @param  WP_Parser_Node $node       The "updateStatement" AST node.
+	 * @return string                     The translated query.
+	 * @throws WP_SQLite_Driver_Exception When the translation fails.
+	 */
+	private function translate_update_statement( WP_Parser_Node $node ): string {
 		// @TODO: Add support for UPDATE with multiple tables and JOINs.
 		//        SQLite supports them in the FROM clause.
 
@@ -2305,9 +3052,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			$order_clause,
 			$limit_clause,
 		);
-		$query = implode( ' ', array_filter( $parts ) );
-
-		$this->last_result_statement = $this->execute_sqlite_query( $query );
+		return implode( ' ', array_filter( $parts ) );
 	}
 
 	/**
@@ -2443,11 +3188,28 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				$where_subquery
 			);
 
+			// Record the translation for the translation template cache.
+			$this->last_translated_statement = array(
+				'is_select' => false,
+				'has_count' => false,
+				'queries'   => array( $query ),
+				'cacheable' => true,
+			);
+
 			$this->last_result_statement = $this->execute_sqlite_query( $query );
 			return;
 		}
 
-		$query                       = $this->translate( $node );
+		$query = $this->translate( $node );
+
+		// Record the translation for the translation template cache.
+		$this->last_translated_statement = array(
+			'is_select' => false,
+			'has_count' => false,
+			'queries'   => array( $query ),
+			'cacheable' => true,
+		);
+
 		$this->last_result_statement = $this->execute_sqlite_query( $query );
 	}
 
@@ -4166,8 +4928,16 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 */
 	private function translate_string_literal( WP_Parser_Node $node ): string {
 		$token = $node->get_first_child_token();
-		$value = $token->get_value();
+		return $this->render_translated_string_literal( $token->get_value() );
+	}
 
+	/**
+	 * Render an unquoted MySQL string literal value as an SQLite literal.
+	 *
+	 * @param  string $value The unquoted MySQL string literal value.
+	 * @return string        The rendered SQLite value.
+	 */
+	private function render_translated_string_literal( string $value ): string {
 		/*
 		 * Translate datetime literals.
 		 *
@@ -7104,13 +7874,14 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 * Clear the state of the driver.
 	 */
 	private function flush(): void {
-		$this->last_mysql_query         = '';
-		$this->last_sqlite_queries      = array();
-		$this->last_result_statement    = null;
-		$this->last_affected_rows       = null;
-		$this->last_column_meta         = array();
-		$this->is_readonly              = false;
-		$this->wrapper_transaction_type = null;
+		$this->last_mysql_query          = '';
+		$this->last_sqlite_queries       = array();
+		$this->last_result_statement     = null;
+		$this->last_affected_rows        = null;
+		$this->last_column_meta          = array();
+		$this->last_translated_statement = null;
+		$this->is_readonly               = false;
+		$this->wrapper_transaction_type  = null;
 		$this->user_defined_functions->flush();
 	}
 

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Translation_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Translation_Tests.php
@@ -2085,10 +2085,17 @@ class WP_SQLite_Driver_Translation_Tests extends TestCase {
 
 		$executed_queries = array_column( $this->driver->get_last_sqlite_queries(), 'sql' );
 
-		// Remove BEGIN and COMMIT/ROLLBACK queries.
-		if ( count( $executed_queries ) > 2 ) {
-			$executed_queries = array_values( array_slice( $executed_queries, 1, -1, true ) );
-		}
+		// Remove BEGIN and COMMIT/ROLLBACK queries, including wrapper savepoints.
+		// The wrapper transaction may be skipped for some statement types.
+		$executed_queries = array_values(
+			array_filter(
+				$executed_queries,
+				function ( $query ) {
+					return ! in_array( $query, array( 'BEGIN', 'BEGIN IMMEDIATE', 'COMMIT', 'ROLLBACK' ), true )
+						&& ! preg_match( '/^(?:SAVEPOINT|RELEASE SAVEPOINT|ROLLBACK TO SAVEPOINT) _wp_sqlite_savepoint_/', $query );
+				}
+			)
+		);
 
 		// Remove temporary table existence checks.
 		$executed_queries = array_values(


### PR DESCRIPTION
## What it does

Speeds up repeated MySQL-on-SQLite query execution on `trunk` by keeping the existing SQLite behavior but doing less parser and translator work before each SQLite statement runs.

The PR is staged as three commits:

1. `Speed up WP_Parser with lazy nodes and FIRST-set pruning`
2. `Reduce driver miss-path overhead with token, AST, and metadata caches`
3. `Replay repeated MySQL query shapes from translation templates`

Local median throughput on the same benchmark harness moves from **3,574 QPS** on `origin/trunk` to **32,284 QPS** on this branch (**9.0x**).

## Rationale

The slow path is mostly before SQLite execution: token handling, parsing, AST walking, metadata lookups, and MySQL-to-SQLite translation. WordPress workloads repeat statement shapes with different literal values, so the largest gain comes from validating a translation template once and replaying it for later executions of the same shape.

The previous develop-based wrapper-transaction stage is intentionally not part of this trunk-based branch. `trunk` already skips wrapper transactions for top-level `SELECT` statements, and DML must still open the write wrapper transaction; `WP_SQLite_Driver_Concurrency_Tests::testWriteQueryOpensWriteTransaction` covers that invariant.

## Implementation

- Defers `WP_Parser_Node` allocation until a branch has matched, caches grammar tables, and uses per-branch FIRST sets to skip impossible branches.
- Updates the reusable MySQL parser reset path so its cached token count follows the new token stream.
- Adds token value memoization, accumulator-based AST traversal helpers, select-item-map caching, per-statement translation memoization, and table metadata caching.
- Adds a literal-normalized translation template cache for `SELECT`, `INSERT`, `REPLACE`, `UPDATE`, and `DELETE`:
  - first occurrence builds a template with sentinel literals;
  - second occurrence validates that rendering the template byte-matches the full translation;
  - third and later occurrences replay rendered SQLite directly.
- Clears dependent caches on schema/session-affecting statements and rollback paths.

Fair benchmark against `origin/trunk` (`php .context/driver-bench-trunk.php --iters=5000 --warmup=300`, three samples per ref):

| Stage | Commit | Median QPS | Vs `origin/trunk` |
|---|---:|---:|---:|
| `origin/trunk` | `0545a37` | 3,574 | 1.0x |
| Parser allocation/FIRST sets | `6a7ef80` | 4,780 | 1.34x |
| Token/AST/metadata caches | `53ef656` | 5,551 | 1.55x |
| Translation template replay | `2eaa775` | 32,284 | 9.03x |

## Testing instructions

Run:

```bash
cd packages/mysql-on-sqlite && ../../vendor/bin/phpunit --stop-on-failure --stop-on-error
php vendor/bin/phpcs packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php packages/mysql-on-sqlite/src/mysql/class-wp-mysql-token.php packages/mysql-on-sqlite/src/parser/class-wp-parser.php packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php packages/mysql-on-sqlite/src/parser/class-wp-parser-token.php packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Translation_Tests.php
php vendor/bin/parallel-lint packages/mysql-on-sqlite/src/mysql/class-wp-mysql-parser.php packages/mysql-on-sqlite/src/mysql/class-wp-mysql-token.php packages/mysql-on-sqlite/src/parser/class-wp-parser.php packages/mysql-on-sqlite/src/parser/class-wp-parser-grammar.php packages/mysql-on-sqlite/src/parser/class-wp-parser-node.php packages/mysql-on-sqlite/src/parser/class-wp-parser-token.php packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Translation_Tests.php
git diff --check origin/trunk...HEAD
```

Local results:

- PHPUnit: 718 tests, 1,428,237 assertions; 15 skipped, 2 incomplete.
- PHPCS on touched files: clean.
- parallel-lint on touched files: clean.
- `git diff --check origin/trunk...HEAD`: clean.
