### PR TITLE
Add REVERSE() to user defined functions

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -90,6 +90,7 @@ class WP_SQLite_PDO_User_Defined_Functions {
 		'utc_time'                     => 'utc_time',
 		'utc_timestamp'                => 'utc_timestamp',
 		'version'                      => 'version',
+		'reverse'                      => 'reverse',
 
 		// Internal helper functions.
 		'_helper_like_to_glob_pattern' => '_helper_like_to_glob_pattern',
@@ -927,6 +928,22 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	 */
 	public function version() {
 		return '5.5';
+	}
+
+	/**
+	 * Method to emulate MySQL REVERSE() function.
+	 *
+	 * Takes a string and returns the reverse of it.
+	 *
+	* @param string|null $str The string to reverse.
+	*
+	* @return string|null reversed string, or NULL.
+	*/
+	public function reverse( $str ) {
+		if ( null === $str ) {
+			return null;
+		}
+		return strrev( $str );
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -12483,4 +12483,18 @@ END;
 		$this->assertSame( "DATETIME(CURRENT_TIMESTAMP, '+' || 1 || ' YEAR')", $result[2]['dflt_value'] );
 		$this->assertSame( "('a' || 'b')", $result[3]['dflt_value'] );
 	}
+
+	public function testReverseFunction(): void {
+		// Normal reverse.
+		$result = $this->assertQuery( "SELECT REVERSE('aoeuidhtns') AS reversed" );
+		$this->assertSame( 'snthdiueoa', $result[0]->reversed );
+
+		// Empty string.
+		$result = $this->assertQuery( "SELECT REVERSE('') AS reversed" );
+		$this->assertSame( '', $result[0]->reversed );
+
+		// NULL input returns NULL.
+		$result = $this->assertQuery( 'SELECT REVERSE(NULL) AS reversed' );
+		$this->assertNull( $result[0]->reversed );
+	}
 }


### PR DESCRIPTION
I ran into an issue where a plugin is using the REVERSE() function to add the reverse of a string into the database. Since this isn't supported by SQLite it breaks the plugin. This fixes it for me.