### PR TITLE
Preserve aliases in UPDATE JOIN translation

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -2147,15 +2147,21 @@ class WP_MySQL_On_SQLite extends PDO {
 						)->fetchAll( PDO::FETCH_COLUMN );
 					}
 
-					$matched_tables          = array_merge( $matched_temporary_tables, $matched_persistent_tables );
-					$matched_aliases         = array_keys(
-						array_filter(
-							$table_alias_map,
-							function ( $data ) use ( $matched_tables ) {
-								return in_array( $data['table_name'], $matched_tables, true );
+					$matched_tables  = array_merge( $matched_temporary_tables, $matched_persistent_tables );
+					$matched_aliases = array();
+					foreach ( $table_alias_map as $alias => $data ) {
+						// Derived tables do not have a table name.
+						if ( null === $data['table_name'] ) {
+							continue;
+						}
+
+						foreach ( $matched_tables as $matched_table ) {
+							if ( 0 === strcasecmp( $data['table_name'], $matched_table ) ) {
+								$matched_aliases[] = $alias;
+								break;
 							}
-						)
-					);
+						}
+					}
 					$updates_multiple_tables = count( $matched_aliases ) > 1;
 					if ( 1 === count( $matched_aliases ) ) {
 						$table_or_alias = $matched_aliases[0];

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -2148,9 +2148,17 @@ class WP_MySQL_On_SQLite extends PDO {
 					}
 
 					$matched_tables          = array_merge( $matched_temporary_tables, $matched_persistent_tables );
-					$updates_multiple_tables = count( $matched_tables ) > 1;
-					if ( 1 === count( $matched_tables ) ) {
-						$table_or_alias = $matched_tables[0];
+					$matched_aliases         = array_keys(
+						array_filter(
+							$table_alias_map,
+							function ( $data ) use ( $matched_tables ) {
+								return in_array( $data['table_name'], $matched_tables, true );
+							}
+						)
+					);
+					$updates_multiple_tables = count( $matched_aliases ) > 1;
+					if ( 1 === count( $matched_aliases ) ) {
+						$table_or_alias = $matched_aliases[0];
 					} else {
 						break;
 					}

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Translation_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Translation_Tests.php
@@ -415,6 +415,70 @@ class WP_MySQL_On_SQLite_Translation_Tests extends TestCase {
 		);
 	}
 
+	public function testUpdateJoinWithDerivedTablePreservesTargetAlias(): void {
+		$sqlite_version = $this->driver->get_sqlite_version();
+		if ( version_compare( $sqlite_version, '3.33.0', '<' ) ) {
+			$this->markTestSkipped(
+				sprintf( "SQLite version %s doesn't support UPDATE with FROM clause.", $sqlite_version )
+			);
+			return;
+		}
+
+		$this->driver->query( 'CREATE TABLE actions (action_id INT, claim_id INT, status TEXT)' );
+		$this->driver->query( "INSERT INTO actions VALUES (1, 0, 'pending'), (2, 0, 'pending'), (3, 0, 'complete'), (4, 0, 'canceled')" );
+
+		$statement = $this->driver->query(
+			"UPDATE actions t1
+			JOIN (
+				SELECT action_id
+				FROM actions
+				WHERE claim_id = 0
+					AND status = 'pending'
+				ORDER BY action_id ASC
+				LIMIT 1
+				FOR UPDATE
+			) t2 ON t1.action_id = t2.action_id
+			SET claim_id = 99"
+		);
+
+		$this->assertSame( 1, $statement->rowCount() );
+		$queries = array_map(
+			function ( $query ) {
+				return trim( preg_replace( '/\s+/', ' ', $query ) );
+			},
+			array_column( $this->driver->get_last_sqlite_queries(), 'sql' )
+		);
+		$this->assertContains(
+			"UPDATE `actions` AS `t1` SET `claim_id` = 99 FROM ( SELECT `action_id` FROM `actions` WHERE `claim_id` = 0 AND `status` = 'pending' ORDER BY `action_id` ASC LIMIT 1 ) AS `t2` WHERE `t1`.`action_id` = `t2`.`action_id`",
+			$queries
+		);
+		$this->assertSame(
+			array(
+				array(
+					'action_id' => '1',
+					'claim_id'  => '99',
+					'status'    => 'pending',
+				),
+			),
+			$this->driver->query( 'SELECT * FROM actions WHERE claim_id = 99' )->fetchAll( PDO::FETCH_ASSOC )
+		);
+		$this->assertSame(
+			array(
+				array(
+					'action_id' => '3',
+					'claim_id'  => '0',
+					'status'    => 'complete',
+				),
+				array(
+					'action_id' => '4',
+					'claim_id'  => '0',
+					'status'    => 'canceled',
+				),
+			),
+			$this->driver->query( "SELECT * FROM actions WHERE status IN ( 'complete', 'canceled' ) ORDER BY action_id" )->fetchAll( PDO::FETCH_ASSOC )
+		);
+	}
+
 	public function testDelete(): void {
 		$this->assertQuery(
 			'DELETE FROM `t`',

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Translation_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Translation_Tests.php
@@ -428,7 +428,7 @@ class WP_MySQL_On_SQLite_Translation_Tests extends TestCase {
 		$this->driver->query( "INSERT INTO actions VALUES (1, 0, 'pending'), (2, 0, 'pending'), (3, 0, 'complete'), (4, 0, 'canceled')" );
 
 		$statement = $this->driver->query(
-			"UPDATE actions t1
+			"UPDATE Actions t1
 			JOIN (
 				SELECT action_id
 				FROM actions
@@ -449,7 +449,7 @@ class WP_MySQL_On_SQLite_Translation_Tests extends TestCase {
 			array_column( $this->driver->get_last_sqlite_queries(), 'sql' )
 		);
 		$this->assertContains(
-			"UPDATE `actions` AS `t1` SET `claim_id` = 99 FROM ( SELECT `action_id` FROM `actions` WHERE `claim_id` = 0 AND `status` = 'pending' ORDER BY `action_id` ASC LIMIT 1 ) AS `t2` WHERE `t1`.`action_id` = `t2`.`action_id`",
+			"UPDATE `Actions` AS `t1` SET `claim_id` = 99 FROM ( SELECT `action_id` FROM `actions` WHERE `claim_id` = 0 AND `status` = 'pending' ORDER BY `action_id` ASC LIMIT 1 ) AS `t2` WHERE `t1`.`action_id` = `t2`.`action_id`",
 			$queries
 		);
 		$this->assertSame(


### PR DESCRIPTION
## Summary
- resolve unqualified UPDATE targets back to their unique source alias
- preserve the target alias and exclude it from SQLite FROM clauses
- cover the Action Scheduler derived-table claim query from #461

## Testing
- composer run test -- --filter WP_MySQL_On_SQLite_Translation_Tests
- composer run test
- composer run check-cs

Fixes #461

## AI assistance
OpenAI model `openai/gpt-5.6-sol` via OpenCode analyzed the generic translator path, implemented the alias-resolution, and drafted the focused PDO regression coverage. Chris Huber reviews and owns the change.