### PR TITLE
Run the MySQL server suite on every PR

### DIFF
--- a/.github/workflows/mysql-server-suite.yml
+++ b/.github/workflows/mysql-server-suite.yml
@@ -1,0 +1,106 @@
+name: MySQL Server Suite
+
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  trunk-commit-gate:
+    name: Decide whether to run MySQL server suite
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run_suite: ${{ steps.decision.outputs.run_suite }}
+      reason: ${{ steps.decision.outputs.reason }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to run
+        id: decision
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != 'push' ]; then
+            echo "run_suite=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Running MySQL server suite for ${{ github.event_name }}." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.ref }}" != 'refs/heads/trunk' ]; then
+            echo "run_suite=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Skipping: push was not to trunk." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          before='${{ github.event.before }}'
+          after='${{ github.sha }}'
+
+          after_count="$(git rev-list --first-parent --count "$after")"
+          if [[ "$before" =~ ^0+$ ]] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
+            before_count=$(( after_count - 1 ))
+          else
+            before_count="$(git rev-list --first-parent --count "$before")"
+          fi
+
+          next_tenth=$(( ( before_count / 10 + 1 ) * 10 ))
+          if [ "$next_tenth" -le "$after_count" ]; then
+            echo "run_suite=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Running: trunk first-parent commit $next_tenth was included in this push." >> "$GITHUB_OUTPUT"
+          else
+            echo "run_suite=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Skipping: trunk first-parent commit count is $after_count; next MySQL server suite run is $next_tenth." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summary
+        run: echo "${{ steps.decision.outputs.reason }}"
+
+  test:
+    name: Full MySQL server suite
+    needs: trunk-commit-gate
+    if: needs.trunk-commit-gate.outputs.run_suite == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          tools: phpunit-polyfills
+
+      - name: Install Composer dependencies (mysql-on-sqlite)
+        uses: ramsey/composer-install@v3
+        with:
+          working-directory: packages/mysql-on-sqlite
+          ignore-cache: "yes"
+          composer-options: "--optimize-autoloader"
+
+      - name: Run MySQL server lexer suite
+        run: php ./vendor/bin/phpunit -c ./phpunit.xml.dist tests/mysql/WP_MySQL_Server_Suite_Lexer_Tests.php
+        working-directory: packages/mysql-on-sqlite
+
+      - name: Run MySQL server parser suite
+        run: php ./vendor/bin/phpunit -c ./phpunit.xml.dist tests/mysql/WP_MySQL_Server_Suite_Parser_Tests.php
+        working-directory: packages/mysql-on-sqlite

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -4,6 +4,12 @@ on:
   push:
     branches:
       - trunk
+    paths:
+      - '.github/workflows/phpunit-tests.yml'
+      - 'packages/mysql-on-sqlite/**'
+      - 'packages/php-ext-wp-mysql-parser/**'
+      - 'composer.json'
+      - 'composer.lock'
   pull_request:
     paths:
       - '.github/workflows/phpunit-tests.yml'
