### PR TITLE
Resolve column keys when PDO SQLite lacks SQLITE_ENABLE_COLUMN_METADATA

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -1251,13 +1251,15 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			$name  = $meta['name'];
 			$type  = strtoupper( $meta['sqlite:decl_type'] ?? $meta['native_type'] ?? '' );
 
-			// Without "SQLITE_ENABLE_COLUMN_METADATA", PDO leaves "table" empty,
-			// which would drop the column key flags below. Fall back to the last
-			// SELECT's single source table so the keys still resolve. This is
-			// only a candidate: expression columns (e.g. "COUNT(*)") share that
-			// table name but aren't real columns, so we confirm each one exists
-			// via the information schema lookup before trusting it (see below).
-			if ( ( null === $table || '' === $table ) && null !== $this->last_result_single_table ) {
+			// PDO only includes the "table" key when SQLite was built with
+			// "SQLITE_ENABLE_COLUMN_METADATA"; otherwise the origin table is
+			// unknown and the information schema lookup below (and its column key
+			// flags) would be skipped. When the key is absent, fall back to the
+			// last SELECT's single source table. It's only a candidate - each
+			// column is still confirmed against the information schema, so
+			// expression columns (e.g. "COUNT(*)") don't inherit it.
+			$table_is_known = array_key_exists( 'table', $meta );
+			if ( ! $table_is_known && null !== $this->last_result_single_table ) {
 				$table = $this->last_result_single_table;
 			}
 
@@ -1384,14 +1386,15 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				$mysqli_charsetnr = 63;  // binary
 			}
 
