### PR TITLE
Release 3.0.0-rc.7

### DIFF
--- a/packages/mysql-on-sqlite/src/version.php
+++ b/packages/mysql-on-sqlite/src/version.php
@@ -5,4 +5,4 @@
  *
  * This constant needs to be updated on plugin release!
  */
-define( 'SQLITE_DRIVER_VERSION', '3.0.0-rc.6' );
+define( 'SQLITE_DRIVER_VERSION', '3.0.0-rc.7' );

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: SQLite Database Integration
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
- * Version: 3.0.0-rc.6
+ * Version: 3.0.0-rc.7
  * Requires PHP: 7.2
  * Textdomain: sqlite-database-integration
  *

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgic
 Requires at least: 6.4
 Tested up to:      6.9
 Requires PHP:      7.2
-Stable tag:        3.0.0-rc.6
+Stable tag:        3.0.0-rc.7
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, database
@@ -43,6 +43,11 @@ the wpdb API, while queries are internally adapted to be compatible
 with SQLite syntax and behavior.
 
 == Changelog ==
+
+= 3.0.0-rc.7 =
+
+* Preserve configured SQLite journal mode in driver wrapper ([#447](https://github.com/WordPress/sqlite-database-integration/pull/447))
+* Release 3.0.0-rc.6 ([#444](https://github.com/WordPress/sqlite-database-integration/pull/444))
 
 = 3.0.0-rc.6 =
 


### PR DESCRIPTION
## Release `3.0.0-rc.7`

Version bump and changelog update for release `3.0.0-rc.7`.

**Changelog draft:**
* Preserve configured SQLite journal mode in driver wrapper ([#447](https://github.com/WordPress/sqlite-database-integration/pull/447))
* Release 3.0.0-rc.6 ([#444](https://github.com/WordPress/sqlite-database-integration/pull/444))

**Full changelog:** https://github.com/WordPress/sqlite-database-integration/compare/v3.0.0-rc.6...release/v3.0.0-rc.7

## Next steps

1. **Review** the changes in this pull request.
2. **Push** any additional edits to this branch (`release/v3.0.0-rc.7`).
3. **Merge** this pull request to complete the release.

Merging will automatically build the plugin ZIP and create a [GitHub release](https://github.com/WordPress/sqlite-database-integration/releases).

> [!NOTE]
> This is a **pre-release**. It will not be deployed to [WordPress.org](https://wordpress.org/plugins/sqlite-database-integration/).