@@ -22,63 +28,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  trunk-commit-gate:
-    name: Decide whether to run full MySQL suite
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    outputs:
-      run_suite: ${{ steps.decision.outputs.run_suite }}
-      reason: ${{ steps.decision.outputs.reason }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Decide whether to run
-        id: decision
-        run: |
-          set -euo pipefail
-
-          if [ "${{ github.event_name }}" != 'push' ]; then
-            echo "run_suite=true" >> "$GITHUB_OUTPUT"
-            echo "reason=Running full suite for ${{ github.event_name }}." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if [ "${{ github.ref }}" != 'refs/heads/trunk' ]; then
-            echo "run_suite=false" >> "$GITHUB_OUTPUT"
-            echo "reason=Skipping: push was not to trunk." >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          before='${{ github.event.before }}'
-          after='${{ github.sha }}'
-
-          after_count="$(git rev-list --first-parent --count "$after")"
-          if [[ "$before" =~ ^0+$ ]] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
-            before_count=$(( after_count - 1 ))
-          else
-            before_count="$(git rev-list --first-parent --count "$before")"
-          fi
-
-          next_tenth=$(( ( before_count / 10 + 1 ) * 10 ))
-          if [ "$next_tenth" -le "$after_count" ]; then
-            echo "run_suite=true" >> "$GITHUB_OUTPUT"
-            echo "reason=Running: trunk first-parent commit $next_tenth was included in this push." >> "$GITHUB_OUTPUT"
-          else
-            echo "run_suite=false" >> "$GITHUB_OUTPUT"
-            echo "reason=Skipping: trunk first-parent commit count is $after_count; next full run is $next_tenth." >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Summary
-        run: echo "${{ steps.decision.outputs.reason }}"
-
   test:
-    needs: trunk-commit-gate
-    if: needs.trunk-commit-gate.outputs.run_suite == 'true'
     # The pure-PHP parser is exercised across the full PHP/SQLite range; the
     # native Rust parser extension is exercised on PHP 8.0+ (its minimum). Both
     # run the same mysql-on-sqlite suite, just with a different parser engine.

--- a/.github/workflows/phpunit-tests.yml
+++ b/.github/workflows/phpunit-tests.yml
@@ -4,12 +4,6 @@ on:
   push:
     branches:
       - trunk
-    paths:
-      - '.github/workflows/phpunit-tests.yml'
-      - 'packages/mysql-on-sqlite/**'
-      - 'packages/php-ext-wp-mysql-parser/**'
-      - 'composer.json'
-      - 'composer.lock'
   pull_request:
     paths:
       - '.github/workflows/phpunit-tests.yml'
@@ -28,7 +22,63 @@ concurrency:
 permissions: {}
 
 jobs:
+  trunk-commit-gate:
+    name: Decide whether to run full MySQL suite
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      run_suite: ${{ steps.decision.outputs.run_suite }}
+      reason: ${{ steps.decision.outputs.reason }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether to run
+        id: decision
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != 'push' ]; then
+            echo "run_suite=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Running full suite for ${{ github.event_name }}." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ "${{ github.ref }}" != 'refs/heads/trunk' ]; then
+            echo "run_suite=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Skipping: push was not to trunk." >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          before='${{ github.event.before }}'
+          after='${{ github.sha }}'
+
+          after_count="$(git rev-list --first-parent --count "$after")"
+          if [[ "$before" =~ ^0+$ ]] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
+            before_count=$(( after_count - 1 ))
+          else
+            before_count="$(git rev-list --first-parent --count "$before")"
+          fi
+
+          next_tenth=$(( ( before_count / 10 + 1 ) * 10 ))
+          if [ "$next_tenth" -le "$after_count" ]; then
+            echo "run_suite=true" >> "$GITHUB_OUTPUT"
+            echo "reason=Running: trunk first-parent commit $next_tenth was included in this push." >> "$GITHUB_OUTPUT"
+          else
+            echo "run_suite=false" >> "$GITHUB_OUTPUT"
+            echo "reason=Skipping: trunk first-parent commit count is $after_count; next full run is $next_tenth." >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Summary
+        run: echo "${{ steps.decision.outputs.reason }}"
+
   test:
+    needs: trunk-commit-gate
+    if: needs.trunk-commit-gate.outputs.run_suite == 'true'
     # The pure-PHP parser is exercised across the full PHP/SQLite range; the
     # native Rust parser extension is exercised on PHP 8.0+ (its minimum). Both
     # run the same mysql-on-sqlite suite, just with a different parser engine.


### PR DESCRIPTION
## Summary

This adds a dedicated GitHub Actions workflow for the real MySQL server corpus checks.

The important behavior is simple: every PR now runs the full MySQL server lexer and parser suites, so compatibility issues are visible before merge. After merge, every `trunk` push still enters a tiny gate job, but the expensive suite only runs when trunk's first-parent commit count crosses a multiple of 10. Maintainers can also run the workflow manually when they want an immediate signal.

## What Runs

The new `MySQL Server Suite` workflow runs these package-local PHPUnit files:

- `tests/mysql/WP_MySQL_Server_Suite_Lexer_Tests.php`
- `tests/mysql/WP_MySQL_Server_Suite_Parser_Tests.php`

It installs Composer dependencies only for `packages/mysql-on-sqlite` and runs on PHP 8.3 with coverage disabled.

## Why A Separate Workflow

Keeping this separate from the regular PHP unit workflow makes the signal easier to understand. The existing package test matrix stays focused on normal unit coverage, while this workflow is clearly the heavier MySQL server compatibility check.

## Trunk Behavior

On `pull_request` and `workflow_dispatch`, the suite always runs.

On `push` to `trunk`, the gate counts first-parent commits. If the pushed range crosses commit 10, 20, 30, and so on, the full suite runs once for that push. Otherwise only the lightweight gate job runs and reports why the suite was skipped.

## Known Limitations

- The post-merge cadence is commit-count based, not time based.
- A batch push that crosses more than one tenth-commit boundary still runs the suite once for that push.
- This covers the checked-in MySQL server lexer/parser suites, not Docker-based WordPress runtime tests.
- Running the full suite on every PR is intentionally heavier than path-filtered checks; this favors compatibility signal over PR latency.

## Validation

- Parsed `.github/workflows/mysql-server-suite.yml` as YAML.
- Ran `bash -n` over every workflow `run:` block in the new file.
- Ran `git diff --check upstream/trunk...HEAD`.
- PR-triggered run succeeded: https://github.com/WordPress/sqlite-database-integration/actions/runs/27696678705