-			// Expose the origin table. Prefer what PDO reported; otherwise use the
-			// single-table fallback, but only for columns confirmed to belong to
-			// that table via the information schema ("$column_info" is set). This
-			// keeps expression columns (e.g. "COUNT(*)") without a spurious table.
-			$pdo_table  = $meta['table'] ?? '';
-			$table_name = '' !== $pdo_table
-				? $pdo_table
-				: ( null !== $column_info ? ( $table ?? '' ) : '' );
+			// Expose the origin table. When PDO reported it, use that verbatim.
+			// Otherwise apply the single-table fallback, but only to columns
+			// confirmed to belong to that table via the information schema
+			// ("$column_info" is set) - so expression columns keep an empty table.
+			if ( $table_is_known ) {
+				$table_name = $meta['table'];
+			} else {
+				$table_name = null !== $column_info ? ( $table ?? '' ) : '';
+			}
 
 			$column_meta[] = array(
 				'native_type'      => $native_type,
@@ -2847,7 +2850,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 
 					// Synthetic result columns; no single source table applies.
 					$this->last_result_single_table = null;
-					$this->last_column_meta          = array(
+					$this->last_column_meta         = array(
 						array(
 							'native_type' => 'STRING',
 							'pdo_type'    => PDO::PARAM_STR,

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -503,6 +503,16 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	private $last_column_meta = array();
 
 	/**
+	 * Source table of the last SELECT, if it read from exactly one base table.
+	 *
+	 * Fallback origin table for "get_last_column_meta()" when PDO doesn't report
+	 * one (SQLite built without "SQLITE_ENABLE_COLUMN_METADATA"). Null otherwise.
+	 *
+	 * @var string|null
+	 */
+	private $last_result_single_table = null;
+
+	/**
 	 * Data for emulating the "FOUND_ROWS()" function.
 	 *
 	 * When "SQL_CALC_FOUND_ROWS" is used, the appropriate value is stored here.
@@ -1241,9 +1251,16 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 			$name  = $meta['name'];
 			$type  = strtoupper( $meta['sqlite:decl_type'] ?? $meta['native_type'] ?? '' );
 
+			// Without "SQLITE_ENABLE_COLUMN_METADATA", PDO leaves "table" empty,
+			// which would drop the column key flags below. Fall back to the last
+			// SELECT's single source table so the keys still resolve.
+			if ( ( null === $table || '' === $table ) && null !== $this->last_result_single_table ) {
+				$table = $this->last_result_single_table;
+			}
+
 			// When table is known, we can get data from the information schema.
 			$column_info = null;
-			if ( null !== $table ) {
+			if ( null !== $table && '' !== $table ) {
 				$table_is_temporary = $this->information_schema_builder->temporary_table_exists( $table );
 				$columns_table      = $this->information_schema_builder->get_table_name( $table_is_temporary, 'columns' );
 				$column_info        = $this->execute_sqlite_query(
@@ -1364,11 +1381,15 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				$mysqli_charsetnr = 63;  // binary
 			}
 
+			// Expose the resolved table (see fallback above) so consumers keying
+			// off the origin table work without "SQLITE_ENABLE_COLUMN_METADATA".
+			$table_name = $table ?? ( $meta['table'] ?? '' );
+
 			$column_meta[] = array(
 				'native_type'      => $native_type,
 				'pdo_type'         => $pdo_type,
 				'flags'            => $flags,
-				'table'            => $meta['table'] ?? '',
+				'table'            => $table_name,
 				'name'             => $meta['name'],
 				'len'              => $len,
 				'precision'        => $precision,
@@ -1379,7 +1400,7 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				 * We'll add the data here for use cases such as "wpdb::get_col_info()".
 				 */
 				'mysqli:orgname'   => $meta['name'],        // TODO: Use correct original name when alias is used.
-				'mysqli:orgtable'  => $meta['table'] ?? '', // TODO: Use correct original name when table alias is used.
+				'mysqli:orgtable'  => $table_name,          // TODO: Use correct original name when table alias is used.
 				'mysqli:db'        => $this->db_name,       // TODO: Use correct DB for queries to information schema.
 				'mysqli:charsetnr' => $mysqli_charsetnr,
 				'mysqli:flags'     => 0,                    // TODO: We can compute correct MySQL flags.
@@ -1894,7 +1915,40 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 		// Store column meta info. This must be done before fetching data, which
 		// seems to erase type information for expressions in the SELECT clause.
 		$this->store_last_column_meta_from_statement( $stmt );
-		$this->last_result_statement = $stmt;
+		$this->last_result_statement    = $stmt;
+		$this->last_result_single_table = $this->get_select_single_table_name( $node );
+	}
+
+	/**
+	 * Get the single base table a SELECT reads from, or null when not exactly
+	 * one (joins, subqueries, derived tables, UNIONs). See
+	 * "$last_result_single_table".
+	 *
+	 * @param  WP_Parser_Node $node The "selectStatement" AST node.
+	 * @return string|null
+	 */
+	private function get_select_single_table_name( WP_Parser_Node $node ): ?string {
+		// A single-table read has exactly one table reference and no subquery.
+		$single_tables = $node->get_descendant_nodes( 'singleTable' );
+		if ( count( $single_tables ) !== 1 ) {
+			return null;
+		}
+		if ( null !== $node->get_first_descendant_node( 'derivedTable' ) ) {
+			return null;
+		}
+
+		$table_ref = $single_tables[0]->get_first_child_node( 'tableRef' );
+		if ( null === $table_ref ) {
+			return null;
+		}
+
+		// Only base tables in the current schema qualify; skip information_schema.
+		$database = $this->get_database_name( $table_ref );
+		if ( 'information_schema' === strtolower( $database ) ) {
+			return null;
+		}
+
+		return $this->unquote_sqlite_identifier( $this->translate( $table_ref ) );
 	}
 
 	/**
@@ -2783,7 +2837,9 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 
 					$sql = $this->get_mysql_create_table_statement( $table_is_temporary, $table_name );
 
-					$this->last_column_meta = array(
+					// Synthetic result columns; no single source table applies.
+					$this->last_result_single_table = null;
+					$this->last_column_meta          = array(
 						array(
 							'native_type' => 'STRING',
 							'pdo_type'    => PDO::PARAM_STR,
@@ -5670,6 +5726,9 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 	 */
 	private function store_last_column_meta_from_statement( PDOStatement $stmt ): void {
 		$this->last_column_meta = array();
+
+		// Clear the fallback; only a single-table SELECT re-sets it.
+		$this->last_result_single_table = null;
 		for ( $i = 0; $i < $stmt->columnCount(); $i++ ) {
 			/*
 			 * Workaround for PHP PDO SQLite bug (#79664) in PHP < 7.3.

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-pdo-mysql-on-sqlite.php
@@ -1253,7 +1253,10 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 
 			// Without "SQLITE_ENABLE_COLUMN_METADATA", PDO leaves "table" empty,
 			// which would drop the column key flags below. Fall back to the last
-			// SELECT's single source table so the keys still resolve.
+			// SELECT's single source table so the keys still resolve. This is
+			// only a candidate: expression columns (e.g. "COUNT(*)") share that
+			// table name but aren't real columns, so we confirm each one exists
+			// via the information schema lookup before trusting it (see below).
 			if ( ( null === $table || '' === $table ) && null !== $this->last_result_single_table ) {
 				$table = $this->last_result_single_table;
 			}
@@ -1381,9 +1384,14 @@ class WP_PDO_MySQL_On_SQLite extends PDO {
 				$mysqli_charsetnr = 63;  // binary
 			}
 
-			// Expose the resolved table (see fallback above) so consumers keying
-			// off the origin table work without "SQLITE_ENABLE_COLUMN_METADATA".
-			$table_name = $table ?? ( $meta['table'] ?? '' );
+			// Expose the origin table. Prefer what PDO reported; otherwise use the
+			// single-table fallback, but only for columns confirmed to belong to
+			// that table via the information schema ("$column_info" is set). This
+			// keeps expression columns (e.g. "COUNT(*)") without a spurious table.
+			$pdo_table  = $meta['table'] ?? '';
+			$table_name = '' !== $pdo_table
+				? $pdo_table
+				: ( null !== $column_info ? ( $table ?? '' ) : '' );
 
 			$column_meta[] = array(
 				'native_type'      => $native_type,

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -52,8 +52,9 @@ class WP_SQLite_Driver_Tests extends TestCase {
 	}
 
 	/**
-	 * Blank out the "table" in the stored PDO column metadata to simulate a
-	 * SQLite library built without "SQLITE_ENABLE_COLUMN_METADATA".
+	 * Remove the "table" key from the stored PDO column metadata to simulate a
+	 * SQLite library built without "SQLITE_ENABLE_COLUMN_METADATA" (which omits
+	 * the key entirely).
 	 */
 	private function stripPdoColumnMetaTable(): void {
 		$driver_prop = new ReflectionProperty( WP_SQLite_Driver::class, 'mysql_on_sqlite_driver' );
@@ -64,7 +65,7 @@ class WP_SQLite_Driver_Tests extends TestCase {
 		$meta_prop->setAccessible( true );
 		$meta = $meta_prop->getValue( $pdo_driver );
 		foreach ( $meta as &$column ) {
-			$column['table'] = '';
+			unset( $column['table'] );
 		}
 		unset( $column );
 		$meta_prop->setValue( $pdo_driver, $meta );

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -51,6 +51,25 @@ class WP_SQLite_Driver_Tests extends TestCase {
 		$this->assertSame( $error_message, $exception->getMessage() );
 	}
 
+	/**
+	 * Blank out the "table" in the stored PDO column metadata to simulate a
+	 * SQLite library built without "SQLITE_ENABLE_COLUMN_METADATA".
+	 */
+	private function stripPdoColumnMetaTable(): void {
+		$driver_prop = new ReflectionProperty( WP_SQLite_Driver::class, 'mysql_on_sqlite_driver' );
+		$driver_prop->setAccessible( true );
+		$pdo_driver = $driver_prop->getValue( $this->engine );
+
+		$meta_prop = new ReflectionProperty( WP_PDO_MySQL_On_SQLite::class, 'last_column_meta' );
+		$meta_prop->setAccessible( true );
+		$meta = $meta_prop->getValue( $pdo_driver );
+		foreach ( $meta as &$column ) {
+			$column['table'] = '';
+		}
+		unset( $column );
+		$meta_prop->setValue( $pdo_driver, $meta );
+	}
+
 	public function testRegexp() {
 		$this->assertQuery(
 			"INSERT INTO _options (option_name, option_value) VALUES ('rss_0123456789abcdef0123456789abcdef', '1');"
@@ -8066,6 +8085,40 @@ END;
 			),
 			$column_info[3]
 		);
+	}
+
+	/**
+	 * When PHP's SQLite is built without "SQLITE_ENABLE_COLUMN_METADATA", PDO
+	 * leaves "getColumnMeta()['table']" empty. The driver should still resolve
+	 * the origin table (and thus the column keys) for a single-table SELECT.
+	 */
+	public function testColumnInfoWithoutPdoColumnMetadata(): void {
+		$this->assertQuery(
+			'CREATE TABLE t (
+				id INT,
+				name TEXT,
+				PRIMARY KEY (id),
+				UNIQUE KEY (name(64))
+			)'
+		);
+
+		$this->assertQuery( 'SELECT * FROM t' );
+		$this->stripPdoColumnMetaTable();
+		$column_info = $this->engine->get_last_column_meta();
+
+		$this->assertSame( 't', $column_info[0]['table'] );
+		$this->assertSame( 't', $column_info[0]['mysqli:orgtable'] );
+		$this->assertContains( 'primary_key', $column_info[0]['flags'] );
+		$this->assertContains( 'unique_key', $column_info[1]['flags'] );
+
+		// A join is ambiguous, so the fallback must stay off: no table, no keys.
+		$this->assertQuery( 'CREATE TABLE t2 (t_id INT, note TEXT)' );
+		$this->assertQuery( 'SELECT t.id, t2.note FROM t JOIN t2 ON t2.t_id = t.id' );
+		$this->stripPdoColumnMetaTable();
+		$column_info = $this->engine->get_last_column_meta();
+
+		$this->assertSame( '', $column_info[0]['table'] );
+		$this->assertNotContains( 'primary_key', $column_info[0]['flags'] );
 	}
 
 	public function testColumnInfoWithConstraints(): void {

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Driver_Tests.php
@@ -52,23 +52,30 @@ class WP_SQLite_Driver_Tests extends TestCase {
 	}
 
 	/**
-	 * Remove the "table" key from the stored PDO column metadata to simulate a
-	 * SQLite library built without "SQLITE_ENABLE_COLUMN_METADATA" (which omits
-	 * the key entirely).
+	 * Set a private property of the inner WP_PDO_MySQL_On_SQLite driver.
+	 *
+	 * @param mixed $value
 	 */
-	private function stripPdoColumnMetaTable(): void {
-		$driver_prop = new ReflectionProperty( WP_SQLite_Driver::class, 'mysql_on_sqlite_driver' );
-		$driver_prop->setAccessible( true );
-		$pdo_driver = $driver_prop->getValue( $this->engine );
+	private function setPdoDriverProperty( string $name, $value ): void {
+		$this->pdoDriverProperty( $name )->setValue( $this->getPdoDriver(), $value );
+	}
 
-		$meta_prop = new ReflectionProperty( WP_PDO_MySQL_On_SQLite::class, 'last_column_meta' );
-		$meta_prop->setAccessible( true );
-		$meta = $meta_prop->getValue( $pdo_driver );
-		foreach ( $meta as &$column ) {
-			unset( $column['table'] );
+	private function getPdoDriver(): WP_PDO_MySQL_On_SQLite {
+		$prop = new ReflectionProperty( WP_SQLite_Driver::class, 'mysql_on_sqlite_driver' );
+		// ReflectionProperty::setAccessible() is a no-op since PHP 8.1 and
+		// deprecated in 8.5; only needed on older versions the suite still tests.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
 		}
-		unset( $column );
-		$meta_prop->setValue( $pdo_driver, $meta );
+		return $prop->getValue( $this->engine );
+	}
+
+	private function pdoDriverProperty( string $name ): ReflectionProperty {
+		$prop = new ReflectionProperty( WP_PDO_MySQL_On_SQLite::class, $name );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prop->setAccessible( true );
+		}
+		return $prop;
 	}
 
 	public function testRegexp() {
@@ -8090,8 +8097,12 @@ END;
 
 	/**
 	 * When PHP's SQLite is built without "SQLITE_ENABLE_COLUMN_METADATA", PDO
-	 * leaves "getColumnMeta()['table']" empty. The driver should still resolve
-	 * the origin table (and thus the column keys) for a single-table SELECT.
+	 * omits the column "table", so the driver can't read the origin table from
+	 * it. For a single-table SELECT it should fall back to that table and still
+	 * resolve the column keys - while leaving expression columns untouched.
+	 *
+	 * The stored column metadata is injected directly so the test doesn't depend
+	 * on how a given PHP/SQLite build populates "getColumnMeta()".
 	 */
 	public function testColumnInfoWithoutPdoColumnMetadata(): void {
 		$this->assertQuery(
@@ -8103,23 +8114,64 @@ END;
 			)'
 		);
 
-		$this->assertQuery( 'SELECT * FROM t' );
-		$this->stripPdoColumnMetaTable();
+		// "id" and "name" are real columns; "cnt" is an expression column. None
+		// carry a "table" (as on a build without SQLITE_ENABLE_COLUMN_METADATA).
+		$this->setColumnMetaForSingleTable(
+			't',
+			array(
+				array(
+					'name'             => 'id',
+					'sqlite:decl_type' => 'INT',
+				),
+				array(
+					'name'             => 'name',
+					'sqlite:decl_type' => 'TEXT',
+				),
+				array(
+					'name'             => 'cnt',
+					'sqlite:decl_type' => 'INTEGER',
+				),
+			)
+		);
 		$column_info = $this->engine->get_last_column_meta();
 
+		// Real columns get the fallback table and their keys.
 		$this->assertSame( 't', $column_info[0]['table'] );
 		$this->assertSame( 't', $column_info[0]['mysqli:orgtable'] );
 		$this->assertContains( 'primary_key', $column_info[0]['flags'] );
 		$this->assertContains( 'unique_key', $column_info[1]['flags'] );
 
-		// A join is ambiguous, so the fallback must stay off: no table, no keys.
-		$this->assertQuery( 'CREATE TABLE t2 (t_id INT, note TEXT)' );
-		$this->assertQuery( 'SELECT t.id, t2.note FROM t JOIN t2 ON t2.t_id = t.id' );
-		$this->stripPdoColumnMetaTable();
+		// The expression column is not in the table, so it keeps an empty table.
+		$this->assertSame( '', $column_info[2]['table'] );
+		$this->assertNotContains( 'primary_key', $column_info[2]['flags'] );
+
+		// With no single source table (e.g. a join), the fallback stays off.
+		$this->setColumnMetaForSingleTable(
+			null,
+			array(
+				array(
+					'name'             => 'id',
+					'sqlite:decl_type' => 'INT',
+				),
+			)
+		);
 		$column_info = $this->engine->get_last_column_meta();
 
 		$this->assertSame( '', $column_info[0]['table'] );
 		$this->assertNotContains( 'primary_key', $column_info[0]['flags'] );
+	}
+
+	/**
+	 * Inject stored column metadata (without a "table" key) plus a single-table
+	 * fallback, to drive get_last_column_meta() deterministically.
+	 *
+	 * @param string|null $single_table Fallback table, or null for none.
+	 * @param array       $columns      Partial column-meta rows; "name" and
+	 *                                  "sqlite:decl_type" are enough.
+	 */
+	private function setColumnMetaForSingleTable( ?string $single_table, array $columns ): void {
+		$this->setPdoDriverProperty( 'last_column_meta', $columns );
+		$this->setPdoDriverProperty( 'last_result_single_table', $single_table );
 	}
 
 	public function testColumnInfoWithConstraints(): void {


### PR DESCRIPTION
## Problem

`get_last_column_meta()` sources each column's origin table from PDO's `PDOStatement::getColumnMeta()['table']`. PDO SQLite only provides that when the SQLite library was built with **`SQLITE_ENABLE_COLUMN_METADATA`**, which is off by default in a standard SQLite build — so on many statically-linked PHP builds the `table` key is absent entirely, breaking two things:

1. The information-schema lookup for `COLUMN_KEY` matches nothing, so columns lose their key flags — even `wp_posts.ID`, a real `PRIMARY KEY`.
2. The returned `table` / `mysqli:orgtable` fields stay empty.

Both matter to consumers. phpMyAdmin's `Sql::resultSetContainsUniqueKey()` returns `false` as soon as a column's `table` is `''` — before it looks at key flags — so browsing any table shows *"Current selection does not contain a unique column. Grid edit, checkbox, Edit, Copy and Delete features are not available."* and inline editing is disabled. It works on PHP built *with* the flag (e.g. WebAssembly builds), which is why it's environment-specific; surfaced in WordPress Studio's native-PHP runtime.

## Fix

The driver already parses each statement into an AST, so it can recover the origin table itself. When a `SELECT` reads from exactly one base table (no joins, subqueries, derived tables, or UNIONs), remember it and use it in `get_last_column_meta()` **when PDO reports no column metadata at all** (the `table` key is absent, as on builds without the flag) — for both the key-flag lookup and the returned `table` / `mysqli:orgtable` fields. Each column is still confirmed against the information schema, so expression columns (e.g. `COUNT(*)`) don't inherit the table.

Conservative by design: multi-table queries leave `table` empty (behavior unchanged, matching how joins are already treated), and when PDO *does* provide column metadata the fallback never fires — so metadata-enabled builds (CI, WebAssembly) are entirely unaffected.

## Testing

Against a real WordPress SQLite DB on PHP **without** `SQLITE_ENABLE_COLUMN_METADATA`, `table` / flags from `get_last_column_meta()`
(before → after):

| Query | Column | `table` | Flags |
| --- | --- | --- | --- |
| `SELECT * FROM wp_posts` | `ID` | `''` → `wp_posts` | `not_null` → `+ primary_key` ✅ |
| `SELECT * FROM wp_options` | `option_id` | `''` → `wp_options` | `not_null` → `+ primary_key` ✅ |
| `SELECT * FROM wp_options` | `option_name` | `''` → `wp_options` | `not_null` → `+ unique_key` ✅ |
| `SELECT ID, COUNT(*) … FROM wp_posts` | `COUNT(*)` | `''` → `''` | unchanged (expression, correct) ✅ |
| `SELECT p.ID … JOIN …` | `ID` | `''` → `''` | unchanged (correct) ✅ |

A single-table `SELECT` right after a `JOIN` still resolves, confirming no stale-state leak. `testColumnInfoWithoutPdoColumnMetadata` covers the flagless path; the full driver suite (366 tests) passes on both flagless and metadata-enabled SQLite builds.

End-to-end: browsing `wp_posts` in phpMyAdmin now yields `hasUnique=true` and the notice is gone.