### PR TITLE
Don't take a write lock for SET statements (fixes "database is locked" on connect)

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -44,6 +44,12 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	const GLOBAL_VARIABLES_TABLE_NAME = self::RESERVED_PREFIX . 'global_variables';
 
 	/**
+	 * Name of the connection-private TEMP table used to build empty result sets
+	 * without acquiring a write lock on the database. See create_result_statement_from_data().
+	 */
+	const EMPTY_RESULT_TABLE_NAME = self::RESERVED_PREFIX . 'empty_result';
+
+	/**
 	 * The name of the SQLite driver version variable.
 	 *
 	 * This internal variable is used to store the latest version of the SQLite
@@ -528,6 +534,14 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	private $is_readonly;
 
 	/**
+	 * Whether the TEMP table backing empty result sets has been created on this
+	 * connection. See create_result_statement_from_data().
+	 *
+	 * @var bool
+	 */
+	private $empty_result_table_ready = false;
+
+	/**
 	 * Type of wrapper transaction that is active for the MySQL query emulation.
 	 *
 	 * Possible values:
@@ -920,6 +934,11 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				if (
 					'selectStatement' === $statement_node->rule_name
 					|| 'showStatement' === $statement_node->rule_name
+					// A SET statement only changes session state (sql_mode, etc.)
+					// and writes nothing to the database, so it must not take a
+					// write lock. Treat it as read-only -> deferred BEGIN instead
+					// of BEGIN IMMEDIATE. (Mirrors the SHOW/DESCRIBE handling.)
+					|| 'setStatement' === $statement_node->rule_name
 				) {
 					$this->is_readonly = true;
 				} elseif ( 'utilityStatement' === $statement_node->rule_name ) {
@@ -7003,10 +7022,29 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		 * This can be done using a noop INSERT statement that modifies no data.
 		 */
 		if ( 0 === count( $columns ) ) {
+			/*
+			 * Build a 0-column statement to represent an empty result set.
+			 *
+			 * A no-op "INSERT ... WHERE FALSE" into a regular table still acquires
+			 * SQLite's write lock, even though it writes nothing. That makes
+			 * no-write statements such as "SET sql_mode = ..." fatal with
+			 * "database is locked" whenever another connection holds the write
+			 * lock. Writing to a connection-private TEMP table uses the temp
+			 * database, which has no shared lock, so it never contends.
+			 */
+			if ( ! $this->empty_result_table_ready ) {
+				$pdo->exec(
+					sprintf(
+						'CREATE TEMP TABLE IF NOT EXISTS %s ( x )',
+						$this->quote_sqlite_identifier( self::EMPTY_RESULT_TABLE_NAME )
+					)
+				);
+				$this->empty_result_table_ready = true;
+			}
 			return $pdo->query(
 				sprintf(
-					'INSERT INTO %s (rowid) SELECT NULL WHERE FALSE',
-					$this->quote_sqlite_identifier( self::GLOBAL_VARIABLES_TABLE_NAME )
+					'INSERT INTO %s ( x ) SELECT NULL WHERE FALSE',
+					$this->quote_sqlite_identifier( self::EMPTY_RESULT_TABLE_NAME )
 				)
 			);
 		}

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -934,10 +934,11 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				if (
 					'selectStatement' === $statement_node->rule_name
 					|| 'showStatement' === $statement_node->rule_name
-					// A SET statement only changes session state (sql_mode, etc.)
-					// and writes nothing to the database, so it must not take a
-					// write lock. Treat it as read-only -> deferred BEGIN instead
-					// of BEGIN IMMEDIATE. (Mirrors the SHOW/DESCRIBE handling.)
+					// Supported SET statements mutate only connection-local driver state
+					// (sql_mode, user variables, etc.) or fail before touching SQLite.
+					// They do not write to the SQLite database, so they must not take a
+					// write lock. Use a deferred BEGIN instead of BEGIN IMMEDIATE.
+					// This mirrors the SHOW/DESCRIBE handling.
 					|| 'setStatement' === $statement_node->rule_name
 				) {
 					$this->is_readonly = true;
@@ -7035,7 +7036,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			if ( ! $this->empty_result_table_ready ) {
 				$pdo->exec(
 					sprintf(
-						'CREATE TEMP TABLE IF NOT EXISTS %s ( x )',
+						'CREATE TEMP TABLE IF NOT EXISTS %s ( placeholder_for_empty_insert )',
 						$this->quote_sqlite_identifier( self::EMPTY_RESULT_TABLE_NAME )
 					)
 				);
@@ -7043,7 +7044,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			}
 			return $pdo->query(
 				sprintf(
-					'INSERT INTO %s ( x ) SELECT NULL WHERE FALSE',
+					'INSERT INTO %s ( placeholder_for_empty_insert ) SELECT NULL WHERE FALSE',
 					$this->quote_sqlite_identifier( self::EMPTY_RESULT_TABLE_NAME )
 				)
 			);

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Concurrency_Tests.php
@@ -97,6 +97,45 @@ class WP_SQLite_Driver_Concurrency_Tests extends TestCase {
 		$this->assertReadOnlyQuerySucceedsUnderWriteLock( 'DESCRIBE t' );
 	}
 
+	public function testSetQueryOpensReadOnlyTransaction(): void {
+		$driver = $this->create_in_memory_driver();
+		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+
+		$driver->query( "SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'" );
+
+		$this->assertSame( 'BEGIN', $driver->get_last_sqlite_queries()[0]['sql'] );
+	}
+
+	public function testSetQuerySucceedsWhileAnotherConnectionHoldsWriteLock(): void {
+		// Connection A: set up the database and hold a write transaction.
+		$conn_a   = new WP_SQLite_Connection( array( 'path' => $this->db_path ) );
+		$driver_a = new WP_SQLite_Driver( $conn_a, 'wp' );
+		$driver_a->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+		$driver_a->query( "INSERT INTO t VALUES (1, 'Alice')" );
+
+		// Simulate another PHP process holding a write transaction.
+		$conn_a->get_pdo()->exec( 'BEGIN IMMEDIATE' );
+
+		try {
+			// Connection B with zero timeout — any lock conflict fails immediately.
+			$conn_b   = new WP_SQLite_Connection(
+				array(
+					'path'    => $this->db_path,
+					'timeout' => 0,
+				)
+			);
+			$driver_b = new WP_SQLite_Driver( $conn_b, 'wp' );
+			$conn_b->get_pdo()->setAttribute( PDO::ATTR_TIMEOUT, 0 );
+
+			// SET writes nothing, so it must not contend for the write lock.
+			$result = $driver_b->query( "SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'" );
+
+			$this->assertSame( 0, $result );
+		} finally {
+			$conn_a->get_pdo()->exec( 'ROLLBACK' );
+		}
+	}
+
 	private function assertReadOnlyQuerySucceedsUnderWriteLock( string $query ): void {
 		// Connection A: set up the database.
 		$conn_a   = new WP_SQLite_Connection( array( 'path' => $this->db_path ) );


### PR DESCRIPTION
Related to STU-1821

## What changed

Every WordPress request runs `SET SESSION sql_mode = …` at bootstrap (via `wpdb::set_sql_mode()`). This statement changes only session state and writes nothing to the database, but the driver acquires an SQLite write lock for it. Under concurrent access, this makes an otherwise read-only request fatal with `database is locked` (`SQLITE_BUSY`) the moment any other connection holds the write lock.

This PR fixes the two places the `SET` path takes a write lock (`WP_PDO_MySQL_On_SQLite`):

1. **The wrapper transaction.** `query()` opens `BEGIN IMMEDIATE` (a RESERVED/write lock) for every non-`SELECT` statement, and `SET` was treated as a write. → `SET` is now detected as read-only, so it opens a deferred `BEGIN` (SHARED) instead — the same treatment `SHOW`/`DESCRIBE` already receive (#361).

2. **The empty-result builder.** `create_result_statement_from_data()` fabricates a 0-column result with a no-op `INSERT … WHERE FALSE` against a regular table. SQLite acquires a write lock for *any* DML, even one that inserts zero rows, so this re-took a write lock right after the wrapper committed. → The 0-column statement is now built with a no-op `INSERT` into a connection-private **`TEMP` table**, whose temp database has no shared lock.

Both changes are required: with only (1), the fatal simply moves from the `BEGIN IMMEDIATE` to the no-op `INSERT`.

## Why

This is a direct follow-up to #361 (which stopped `SELECT`/`SHOW`/`DESCRIBE` from taking write locks and closed #318). `SET` was left on the write path. Because `set_sql_mode()` runs on every connection, the impact is broad: a single slow request holding a write transaction (a background WooCommerce/Jetpack write, an import, a long render on a heavy site) makes every concurrent request fail at connect, not only concurrent writers. SQLite is single-writer by design, but statements that perform no writes should never contend for the write lock.

Journal mode does not address this on its own: it reproduces identically under both `DELETE` and `WAL` (WAL still serialises writers).

## Reproduction

Deterministic, single process, two driver connections to one file:

```php
$path = tempnam( sys_get_temp_dir(), 'sqlite' );
@unlink( $path );

$make = fn() => new WP_SQLite_Driver( new WP_SQLite_Connection( array( 'path' => $path ) ), 'db' );

// Build both connections first, so B's schema setup doesn't run under the lock.
$a = $make();
$a->query( 'CREATE TABLE t ( id INTEGER PRIMARY KEY )' );
$b = $make();
$b->execute_sqlite_query( 'PRAGMA busy_timeout = 1500' ); // fail fast on a lock

// A holds a write lock.
$a->query( 'START TRANSACTION' );
$a->query( 'INSERT INTO t ( id ) VALUES ( 1 )' );

// B runs the connect-time statement. It writes nothing, so it must not block.
$b->query( "SET SESSION sql_mode = 'NO_ENGINE_SUBSTITUTION'" );
// Before this PR: throws "database is locked". After: returns immediately.
```

**Before:** `WP_SQLite_Driver_Exception: … database is locked`, first in `begin_wrapper_transaction()`, or after fixing only (1), in `create_result_statement_from_data()`.

**After:** the `SET` returns immediately while A still holds its write lock.

This also reproduces end-to-end in a multi-worker WordPress install (eg. PHP-FPM with more than one workers) under concurrent requests, where one slow request holding a write transaction makes concurrent page loads fatal at `set_sql_mode`.

## Tests

Two regression tests added to `WP_SQLite_Driver_Concurrency_Tests`:

- `testSetQueryOpensReadOnlyTransaction`: `SET` opens `BEGIN`, not `BEGIN IMMEDIATE`.
- `testSetQuerySucceedsWhileAnotherConnectionHoldsWriteLock`: with another connection holding `BEGIN IMMEDIATE` and `timeout = 0`, `SET` completes instead of throwing `SQLITE_BUSY`.

Both fail on `trunk` and pass with this change.

## Notes / risk

- **The 0-column contract is preserved.** `WP_SQLite_Driver::query()` returns `fetchAll()` when `columnCount() > 0`, otherwise `rowCount()`. The replacement empty-result statement keeps `columnCount() === 0`, so writes and `SET` still return their affected-row count (not an empty array). Verified: running a representative `CREATE`/`INSERT`/`SELECT`/`COUNT`/`UPDATE`/`DELETE`/`SET` sequence produces byte-identical results before and after.
- **Bonus:** real writes (`INSERT`/`UPDATE`/`DELETE`) also fabricate their empty result through this path, which previously meant a second, redundant write-lock acquisition after the real write. That redundant lock is now gone, slightly reducing lock pressure for all writes.
- **Temp-table lifetime.** The `TEMP` table is created once per connection (guarded by a flag); `TEMP` tables live for the connection's lifetime. A reviewer preferring maximum robustness over the micro-optimisation could drop the flag and always issue the idempotent `CREATE TEMP TABLE IF NOT EXISTS`.
