### PR TITLE
Preserve configured SQLite journal mode in driver wrapper

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-driver.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-driver.php
@@ -71,6 +71,7 @@ class WP_SQLite_Driver {
 			array(
 				'mysql_version' => $mysql_version,
 				'pdo'           => $connection->get_pdo(),
+				'journal_mode'  => $connection->query( 'PRAGMA journal_mode' )->fetchColumn(),
 			)
 		);
 		$this->main_db_name           = $database;

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
@@ -178,6 +178,19 @@ class WP_SQLite_Connection_Tests extends TestCase {
 		);
 	}
 
+	public function testDriverKeepsConfiguredJournalMode(): void {
+		$connection = new WP_SQLite_Connection(
+			array(
+				'path'         => $this->db_path,
+				'journal_mode' => 'DELETE',
+			)
+		);
+
+		$driver = new WP_SQLite_Driver( $connection, 'wp' );
+
+		$this->assertSame( 'delete', $this->get_journal_mode( $driver->get_connection() ) );
+	}
+
 	/**
 	 * Create the database file first, and then make its directory read-only,
 	 * so that the WAL sidecar files ("-wal", "-shm") cannot be created.


### PR DESCRIPTION
## What it does

Preserves the configured SQLite journal mode when `WP_SQLite_Driver` wraps an existing `WP_SQLite_Connection` in `WP_PDO_MySQL_On_SQLite`.

A connection opened with `journal_mode = DELETE` now stays in `DELETE` after the wrapper is created.

## Rationale

`SQLITE_JOURNAL_MODE` was honored by the first WordPress SQLite connection, but the internal wrapper did not receive that setting. It created another `WP_SQLite_Connection` around the same PDO without `journal_mode`, which fell back to the class default:

```php
$journal_mode = $options['journal_mode'] ?? 'WAL';
```

That could silently switch a `DELETE`-mode database back to WAL during the same connection flow.

Related Playground issue: WordPress/wordpress-playground#3883

## Implementation

`WP_SQLite_Driver` now reads the effective mode from the existing connection and forwards it to `WP_PDO_MySQL_On_SQLite`:

```php
'journal_mode' => $connection->query( 'PRAGMA journal_mode' )->fetchColumn(),
```

The regression test creates a file-backed `DELETE` connection, wraps it in `WP_SQLite_Driver`, and verifies the wrapped connection still reports `delete`.

## Testing instructions

```bash
php -n -l packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-driver.php
php -n -l packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
cd packages/mysql-on-sqlite && composer run test -- tests/WP_SQLite_Connection_Tests.php
cd packages/mysql-on-sqlite && composer run test
```

All tests pass locally. PHP emits a startup warning about a missing local `wasmtime.so`, but it does not affect the test run.
