### PR TITLE
Run MySQL server result tests against the SQLite proxy

### DIFF
--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -112,8 +112,28 @@ jobs:
           SH
             chmod +x "$1"
           }
-          for helper in mysql_ssl_rsa_setup mysql_migrate_keyring mysql_keyring_encryption_test; do
-            create_noop_helper "$client_bindir/$helper"
+          for helper in \
+            ibd2sdi \
+            innochecksum \
+            my_print_defaults \
+            myisamchk \
+            myisampack \
+            mysql_client_test \
+            mysql_config_editor \
+            mysql_keyring_encryption_test \
+            mysql_migrate_keyring \
+            mysql_plugin \
+            mysql_secure_installation \
+            mysql_ssl_rsa_setup \
+            mysql_tzinfo_to_sql \
+            mysql_upgrade \
+            mysqlbinlog \
+            mysqlcheck \
+            mysqlimport \
+            mysqlpump; do
+            if [ ! -e "$client_bindir/$helper" ]; then
+              create_noop_helper "$client_bindir/$helper"
+            fi
           done
           create_noop_helper "$client_bindir/mysqld"
           create_noop_helper "$install_dir/bin/mysqld"

--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -67,6 +67,13 @@ jobs:
           mkdir -p "$install_dir"
           tar -xJf "$download_path" -C "$install_dir" --strip-components=1
 
+          mkdir -p "$install_dir/share"
+          if [ -d /usr/share/mysql ]; then
+            ln -sfn /usr/share/mysql "$install_dir/share/mysql"
+          else
+            mkdir -p "$install_dir/share/mysql"
+          fi
+
           mysql_test_dir="$(find "$install_dir" -type f -name mysql-test-run.pl -printf '%h\n' | head -n 1)"
           mysqltest_bin="$(find "$install_dir" -type f -name mysqltest -perm /111 -print | head -n 1)"
 

