### PR TITLE
Normalize BIT column default literals

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -5605,7 +5605,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			// Get the UPDATE value. It's either an expression or a DEFAULT keyword.
 			if ( null === $expr ) {
 				// Emulate "column = DEFAULT".
-				$value = null === $default ? 'NULL' : $this->quote_sqlite_value( $default );
+				$value = null === $default ? 'NULL' : $this->format_sqlite_column_default( $column_info );
 			} else {
 				$value = $this->translate( $expr );
 			}
@@ -6317,7 +6317,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 					$default_clause = $this->translate( $expr );
 					$query         .= sprintf( ' DEFAULT (%s)', $default_clause );
 				} else {
-					$query .= ' DEFAULT ' . $this->quote_sqlite_value( $column['COLUMN_DEFAULT'] );
+					$query .= ' DEFAULT ' . $this->format_sqlite_column_default( $column );
 				}
 			}
 			$rows[] = $query;
@@ -6624,7 +6624,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				if ( str_contains( $column['EXTRA'], 'DEFAULT_GENERATED' ) ) {
 					$sql .= sprintf( ' DEFAULT (%s)', $column['COLUMN_DEFAULT'] );
 				} else {
-					$sql .= ' DEFAULT ' . $this->quote_mysql_utf8_string_literal( $column['COLUMN_DEFAULT'] );
+					$sql .= ' DEFAULT ' . $this->format_mysql_column_default( $column );
 				}
 			} elseif ( 'YES' === $column['IS_NULLABLE'] ) {
 				$sql .= ' DEFAULT NULL';
@@ -6836,6 +6836,36 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			$this->quote_sqlite_identifier( $table ),
 			$this->quote_sqlite_identifier( $column )
 		);
