### PR TITLE
User defined REVERSE() function Unicode support 🎉

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -934,14 +934,19 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	 * Method to emulate MySQL REVERSE() function.
 	 *
 	 * Takes a string and returns the reverse of it.
+	 * Compatible with MySQL behaviour for utf8mb4 strings.
 	 *
-	* @param string|null $str The string to reverse.
-	*
-	* @return string|null reversed string, or NULL.
-	*/
+	 * @param string|null $str The string to reverse.
+	 *
+	 * @return string|null reversed string, or NULL.
+	 */
 	public function reverse( $str ) {
 		if ( null === $str ) {
 			return null;
+		}
+		if ( preg_match( '/[^\x00-\x7F]/', $str ) ) {
+			preg_match_all( '/./u', $str, $matches );
+			return implode( '', array_reverse( $matches[0] ) );
 		}
 		return strrev( $str );
 	}

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -933,8 +933,7 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	/**
 	 * Method to emulate MySQL REVERSE() function.
 	 *
-	 * Takes a string and returns the reverse of it.
-	 * Compatible with MySQL behaviour for utf8mb4 strings.
+	 * Reverse UTF-8 text by code point, matching MySQL behavior.
 	 *
 	 * @param string|null $str The string to reverse.
 	 *
@@ -945,8 +944,12 @@ class WP_SQLite_PDO_User_Defined_Functions {
 			return null;
 		}
 		if ( preg_match( '/[^\x00-\x7F]/', $str ) ) {
-			preg_match_all( '/./u', $str, $matches );
-			return implode( '', array_reverse( $matches[0] ) );
+			if ( function_exists( 'mb_str_split' ) && mb_check_encoding( $str, 'UTF-8' ) ) {
+				return implode( '', array_reverse( mb_str_split( $str ) ) );
+			}
+			if ( preg_match_all( '/./us', $str, $matches ) ) {
+				return implode( '', array_reverse( $matches[0] ) );
+			}
 		}
 		return strrev( $str );
 	}

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -943,13 +943,11 @@ class WP_SQLite_PDO_User_Defined_Functions {
 		if ( null === $str ) {
 			return null;
 		}
-		if ( preg_match( '/[^\x00-\x7F]/', $str ) ) {
-			if ( function_exists( 'mb_str_split' ) && mb_check_encoding( $str, 'UTF-8' ) ) {
-				return implode( '', array_reverse( mb_str_split( $str ) ) );
-			}
-			if ( preg_match_all( '/./us', $str, $matches ) ) {
-				return implode( '', array_reverse( $matches[0] ) );
-			}
+		if (
+			preg_match( '/[^\x00-\x7F]/', $str )
+			&& preg_match_all( '/./us', $str, $matches )
+		) {
+			return implode( '', array_reverse( $matches[0] ) );
 		}
 		return strrev( $str );
 	}

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -12585,6 +12585,14 @@ END;
 		$result = $this->assertQuery( "SELECT REVERSE('aoeuidhtns') AS reversed" );
 		$this->assertSame( 'snthdiueoa', $result[0]->reversed );
 
+		// Unicode reverse.
+		$result = $this->assertQuery( "SELECT REVERSE('Héllö Wörld!') AS reversed" );
+		$this->assertSame( '!dlröW ölléH', $result[0]->reversed );
+
+		// Emoji reverse.
+		$result = $this->assertQuery( "SELECT REVERSE('Text with 😁😂🤣 emoji 🚀') AS reversed" );
+		$this->assertSame( '🚀 ijome 🤣😂😁 htiw txeT', $result[0]->reversed );
+
 		// Empty string.
 		$result = $this->assertQuery( "SELECT REVERSE('') AS reversed" );
 		$this->assertSame( '', $result[0]->reversed );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -12593,6 +12593,10 @@ END;
 		$result = $this->assertQuery( "SELECT REVERSE('Text with 😁😂🤣 emoji 🚀') AS reversed" );
 		$this->assertSame( '🚀 ijome 🤣😂😁 htiw txeT', $result[0]->reversed );
 
+		// Newline reverse.
+		$result = $this->assertQuery( "SELECT REVERSE('Héllö\nWörld!') AS reversed" );
+		$this->assertSame( "!dlröW\nölléH", $result[0]->reversed );
+
 		// Empty string.
 		$result = $this->assertQuery( "SELECT REVERSE('') AS reversed" );
 		$this->assertSame( '', $result[0]->reversed );


### PR DESCRIPTION
As discussed with @JanJakes in pull request #434 I've gone ahead and added the code to support unicode characters while keeping behavior aligned with how mysql reverses a utf8mb4 unicode string, i.e. it correctly reverses multi-byte characters, but fails to preserve the correct order for grapheme clusters / combining characters.

As a practical example: both this implementation and mysql's REVERSE() function will reverse '🧟 🧟‍♂️ 🧟‍♀️' to become '♀‍🧟 ️♂‍🧟 🧟' instead of '🧟‍♀️ 🧟‍♂️ 🧟'.

I've also gone ahead and added a check to enable a fast path with `strrev()` in case all characters are normal ASCII, this improves both speed and prevents additional allocation for arrays.

Finally, I checked to see that
``` php
    preg_match_all( '/./u', $str, $matches );
    return implode( '', array_reverse( $matches[0] ) );
```

is actually about twice as fast as
``` php
    $chars = preg_split( '//u', $str, -1, PREG_SPLIT_NO_EMPTY );
    return implode( '', array_reverse( $chars ) );
```