--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -1,0 +1,206 @@
+name: MySQL Server Result Suite
+
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  test:
+    name: MySQL server result suite
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+          extensions: sockets, pdo_sqlite
+          tools: phpunit-polyfills
+
+      - name: Install Composer dependencies (mysql-proxy)
+        uses: ramsey/composer-install@v3
+        with:
+          working-directory: packages/mysql-proxy
+          ignore-cache: "yes"
+          composer-options: "--optimize-autoloader"
+
+      - name: Install MySQL command-line client
+        run: |
+          set -euo pipefail
+
+          sudo timeout 300s apt-get update
+          sudo env DEBIAN_FRONTEND=noninteractive timeout 300s \
+            apt-get install -y --no-install-recommends mariadb-client
+
+      - name: Download MySQL server test suite
+        run: |
+          set -euo pipefail
+
+          mysql_version='8.0.46'
+          archive="mysql-test-${mysql_version}-linux-glibc2.28-x86_64.tar.xz"
+          archive_url="https://cdn.mysql.com/Downloads/MySQL-8.0/${archive}"
+          download_path="$RUNNER_TEMP/$archive"
+          install_dir="$RUNNER_TEMP/mysql-server-test-suite"
+
+          curl --fail --location --retry 3 --connect-timeout 30 --max-time 1200 \
+            --output "$download_path" \
+            "$archive_url"
+
+          mkdir -p "$install_dir"
+          tar -xJf "$download_path" -C "$install_dir" --strip-components=1
+
+          mysql_test_dir="$(find "$install_dir" -type f -name mysql-test-run.pl -printf '%h\n' | head -n 1)"
+          mysqltest_bin="$(find "$install_dir" -type f -name mysqltest -perm /111 -print | head -n 1)"
+
+          if [ -z "$mysql_test_dir" ] || [ ! -f "$mysql_test_dir/mysql-test-run.pl" ]; then
+            echo "mysql-test-run.pl was not found in $archive." >&2
+            find "$install_dir" -maxdepth 3 -type f | sort | sed -n '1,120p' >&2
+            exit 1
+          fi
+
+          if [ -z "$mysqltest_bin" ]; then
+            echo "mysqltest was not found in $archive." >&2
+            find "$install_dir" -maxdepth 4 -type f -name 'mysql*' | sort >&2
+            exit 1
+          fi
+
+          echo "MYSQL_TEST_DIR=$mysql_test_dir" >> "$GITHUB_ENV"
+          echo "MYSQLTEST_BIN=$mysqltest_bin" >> "$GITHUB_ENV"
+
+          client_bindir="$RUNNER_TEMP/mysql-client-bindir"
+          mkdir -p "$client_bindir"
+          ln -sf "$mysqltest_bin" "$client_bindir/mysqltest"
+          for client in mysql mysqladmin mysqldump mysqlshow mysqlslap perror; do
+            client_path="$(command -v "$client" || true)"
+            if [ -n "$client_path" ]; then
+              ln -sf "$client_path" "$client_bindir/$client"
+            fi
+          done
+
+          echo "MYSQL_CLIENT_BINDIR=$client_bindir" >> "$GITHUB_ENV"
+
+          "$mysqltest_bin" --version
+
+      - name: Run MySQL server result suite against SQLite proxy
+        run: |
+          set -euo pipefail
+
+          port=13306
+          db_path="$RUNNER_TEMP/mysql-server-result-suite.sqlite"
+          proxy_log="$RUNNER_TEMP/mysql-proxy.log"
+          vardir="$RUNNER_TEMP/mysql-test-var"
+
+          php "$GITHUB_WORKSPACE/packages/mysql-proxy/bin/wp-mysql-proxy.php" \
+            --port "$port" \
+            --database "$db_path" \
+            --database-name test \
+            --database-alias mysql \
+            --log-level warning \
+            > "$proxy_log" 2>&1 &
+          proxy_pid="$!"
+
+          cleanup() {
+            kill "$proxy_pid" 2>/dev/null || true
+            wait "$proxy_pid" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          for attempt in $(seq 1 100); do
+            if php -r "\$socket = @fsockopen( '127.0.0.1', $port ); if ( \$socket ) { fclose( \$socket ); exit( 0 ); } exit( 1 );"; then
+              break
+            fi
+            if ! kill -0 "$proxy_pid" 2>/dev/null; then
+              echo "MySQL proxy exited before accepting connections." >&2
+              cat "$proxy_log" >&2 || true
+              exit 1
+            fi
+            if [ "$attempt" -eq 100 ]; then
+              echo "Timed out waiting for MySQL proxy on port $port." >&2
+              cat "$proxy_log" >&2 || true
+              exit 1
+            fi
+            sleep 0.1
+          done
+
+          mkdir -p "$vardir"
+
+          mysql_preflight_stdout="$RUNNER_TEMP/mysql-preflight.out"
+          mysql_preflight_stderr="$RUNNER_TEMP/mysql-preflight.err"
+          set +e
+          "$MYSQL_CLIENT_BINDIR/mysql" \
+            --no-defaults \
+            --host=127.0.0.1 \
+            --port="$port" \
+            --user=root \
+            --password=root \
+            --database=mysql \
+            --connect-timeout=10 \
+            --silent \
+            --execute="SHOW GLOBAL VARIABLES" \
+            > "$mysql_preflight_stdout" 2> "$mysql_preflight_stderr"
+          mysql_preflight_status="$?"
+          set -e
+
+          if [ "$mysql_preflight_status" -ne 0 ]; then
+            echo "MySQL client preflight failed with exit code $mysql_preflight_status." >&2
+            echo "### mysql stdout" >&2
+            cat "$mysql_preflight_stdout" >&2 || true
+            echo "### mysql stderr" >&2
+            cat "$mysql_preflight_stderr" >&2 || true
+            echo "### proxy log" >&2
+            cat "$proxy_log" >&2 || true
+            exit "$mysql_preflight_status"
+          fi
+
+          set +e
+          (
+            cd "$MYSQL_TEST_DIR"
+            MYSQL_TEST="$MYSQLTEST_BIN" perl ./mysql-test-run.pl \
+              --extern host=127.0.0.1 \
+              --extern port="$port" \
+              --extern user=root \
+              --extern password=root \
+              --extern database=test \
+              --force \
+              --timer \
+              --parallel=1 \
+              --client-bindir="$MYSQL_CLIENT_BINDIR" \
+              --vardir="$vardir"
+          )
+          status="$?"
+          set -e
+
+          {
+            echo "## MySQL Server Result Suite"
+            echo
+            echo "- Test source: MySQL server test-suite archive."
+            echo "- Runner: \`$MYSQLTEST_BIN\`."
+            echo "- Target: PHP MySQL proxy backed by the SQLite driver, exposing database \`test\`."
+            echo "- Exit status: \`$status\`."
+            echo
+            echo "### Proxy log tail"
+            echo
+            echo '```text'
+            tail -100 "$proxy_log" || true
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$status"

--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -105,13 +105,18 @@ jobs:
               ln -sf "$client_path" "$client_bindir/$client"
             fi
           done
-          for helper in mysql_ssl_rsa_setup mysql_migrate_keyring mysql_keyring_encryption_test; do
-            cat > "$client_bindir/$helper" <<'SH'
+          create_noop_helper() {
+            cat > "$1" <<'SH'
           #!/usr/bin/env bash
           exit 0
           SH
-            chmod +x "$client_bindir/$helper"
+            chmod +x "$1"
+          }
+          for helper in mysql_ssl_rsa_setup mysql_migrate_keyring mysql_keyring_encryption_test; do
+            create_noop_helper "$client_bindir/$helper"
           done
+          create_noop_helper "$client_bindir/mysqld"
+          create_noop_helper "$install_dir/bin/mysqld"
 
           echo "MYSQL_CLIENT_BINDIR=$client_bindir" >> "$GITHUB_ENV"
 

--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -68,10 +68,14 @@ jobs:
           tar -xJf "$download_path" -C "$install_dir" --strip-components=1
 
           mkdir -p "$install_dir/share"
-          if [ -d /usr/share/mysql ]; then
-            ln -sfn /usr/share/mysql "$install_dir/share/mysql"
-          else
-            mkdir -p "$install_dir/share/mysql"
+          for mysql_share_dir in /usr/share/mysql /usr/share/mariadb; do
+            if [ -d "$mysql_share_dir/charsets" ]; then
+              ln -sfn "$mysql_share_dir" "$install_dir/share/mysql"
+              break
+            fi
+          done
+          if [ ! -e "$install_dir/share/mysql" ]; then
+            mkdir -p "$install_dir/share/mysql/charsets"
           fi
 
           mysql_test_dir="$(find "$install_dir" -type f -name mysql-test-run.pl -printf '%h\n' | head -n 1)"

--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -105,6 +105,11 @@ jobs:
               ln -sf "$client_path" "$client_bindir/$client"
             fi
           done
+          cat > "$client_bindir/mysql_ssl_rsa_setup" <<'SH'
+          #!/usr/bin/env bash
+          exit 0
+          SH
+          chmod +x "$client_bindir/mysql_ssl_rsa_setup"
 
           echo "MYSQL_CLIENT_BINDIR=$client_bindir" >> "$GITHUB_ENV"
 

--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -223,6 +223,7 @@ jobs:
               --extern password=root \
               --extern database=test \
               --force \
+              --max-test-fail=1000 \
               --timer \
               --parallel=1 \
               --client-bindir="$MYSQL_CLIENT_BINDIR" \

--- a/.github/workflows/mysql-server-result-suite.yml
+++ b/.github/workflows/mysql-server-result-suite.yml
@@ -105,11 +105,13 @@ jobs:
               ln -sf "$client_path" "$client_bindir/$client"
             fi
           done
-          cat > "$client_bindir/mysql_ssl_rsa_setup" <<'SH'
+          for helper in mysql_ssl_rsa_setup mysql_migrate_keyring mysql_keyring_encryption_test; do
+            cat > "$client_bindir/$helper" <<'SH'
           #!/usr/bin/env bash
           exit 0
           SH
-          chmod +x "$client_bindir/mysql_ssl_rsa_setup"
+            chmod +x "$client_bindir/$helper"
+          done
 
           echo "MYSQL_CLIENT_BINDIR=$client_bindir" >> "$GITHUB_ENV"
 

--- a/packages/mysql-proxy/bin/wp-mysql-proxy.php
+++ b/packages/mysql-proxy/bin/wp-mysql-proxy.php
@@ -8,16 +8,21 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 // Process CLI arguments:
 $shortopts = 'h:d:p:l:';
-$longopts  = array( 'help', 'database:', 'port:', 'log-level:' );
+$longopts  = array( 'help', 'database:', 'database-name:', 'database-alias:', 'port:', 'log-level:' );
 $opts      = getopt( $shortopts, $longopts );
 
 $help = <<<USAGE
-Usage: php bin/wp-mysql-proxy.php [--port <port>] [--database <path/to/db.sqlite>] [--log-level <log_level>]
+Usage: php bin/wp-mysql-proxy.php [--port <port>] [--database <path/to/db.sqlite>] [--database-name <name>] [--database-alias <name>] [--log-level <log_level>]
 
 Options:
   -h, --help              Show this help message and exit.
   -p, --port=<port>       The port to listen on. Default: 3306
   -d, --database=<path>   The path to the SQLite database file. Default: :memory:
+      --database-name=<name>
+                           The MySQL database name exposed by the proxy. Default: sqlite_database
+      --database-alias=<name>
+                           Additional database name accepted as an alias for --database-name.
+                           May be passed more than once.
   -l, --log-level=<level> The log level to use. One of 'error', 'warning', 'info', 'debug'. Default: info
 
 USAGE;
@@ -30,6 +35,23 @@ if ( isset( $opts['h'] ) || isset( $opts['help'] ) ) {
 
 // Database path.
 $db_path = $opts['d'] ?? $opts['database'] ?? ':memory:';
+
+// Database name.
+$db_name = $opts['database-name'] ?? 'sqlite_database';
+if ( '' === $db_name ) {
+	fwrite( STDERR, "Error: --database-name cannot be empty. Use --help for more information.\n" );
+	exit( 1 );
+}
+
+// Database aliases.
+$db_aliases = $opts['database-alias'] ?? array();
+if ( ! is_array( $db_aliases ) ) {
+	$db_aliases = array( $db_aliases );
+}
+if ( in_array( '', $db_aliases, true ) ) {
+	fwrite( STDERR, "Error: --database-alias cannot be empty. Use --help for more information.\n" );
+	exit( 1 );
+}
 
 // Port.
 $port = (int) ( $opts['p'] ?? $opts['port'] ?? 3306 );
@@ -47,7 +69,7 @@ if ( ! in_array( $log_level, Logger::LEVELS, true ) ) {
 
 // Start the MySQL proxy.
 $proxy = new MySQL_Proxy(
-	new SQLite_Adapter( $db_path ),
+	new SQLite_Adapter( $db_path, $db_name, $db_aliases ),
 	array(
 		'port'      => $port,
 		'log_level' => $log_level,

--- a/packages/mysql-proxy/src/Adapter/class-sqlite-adapter.php
+++ b/packages/mysql-proxy/src/Adapter/class-sqlite-adapter.php
@@ -15,13 +15,25 @@ class SQLite_Adapter implements Adapter {
 	/** @var WP_SQLite_Driver */
 	private $sqlite_driver;
 
-	public function __construct( $sqlite_database_path ) {
+	/** @var string */
+	private $database_name;
+
+	/** @var array<string, true> */
+	private $database_aliases = array();
+
+	public function __construct( $sqlite_database_path, string $database_name = 'sqlite_database', array $database_aliases = array() ) {
 		define( 'FQDB', $sqlite_database_path );
 		define( 'FQDBDIR', dirname( FQDB ) . '/' );
 
+		$this->database_name = $database_name;
+
+		foreach ( $database_aliases as $database_alias ) {
+			$this->database_aliases[ strtolower( $database_alias ) ] = true;
+		}
+
 		$this->sqlite_driver = new WP_SQLite_Driver(
 			new WP_SQLite_Connection( array( 'path' => $sqlite_database_path ) ),
-			'sqlite_database'
+			$database_name
 		);
 	}
 
@@ -32,6 +44,7 @@ class SQLite_Adapter implements Adapter {
 		$rows           = array();
 
 		try {
+			$query          = $this->replace_database_alias_in_use_query( $query );
 			$return_value   = $this->sqlite_driver->query( $query );
 			$last_insert_id = $this->sqlite_driver->get_insert_id() ?? null;
 			if ( is_numeric( $return_value ) ) {
@@ -50,6 +63,29 @@ class SQLite_Adapter implements Adapter {
 			}
 			return MySQL_Result::from_error( 'HY000', 1105, $e->getMessage() ?? 'Unknown error' );
 		}
+	}
+
+	private function replace_database_alias_in_use_query( string $query ): string {
+		if ( empty( $this->database_aliases ) ) {
+			return $query;
+		}
+
+		if ( ! preg_match( '/^USE\s+(`([^`]+)`|"([^"]+)"|\\\'([^\\\']+)\\\'|([^\\s;]+))\s*;?\s*$/i', $query, $matches ) ) {
+			return $query;
+		}
+
+		$database_name = '';
+		for ( $i = 2; $i <= 5; $i++ ) {
+			if ( isset( $matches[ $i ] ) && '' !== $matches[ $i ] ) {
+				$database_name = $matches[ $i ];
+				break;
+			}
+		}
+		if ( ! isset( $this->database_aliases[ strtolower( $database_name ) ] ) ) {
+			return $query;
+		}
+
+		return 'USE `' . str_replace( '`', '``', $this->database_name ) . '`';
 	}
 
 	public function computeColumnInfo() {

--- a/packages/mysql-proxy/src/Adapter/class-sqlite-adapter.php
+++ b/packages/mysql-proxy/src/Adapter/class-sqlite-adapter.php
@@ -44,9 +44,10 @@ class SQLite_Adapter implements Adapter {
 		$rows           = array();
 
 		try {
-			$query          = $this->replace_database_alias_in_use_query( $query );
-			$return_value   = $this->sqlite_driver->query( $query );
-			$last_insert_id = $this->sqlite_driver->get_insert_id() ?? null;
+			$show_variables_like = $this->get_show_variables_like_pattern( $query );
+			$query               = $this->replace_database_alias_in_use_query( $query );
+			$return_value        = $this->sqlite_driver->query( $query );
+			$last_insert_id      = $this->sqlite_driver->get_insert_id() ?? null;
 			if ( is_numeric( $return_value ) ) {
 				$affected_rows = (int) $return_value;
 			} elseif ( is_array( $return_value ) ) {
@@ -54,6 +55,9 @@ class SQLite_Adapter implements Adapter {
 			}
 			if ( $this->sqlite_driver->get_last_column_count() > 0 ) {
 				$columns = $this->computeColumnInfo();
+			}
+			if ( false !== $show_variables_like && empty( $rows ) ) {
+				return $this->get_show_variables_result( $show_variables_like );
 			}
 			return MySQL_Result::from_data( $affected_rows, $last_insert_id, $columns, $rows ?? array() );
 		} catch ( Throwable $e ) {
@@ -86,6 +90,155 @@ class SQLite_Adapter implements Adapter {
 		}
 
 		return 'USE `' . str_replace( '`', '``', $this->database_name ) . '`';
+	}
+
+	/**
+	 * Extract a LIKE pattern from SHOW VARIABLES queries.
+	 *
+	 * @param  string $query The query to inspect.
+	 * @return string|null|false LIKE pattern, null for all variables, or false for non-matching queries.
+	 */
+	private function get_show_variables_like_pattern( string $query ) {
+		if ( ! preg_match( '/^\s*SHOW\s+(?:(?:GLOBAL|SESSION|LOCAL)\s+)?VARIABLES(?:\s+LIKE\s+((?:\'(?:\'\'|[^\'])*\'|"(?:""|[^"])*"|[^\s;]+)))?\s*;?\s*$/i', $query, $matches ) ) {
+			return false;
+		}
+
+		if ( empty( $matches[1] ) ) {
+			return null;
+		}
+
+		$pattern = $matches[1];
+		$quote   = $pattern[0];
+		if ( ( "'" === $quote || '"' === $quote ) && substr( $pattern, -1 ) === $quote ) {
+			$pattern = substr( $pattern, 1, -1 );
+			$pattern = str_replace( $quote . $quote, $quote, $pattern );
+		}
+
+		return $pattern;
+	}
+
+	/**
+	 * Build a fallback SHOW VARIABLES result for clients that need server metadata.
+	 *
+	 * @param  string|null $like_pattern Optional SHOW VARIABLES LIKE pattern.
+	 * @return MySQL_Result
+	 */
+	private function get_show_variables_result( $like_pattern ): MySQL_Result {
+		$rows = array();
+
+		foreach ( $this->get_proxy_server_variables() as $name => $value ) {
+			if ( null !== $like_pattern && ! $this->mysql_like_matches( $name, $like_pattern ) ) {
+				continue;
+			}
+
+			$rows[] = (object) array(
+				'Variable_name' => $name,
+				'Value'         => $value,
+			);
+		}
+
+		return MySQL_Result::from_data( 0, 0, $this->get_show_variables_columns(), $rows );
+	}
+
+	/**
+	 * Return the minimal server variables needed by MySQL clients and MTR startup probes.
+	 *
+	 * @return array<string, string>
+	 */
+	private function get_proxy_server_variables(): array {
+		$variables = array(
+			'autocommit'                 => 'ON',
+			'basedir'                    => '',
+			'binlog_format'              => 'ROW',
+			'character_set_client'       => 'utf8mb4',
+			'character_set_connection'   => 'utf8mb4',
+			'character_set_results'      => 'utf8mb4',
+			'character_set_server'       => 'utf8mb4',
+			'collation_connection'       => 'utf8mb4_0900_ai_ci',
+			'collation_server'           => 'utf8mb4_0900_ai_ci',
+			'datadir'                    => '',
+			'default_storage_engine'     => 'InnoDB',
+			'default_tmp_storage_engine' => 'InnoDB',
+			'gtid_mode'                  => 'OFF',
+			'have_ssl'                   => 'NO',
+			'have_symlink'               => 'YES',
+			'hostname'                   => 'localhost',
+			'innodb_page_size'           => '16384',
+			'log_bin'                    => 'OFF',
+			'lower_case_file_system'     => 'OFF',
+			'lower_case_table_names'     => '0',
+			'max_allowed_packet'         => '67108864',
+			'max_connections'            => '151',
+			'performance_schema'         => 'OFF',
+			'port'                       => '0',
+			'protocol_version'           => '10',
+			'read_only'                  => 'OFF',
+			'secure_file_priv'           => '',
+			'server_id'                  => '1',
+			'skip_name_resolve'          => 'OFF',
+			'skip_networking'            => 'OFF',
+			'sql_mode'                   => '',
+			'storage_engine'             => 'InnoDB',
+			'super_read_only'            => 'OFF',
+			'system_time_zone'           => 'UTC',
+			'time_zone'                  => 'SYSTEM',
+			'tmpdir'                     => sys_get_temp_dir(),
+			'version'                    => '8.0.46',
+			'version_comment'            => 'WordPress SQLite Database Integration MySQL proxy',
+			'version_compile_machine'    => 'x86_64',
+			'version_compile_os'         => PHP_OS_FAMILY,
+		);
+
+		ksort( $variables );
+		return $variables;
+	}
+
+	/**
+	 * Return SHOW VARIABLES column definitions.
+	 *
+	 * @return array<int, array<string, int|string>>
+	 */
+	private function get_show_variables_columns(): array {
+		return array(
+			array(
+				'name'     => 'Variable_name',
+				'length'   => 64,
+				'type'     => MySQL_Protocol::FIELD_TYPE_VAR_STRING,
+				'flags'    => 0,
+				'decimals' => 0,
+			),
+			array(
+				'name'     => 'Value',
+				'length'   => 1024,
+				'type'     => MySQL_Protocol::FIELD_TYPE_VAR_STRING,
+				'flags'    => 0,
+				'decimals' => 0,
+			),
+		);
+	}
+
+	/**
+	 * Match MySQL SHOW VARIABLES LIKE patterns.
+	 *
+	 * @param  string $value   Value to compare.
+	 * @param  string $pattern MySQL LIKE pattern.
+	 * @return bool
+	 */
+	private function mysql_like_matches( string $value, string $pattern ): bool {
+		$regex  = '';
+		$length = strlen( $pattern );
+		for ( $i = 0; $i < $length; $i++ ) {
+			$char = $pattern[ $i ];
+			if ( '%' === $char ) {
+				$regex .= '.*';
+			} elseif ( '_' === $char ) {
+				$regex .= '.';
+			} else {
+				$regex .= preg_quote( $char, '/' );
+			}
+		}
+
+		return 1 === preg_match( '/^' . $regex . '$/i', $value );
 	}
 
 	public function computeColumnInfo() {

--- a/packages/mysql-proxy/tests/WP_MySQL_Proxy_SQLite_Adapter_Test.php
+++ b/packages/mysql-proxy/tests/WP_MySQL_Proxy_SQLite_Adapter_Test.php
@@ -1,0 +1,42 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WP_MySQL_Proxy\Adapter\SQLite_Adapter;
+
+class WP_MySQL_Proxy_SQLite_Adapter_Test extends TestCase {
+	public function test_show_variables_fallback_supplies_mysql_server_metadata(): void {
+		$adapter = new SQLite_Adapter( ':memory:', 'test', array( 'mysql' ) );
+
+		$result = $adapter->handle_query( 'SHOW GLOBAL VARIABLES' );
+
+		$this->assertNull( $result->error_info );
+		$this->assertCount( 2, $result->columns );
+
+		$variables = $this->index_variables( $result->rows );
+		$this->assertSame( '8.0.46', $variables['version'] );
+		$this->assertSame( 'InnoDB', $variables['default_storage_engine'] );
+
+		$like_result = $adapter->handle_query( "SHOW GLOBAL VARIABLES LIKE 'version%'" );
+		$like_names  = array_keys( $this->index_variables( $like_result->rows ) );
+
+		$this->assertContains( 'version', $like_names );
+		$this->assertContains( 'version_comment', $like_names );
+		$this->assertNotContains( 'default_storage_engine', $like_names );
+	}
+
+	/**
+	 * Index SHOW VARIABLES rows by variable name.
+	 *
+	 * @param  array<int, object> $rows Result rows.
+	 * @return array<string, string>
+	 */
+	private function index_variables( array $rows ): array {
+		$variables = array();
+
+		foreach ( $rows as $row ) {
+			$variables[ $row->Variable_name ] = $row->Value;
+		}
+
+		return $variables;
+	}
+}


### PR DESCRIPTION
## Summary

This replaces the parser-only direction from the reverted PR with a result-suite workflow that actually executes MySQL server test cases and compares their expected output.

The new workflow downloads Oracle MySQL's 8.0.46 test-suite archive, starts this repository's PHP MySQL proxy backed by the SQLite driver, and runs MySQL's `mysql-test-run.pl` in `--extern` mode against that proxy. That means the CI signal comes from `.test` files and `.result` files, not from the existing `mysql-server-tests-queries.csv` lexer/parser corpus.

## What Runs

- Adds `.github/workflows/mysql-server-result-suite.yml`.
- Runs on every PR, on `trunk` pushes, and by manual dispatch.
- Installs only the lightweight command-line client package with a 5-minute timeout; it no longer installs the large `mariadb-test` package that hung in CI.
- Downloads the MySQL test-suite tarball directly from `cdn.mysql.com` and discovers Oracle's `mysqltest` plus `mysql-test-run.pl` from that archive.
- Builds a temporary client bindir containing Oracle `mysqltest` and the packaged `mysql`/`mysqladmin` clients for MTR.
- Starts `packages/mysql-proxy/bin/wp-mysql-proxy.php` on localhost.
- Runs `mysql-test-run.pl --extern ... --force --parallel=1` so the suite keeps collecting result mismatches instead of stopping after the first failure.

## Proxy Setup

MySQL's test framework expects the default database to be named `test` when running test cases, and its startup probe also connects to the `mysql` schema to read server variables. The proxy previously hard-coded its exposed schema name as `sqlite_database`, so this PR adds:

- `--database-name`, used in CI as `--database-name test`.
- `--database-alias`, used in CI as `--database-alias mysql` so MTR's startup probe can connect.

The existing default remains `sqlite_database` for current users and tests.

## Known Limitations

- This will be much heavier than the old parser/lexer workflow; the timeout is set to 6 hours.
- The job runs the upstream MySQL result suite against the current SQLite-backed proxy, so existing emulation gaps are expected to appear as real failures.
- The MySQL test-suite archive is large, so the download step has a hard timeout and retries instead of relying on an unbounded apt package install.
- The proxy still supports a single logical database. The `mysql` alias is only an alias for MTR compatibility; it does not add real multi-database support.

## Validation

- Parsed `.github/workflows/mysql-server-result-suite.yml` as YAML.
- Ran `bash -n` over every workflow `run:` block in the new file.
- Ran `php -l` on the changed proxy PHP files.
- Ran PHPCS on the changed proxy PHP files.
- Ran `git diff --check` on the workflow and proxy changes.
- Smoke-tested the new proxy database-name path through the adapter: `USE test`, `SELECT DATABASE()`, and `SELECT 1 AS result`.
- Smoke-tested the new proxy alias path through the adapter: `USE mysql` and `USE \`mysql\``.