+	}
+
+	/**
+	 * Format a column default value as a literal for an SQLite CREATE TABLE statement.
+	 *
+	 * @param  array  $column The information schema column data.
+	 * @return string         The default value as an SQLite literal.
+	 */
+	private function format_sqlite_column_default( array $column ): string {
+		if ( 'bit' === $column['DATA_TYPE'] ) {
+			// BIT defaults are stored as b'...' literals; reformat as an integer.
+			return (string) bindec( substr( $column['COLUMN_DEFAULT'], 2, -1 ) );
+		}
+
+		return $this->quote_sqlite_value( $column['COLUMN_DEFAULT'] );
+	}
+
+	/**
+	 * Format a column default value as a literal for a MySQL SHOW CREATE TABLE statement.
+	 *
+	 * @param  array  $column The information schema column data.
+	 * @return string         The default value as a MySQL literal.
+	 */
+	private function format_mysql_column_default( array $column ): string {
+		// BIT defaults are already stored as b'...' literals.
+		if ( 'bit' === $column['DATA_TYPE'] ) {
+			return $column['COLUMN_DEFAULT'];
+		}
+
+		return $this->quote_mysql_utf8_string_literal( $column['COLUMN_DEFAULT'] );
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-builder.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-builder.php
@@ -1503,13 +1503,14 @@ class WP_SQLite_Information_Schema_Builder {
 	 * @return array                       Column data for the information schema.
 	 */
 	private function extract_column_data( string $table_name, string $column_name, WP_Parser_Node $node, int $position ): array {
-		$default  = $this->get_column_default( $node );
+		list ( $data_type, $column_type ) = $this->get_column_data_types( $node );
+
+		$default  = $this->get_column_default( $node, $data_type );
 		$nullable = $this->get_column_nullable( $node );
 		$key      = $this->get_column_key( $node );
 		$extra    = $this->get_column_extra( $node );
 		$comment  = $this->get_column_comment( $node );
 
-		list ( $data_type, $column_type )    = $this->get_column_data_types( $node );
 		list ( $charset, $collation )        = $this->get_column_charset_and_collation( $node, $data_type );
 		list ( $char_length, $octet_length ) = $this->get_column_lengths( $node, $data_type, $charset );
 		list ( $precision, $scale )          = $this->get_column_numeric_attributes( $node, $data_type );
@@ -2040,10 +2041,11 @@ class WP_SQLite_Information_Schema_Builder {
 	/**
 	 * Extract column default value from the "columnDefinition" or "fieldDefinition" AST node.
 	 *
-	 * @param  WP_Parser_Node $node The "columnDefinition" or "fieldDefinition" AST node.
-	 * @return string               The column default as stored in information schema.
+	 * @param  WP_Parser_Node $node      The "columnDefinition" or "fieldDefinition" AST node.
+	 * @param  string         $data_type The column data type as stored in information schema.
+	 * @return string|null               The column default as stored in information schema.
 	 */
-	private function get_column_default( WP_Parser_Node $node ): ?string {
+	private function get_column_default( WP_Parser_Node $node, string $data_type ): ?string {
 		$default_attr = null;
 		foreach ( $node->get_descendant_nodes( 'columnAttribute' ) as $attr ) {
 			if ( $attr->has_child_token( WP_MySQL_Lexer::DEFAULT_SYMBOL ) ) {
@@ -2073,21 +2075,11 @@ class WP_SQLite_Information_Schema_Builder {
 		$signed_literal = $default_attr->get_first_child_node( 'signedLiteral' );
 		if ( $signed_literal ) {
 			$literal = $signed_literal->get_first_child_node( 'literal' );
-
-			// DEFAULT NULL
-			if ( $literal && $literal->has_child_node( 'nullLiteral' ) ) {
-				return null;
+			if ( null === $literal ) {
+				// A signed number, such as "-5", has no "literal" child node.
+				return $this->get_value( $signed_literal );
 			}
-
-			// DEFAULT TRUE or DEFAULT FALSE
-			if ( $literal && $literal->has_child_node( 'boolLiteral' ) ) {
-				$bool_literal = $literal->get_first_child_node( 'boolLiteral' );
-				return $bool_literal->has_child_token( WP_MySQL_Lexer::TRUE_SYMBOL ) ? '1' : '0';
-			}
-
-			// @TODO: MySQL seems to normalize default values for numeric
-			//        columns, such as 1.0 to 1, 1e3 to 1000, etc.
-			return $this->get_value( $signed_literal );
+			return $this->get_literal_default( $literal, $data_type );
 		}
 
 		// DEFAULT (expression) - MySQL 8.0.13+ supports exprWithParentheses
@@ -2097,6 +2089,74 @@ class WP_SQLite_Information_Schema_Builder {
 		}
 
 		throw new Exception( 'DEFAULT value of this type is not supported.' );
+	}
+
+	/**
+	 * Extract and normalize a literal default value.
+	 *
+	 * @param  WP_Parser_Node $literal   The "literal" AST node.
+	 * @param  string         $data_type The column data type as stored in information schema.
+	 * @return string|null               The default value as stored in information schema.
+	 */
+	private function get_literal_default( WP_Parser_Node $literal, string $data_type ): ?string {
+		// DEFAULT NULL
+		if ( $literal->has_child_node( 'nullLiteral' ) ) {
+			return null;
+		}
+
+		// DEFAULT TRUE or DEFAULT FALSE
+		if ( $literal->has_child_node( 'boolLiteral' ) ) {
+			$bool_literal = $literal->get_first_child_node( 'boolLiteral' );
+			$bool_value   = $bool_literal->has_child_token( WP_MySQL_Lexer::TRUE_SYMBOL ) ? '1' : '0';
+			return 'bit' === $data_type ? "b'{$bool_value}'" : $bool_value;
+		}
+
+		$default = $this->get_value( $literal );
+
+		if ( 'bit' === $data_type ) {
+			return $this->get_bit_default( $default ) ?? $default;
+		}
+
+		/*
+		 * @TODO: Non-BIT literal defaults are currently stored verbatim. To
+		 * match MySQL, they should be normalized. For example:
+		 *  - BINARY/VARBINARY defaults stored as 0x hex literals.
+		 *  - Hex and bit literals coerced to raw bytes for text columns and to
+		 *    their decimal value for numeric columns.
+		 *  - The charset introducer dropped from text-literal defaults.
+		 *  - Numeric defaults normalized, e.g. 1.0 to 1 or 1e3 to 1000.
+		 */
+		return $default;
+	}
+
+	/**
+	 * Normalize a BIT default value to a MySQL bit literal.
+	 *
+	 * The value may be a bit literal, a hex literal, or a decimal.
+	 *
+	 * @param  string      $default_value The BIT default value.
+	 * @return string|null                The default as a bit literal, e.g. "b'101'", or null when not a bit value.
+	 */
+	private function get_bit_default( string $default_value ): ?string {
+		$value = strtolower( $default_value );
+
+		// Bit literal, e.g. b'101' or 0b101.
+		if ( str_starts_with( $value, "b'" ) || str_starts_with( $value, '0b' ) ) {
+			$bits = ltrim( rtrim( substr( $value, 2 ), "'" ), '0' );
+			return "b'" . ( '' === $bits ? '0' : $bits ) . "'";
+		}
+
+		// Hex literal, e.g. x'05' or 0x05.
+		if ( str_starts_with( $value, "x'" ) || str_starts_with( $value, '0x' ) ) {
+			return "b'" . decbin( hexdec( rtrim( substr( $value, 2 ), "'" ) ) ) . "'";
+		}
+
+		// Decimal, e.g. 5, or a numeric string literal such as '0'.
+		if ( is_numeric( $value ) ) {
+			return "b'" . decbin( (int) $value ) . "'";
+		}
+
+		return null;
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
@@ -496,6 +496,11 @@ class WP_SQLite_Information_Schema_Reconstructor {
 		}
 		$mysql_type = strtolower( $mysql_type );
 
+		if ( str_starts_with( $mysql_type, 'bit' ) ) {
+			// BIT columns are stored as INTEGER in SQLite.
+			return "b'" . decbin( (int) $default_value ) . "'";
+		}
+
 		/*
 		 * In MySQL, geometry columns can't have a default value.
 		 *

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -658,6 +658,66 @@ class WP_SQLite_Driver_Tests extends TestCase {
 		);
 	}
 
+	public function testShowCreateTableWithBitDefaultValues(): void {
+		$this->assertQuery(
+			"CREATE TABLE _tmp_bit_defaults (
+				id INT DEFAULT 0,
+				quoted_zero BIT(1) DEFAULT '0',
+				integer_five BIT(4) DEFAULT 5,
+				bit_literal_five BIT(4) DEFAULT b'0101',
+				binary_number_five BIT(4) DEFAULT 0b0101,
+				hex_literal_five BIT(4) DEFAULT x'05',
+				true_literal BIT(4) DEFAULT TRUE,
+				false_literal BIT(4) DEFAULT FALSE
+			)"
+		);
+
+		$this->assertQuery( 'SHOW CREATE TABLE _tmp_bit_defaults;' );
+		$results      = $this->engine->get_query_results();
+		$create_table = $results[0]->{'Create Table'};
+		$this->assertStringContainsString( "`quoted_zero` bit(1) DEFAULT b'0'", $create_table );
+		$this->assertStringContainsString( "`integer_five` bit(4) DEFAULT b'101'", $create_table );
+		$this->assertStringContainsString( "`bit_literal_five` bit(4) DEFAULT b'101'", $create_table );
+		$this->assertStringContainsString( "`binary_number_five` bit(4) DEFAULT b'101'", $create_table );
+		$this->assertStringContainsString( "`hex_literal_five` bit(4) DEFAULT b'101'", $create_table );
+		$this->assertStringContainsString( "`true_literal` bit(4) DEFAULT b'1'", $create_table );
+		$this->assertStringContainsString( "`false_literal` bit(4) DEFAULT b'0'", $create_table );
+
+		$this->assertQuery( 'INSERT INTO _tmp_bit_defaults (id) VALUES (1)' );
+		$this->assertQuery( 'SELECT * FROM _tmp_bit_defaults' );
+		$results = $this->engine->get_query_results();
+		$this->assertEquals(
+			array(
+				(object) array(
+					'id'                 => '1',
+					'quoted_zero'        => '0',
+					'integer_five'       => '5',
+					'bit_literal_five'   => '5',
+					'binary_number_five' => '5',
+					'hex_literal_five'   => '5',
+					'true_literal'       => '1',
+					'false_literal'      => '0',
+				),
+			),
+			$results
+		);
+	}
+
+	public function testUpdateWithBitColumnDefaultValue(): void {
+		$this->assertQuery(
+			"CREATE TABLE _tmp_bit_defaults (
+				id INT,
+				maintenance BIT(4) DEFAULT b'0101'
+			)"
+		);
+
+		$this->assertQuery( 'INSERT INTO _tmp_bit_defaults (id, maintenance) VALUES (1, 0)' );
+		$this->assertQuery( 'UPDATE _tmp_bit_defaults SET maintenance = DEFAULT' );
+		$this->assertQuery( 'SELECT maintenance FROM _tmp_bit_defaults' );
+		$results = $this->engine->get_query_results();
+		$this->assertEquals( array( (object) array( 'maintenance' => '5' ) ), $results );
+	}
+
 	public function testSelectIndexHintForce() {
 		$this->assertQuery( "INSERT INTO _options (option_name) VALUES ('first');" );
 		$result = $this->assertQuery(

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -667,6 +667,7 @@ class WP_SQLite_Driver_Tests extends TestCase {
 				bit_literal_five BIT(4) DEFAULT b'0101',
 				binary_number_five BIT(4) DEFAULT 0b0101,
 				hex_literal_five BIT(4) DEFAULT x'05',
+				hex_number_five BIT(4) DEFAULT 0x05,
 				true_literal BIT(4) DEFAULT TRUE,
 				false_literal BIT(4) DEFAULT FALSE
 			)"
@@ -680,6 +681,7 @@ class WP_SQLite_Driver_Tests extends TestCase {
 		$this->assertStringContainsString( "`bit_literal_five` bit(4) DEFAULT b'101'", $create_table );
 		$this->assertStringContainsString( "`binary_number_five` bit(4) DEFAULT b'101'", $create_table );
 		$this->assertStringContainsString( "`hex_literal_five` bit(4) DEFAULT b'101'", $create_table );
+		$this->assertStringContainsString( "`hex_number_five` bit(4) DEFAULT b'101'", $create_table );
 		$this->assertStringContainsString( "`true_literal` bit(4) DEFAULT b'1'", $create_table );
 		$this->assertStringContainsString( "`false_literal` bit(4) DEFAULT b'0'", $create_table );
 
@@ -695,6 +697,7 @@ class WP_SQLite_Driver_Tests extends TestCase {
 					'bit_literal_five'   => '5',
 					'binary_number_five' => '5',
 					'hex_literal_five'   => '5',
+					'hex_number_five'    => '5',
 					'true_literal'       => '1',
 					'false_literal'      => '0',
 				),

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
@@ -265,6 +265,39 @@ class WP_SQLite_Information_Schema_Reconstructor_Tests extends TestCase {
 		);
 	}
 
+	public function testReconstructBitDefaultValuesFromMysqlDataTypesCache(): void {
+		$connection = $this->engine->get_connection();
+
+		$connection->query( self::CREATE_DATA_TYPES_CACHE_TABLE_SQL );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('t', 'zero', 'bit(1)')" );
+		$connection->query( "INSERT INTO _mysql_data_types_cache (`table`, column_or_index, mysql_type) VALUES ('t', 'five', 'bit(4)')" );
+
+		// BIT columns are stored as INTEGER in SQLite.
+		$connection->query(
+			'
+			CREATE TABLE t (
+				zero INTEGER DEFAULT 0,
+				five INTEGER DEFAULT 5
+			)
+		'
+		);
+
+		$this->reconstructor->ensure_correct_information_schema();
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertSame(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					"  `zero` bit(1) DEFAULT b'0',",
+					"  `five` bit(4) DEFAULT b'101'",
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
+
 	public function testDefaultValueEscaping(): void {
 		$this->engine->get_connection()->query(
 			"


### PR DESCRIPTION
## What

BIT column defaults were stored and rendered incorrectly. A column such as `BIT(1) DEFAULT '0'` (e.g., as produced by Ninja Forms) emitted an invalid `SHOW CREATE TABLE` / dump line:

```sql
`maintenance` bit(1) DEFAULT '0'
```

MySQL does not accept a quoted-string default on a BIT column—the value has to be a bit literal (`b'0'`) or a number (`0`). The invalid output broke dump/restore flows (e.g., Studio → Pressable).

## Fix

Normalize BIT column default literals end to end:

- **Store:** Record BIT defaults in the information schema in a normalized format (`b'...'`).
- **`SHOW CREATE TABLE`:** Emit the stored bit literal verbatim (`bit(1) DEFAULT b'0'`).
- **Internal SQLite DDL / `column = DEFAULT`:** Render the bit literal as the SQLite integer it maps to.
- **Legacy migration:** The information-schema reconstructor converts integer BIT defaults into a bit literal.

## Tests

- `SHOW CREATE TABLE` output **and** the inserted/read-back values for every default form (quoted string, integer, `b'…'`, `0b…`, `x'…'`, `TRUE`, `FALSE`).
- `UPDATE … SET col = DEFAULT` on a BIT column.
- Reconstruction of BIT defaults for legacy databases.
- Full unit suite green; coding standards (PHPCS) pass.
