### PR TITLE
Stabilize WordPress E2E tests

### DIFF
--- a/tests/e2e/specs/query-monitor-plugin.test.js
+++ b/tests/e2e/specs/query-monitor-plugin.test.js
@@ -25,6 +25,7 @@ test.describe( 'Query Monitor plugin', () => {
 		await admin.visitAdminPage( '/plugins.php' );
 		await page.getByLabel( 'Activate Query Monitor', { exact: true } ).click();
 		await page.getByText( 'Plugin activated.', { exact: true } ).waitFor();
+		await page.reload();
 
 		// Skip this test if QM 4.0+ is not active (no shadow DOM container).
 		const hasContainer = await page.locator( '#query-monitor-container' ).count();
@@ -168,6 +169,7 @@ test.describe( 'Query Monitor plugin', () => {
 		await admin.visitAdminPage( '/plugins.php' );
 		await page.getByLabel( 'Activate Query Monitor', { exact: true } ).click();
 		await page.getByText( 'Plugin activated.', { exact: true } ).waitFor();
+		await page.reload();
 
 		// Skip this test if QM 3.x is not active (has shadow DOM container = QM 4.0+).
 		const hasContainer = await page.locator( '#query-monitor-container' ).count();

--- a/wp-setup.sh
+++ b/wp-setup.sh
@@ -61,7 +61,11 @@ sed -i.bak "s#{SQLITE_PLUGIN}#sqlite-database-integration/load.php#g" "$WP_DIR"/
 echo "Rewriting helper class 'WpdbExposedMethodsForTesting' to extend WP_SQLite_DB..."
 sed -i.bak "s#class WpdbExposedMethodsForTesting extends wpdb {#class WpdbExposedMethodsForTesting extends WP_SQLite_DB {#g" "$WP_DIR"/tests/phpunit/includes/utils.php
 
-# 6. Install dependencies.
+# 6. Make wp-config.php changes immediately visible to E2E tests.
+echo "Disabling the PHP OPcache revalidation delay..."
+printf '\nopcache.revalidate_freq = 0\n' >> "$WP_DIR/tools/local-env/php-config.ini"
+
+# 7. Install dependencies.
 echo "Installing dependencies..."
 npm --prefix "$WP_DIR" install
 npm --prefix "$WP_DIR" run build:dev


### PR DESCRIPTION
## What changed

This PR removes two sources of flakiness from the WordPress E2E test environment. Both changes are confined to test code and configuration; they do not affect the distributed plugin.

- **Query Monitor activation:** Reload the plugins screen after activation so Query Monitor is loaded from the beginning of the request before its admin-bar output is inspected.
- **Runtime configuration changes:** Disable the PHP OPcache revalidation delay so changes that E2E tests make to `wp-config.php` become visible immediately.

## Why

The activation response is generated by a request that began before Query Monitor was active, so its interface is not guaranteed to exist on that page. Separately, OPcache can continue executing a cached `wp-config.php` after a test changes it. These timing differences make otherwise valid E2E assertions depend on request and cache state.
