### PR TITLE
Restrict SQLite installation permissions

### DIFF
--- a/.github/workflows/wp-tests-phpunit.yml
+++ b/.github/workflows/wp-tests-phpunit.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Run WordPress PHPUnit tests
         run: node .github/workflows/wp-tests-phpunit-run.js
 
+      - name: Run SQLite plugin single-site PHPUnit tests
+        run: composer run wp-test-plugin-php
+
+      - name: Run SQLite plugin multisite PHPUnit tests
+        run: composer run wp-test-plugin-php-multisite
+
       - name: Stop Docker containers
         if: always()
         run: composer run wp-test-clean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,10 @@ composer run test -- --filter testName  # Run specific unit test class/method
 # SQLite Database Integration plugin E2E tests
 composer run test-e2e                   # Run E2E tests (Playwright via WP env)
 
+# SQLite Database Integration plugin PHPUnit tests
+composer run wp-test-plugin-php          # Run single-site plugin tests
+composer run wp-test-plugin-php-multisite # Run multisite plugin tests
+
 # WordPress tests
 composer run wp-setup                   # Set up WordPress with SQLite for tests
 composer run wp-run                     # Run a WordPress repository command

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ composer run test -- --filter testName  # Run specific unit test class/method
 # SQLite Database Integration plugin E2E tests
 composer run test-e2e                   # Run E2E tests (Playwright via WP env)
 
+# SQLite Database Integration plugin PHPUnit tests
+composer run wp-test-plugin-php          # Run single-site plugin tests
+composer run wp-test-plugin-php-multisite # Run multisite plugin tests
+
 # WordPress tests
 composer run wp-setup                   # Set up WordPress with SQLite for tests
 composer run wp-run                     # Run a WordPress repository command

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,12 @@
 			"rm -rf wordpress/src/wp-content/database/.ht.sqlite @no_additional_args",
 			"npm --prefix wordpress run test:php -- @additional_args"
 		],
+		"wp-test-plugin-php": [
+			"@wp-test-php tests/phpunit/plugin-sqlite-database-integration/authorization.php"
+		],
+		"wp-test-plugin-php-multisite": [
+			"@wp-test-php -c tests/phpunit/multisite.xml tests/phpunit/plugin-sqlite-database-integration/authorization.php"
+		],
 		"wp-test-e2e": [
 			"@wp-test-ensure-env @no_additional_args",
 			"npm --prefix wordpress run test:e2e -- @additional_args"

--- a/packages/plugin-sqlite-database-integration/activate.php
+++ b/packages/plugin-sqlite-database-integration/activate.php
@@ -14,10 +14,15 @@
  * @param string $plugin The plugin basename.
  */
 function sqlite_plugin_activation_redirect( $plugin ) {
-	if ( plugin_basename( SQLITE_MAIN_FILE ) === $plugin ) {
-		if ( wp_safe_redirect( admin_url( 'options-general.php?page=sqlite-integration' ) ) ) {
-			exit;
-		}
+	if (
+		plugin_basename( SQLITE_MAIN_FILE ) !== $plugin
+		|| ! current_user_can( sqlite_plugin_get_manage_capability() )
+	) {
+		return;
+	}
+
+	if ( wp_safe_redirect( admin_url( 'options-general.php?page=sqlite-integration' ) ) ) {
+		exit;
 	}
 }
 add_action( 'activated_plugin', 'sqlite_plugin_activation_redirect' );
@@ -25,7 +30,7 @@ add_action( 'activated_plugin', 'sqlite_plugin_activation_redirect' );
 /**
  * Check the URL to ensure we're on the plugin page,
  * the user has clicked the button to install SQLite,
- * and the nonce is valid.
+ * the user has permission to manage the shared drop-in, and the nonce is valid.
  * If the above conditions are met, run the sqlite_plugin_copy_db_file() function,
  * and redirect to the install screen.
  *
@@ -36,25 +41,29 @@ function sqlite_activation() {
 	if ( isset( $current_screen->base ) && 'settings_page_sqlite-integration' === $current_screen->base ) {
 		return;
 	}
-	if ( isset( $_GET['confirm-install'] ) && wp_verify_nonce( $_GET['_wpnonce'], 'sqlite-install' ) ) {
-
-		// Handle upgrading from the performance-lab plugin.
-		if ( isset( $_GET['upgrade-from-pl'] ) ) {
-			global $wp_filesystem;
-			require_once ABSPATH . '/wp-admin/includes/file.php';
-			// Delete the previous db.php file.
-			$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
-			// Deactivate the performance-lab SQLite module.
-			$pl_option_name = defined( 'PERFLAB_MODULES_SETTING' ) ? PERFLAB_MODULES_SETTING : 'perflab_modules_settings';
-			$pl_option      = get_option( $pl_option_name, array() );
-			unset( $pl_option['database/sqlite'] );
-			update_option( $pl_option_name, $pl_option );
-		}
-		sqlite_plugin_copy_db_file();
-		// WordPress will automatically redirect to the install screen here.
-		wp_redirect( admin_url() );
-		exit;
+	if ( ! isset( $_GET['confirm-install'] ) ) {
+		return;
 	}
+
+	sqlite_plugin_check_manage_capability();
+	check_admin_referer( 'sqlite-install' );
+
+	// Handle upgrading from the performance-lab plugin.
+	if ( isset( $_GET['upgrade-from-pl'] ) ) {
+		global $wp_filesystem;
+		require_once ABSPATH . '/wp-admin/includes/file.php';
+		// Delete the previous db.php file.
+		$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
+		// Deactivate the performance-lab SQLite module.
+		$pl_option_name = defined( 'PERFLAB_MODULES_SETTING' ) ? PERFLAB_MODULES_SETTING : 'perflab_modules_settings';
+		$pl_option      = get_option( $pl_option_name, array() );
+		unset( $pl_option['database/sqlite'] );
+		update_option( $pl_option_name, $pl_option );
+	}
+	sqlite_plugin_copy_db_file();
+	// WordPress will automatically redirect to the install screen here.
+	wp_redirect( admin_url() );
+	exit;
 }
 add_action( 'admin_init', 'sqlite_activation' );
 

--- a/packages/plugin-sqlite-database-integration/admin-page.php
+++ b/packages/plugin-sqlite-database-integration/admin-page.php
@@ -15,7 +15,7 @@ function sqlite_add_admin_menu() {
 	add_options_page(
 		__( 'SQLite integration', 'sqlite-database-integration' ),
 		__( 'SQLite integration', 'sqlite-database-integration' ),
-		'manage_options',
+		sqlite_plugin_get_manage_capability(),
 		'sqlite-integration',
 		'sqlite_integration_admin_screen'
 	);
@@ -26,6 +26,8 @@ add_action( 'admin_menu', 'sqlite_add_admin_menu' );
  * The admin page contents.
  */
 function sqlite_integration_admin_screen() {
+	sqlite_plugin_check_manage_capability();
+
 	$db_dropin_path = WP_CONTENT_DIR . '/db.php';
 
 	/*
@@ -154,6 +156,10 @@ function sqlite_integration_admin_screen() {
 function sqlite_plugin_adminbar_item( $admin_bar ) {
 	global $wpdb;
 
+	if ( is_multisite() && ! current_user_can( sqlite_plugin_get_manage_capability() ) ) {
+		return;
+	}
+
 	if ( defined( 'SQLITE_DB_DROPIN_VERSION' ) && defined( 'DB_ENGINE' ) && 'sqlite' === DB_ENGINE ) {
 		$title = '<span style="color:#46B450;">' . __( 'Database: SQLite', 'sqlite-database-integration' ) . '</span>';
 	} elseif ( stripos( $wpdb->db_server_info(), 'maria' ) !== false ) {
@@ -172,3 +178,32 @@ function sqlite_plugin_adminbar_item( $admin_bar ) {
 	$admin_bar->add_node( $args );
 }
 add_action( 'admin_bar_menu', 'sqlite_plugin_adminbar_item', 999 );
+
+/**
+ * Stop users who cannot manage the SQLite integration.
+ *
+ * @since n.e.x.t
+ */
+function sqlite_plugin_check_manage_capability() {
+	if ( ! current_user_can( sqlite_plugin_get_manage_capability() ) ) {
+		wp_die(
+			esc_html__( 'Sorry, you are not allowed to manage the SQLite integration.', 'sqlite-database-integration' ),
+			'',
+			403
+		);
+	}
+}
+
+/**
+ * Get the capability required to manage the SQLite integration.
+ *
+ * The database drop-in is shared by every site in a multisite network, so only
+ * users who can manage network options may change it.
+ *
+ * @since n.e.x.t
+ *
+ * @return string Required capability.
+ */
+function sqlite_plugin_get_manage_capability() {
+	return is_multisite() ? 'manage_network_options' : 'manage_options';
+}

--- a/tests/phpunit/authorization.php
+++ b/tests/phpunit/authorization.php
@@ -1,0 +1,434 @@
+<?php
+/**
+ * SQLite Database Integration authorization tests.
+ *
+ * @package wp-sqlite-integration
+ */
+
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+require_once ABSPATH . 'wp-content/plugins/sqlite-database-integration/load.php';
+
+/**
+ * Tests the permissions protecting the SQLite database drop-in.
+ *
+ * @group sqlite-database-integration
+ */
+class Tests_SQLite_Database_Integration_Authorization extends WP_UnitTestCase {
+
+	/**
+	 * Subsite used by multisite tests.
+	 *
+	 * @var int
+	 */
+	private static $site_id;
+
+	/**
+	 * Subsite administrator used by multisite tests.
+	 *
+	 * @var int
+	 */
+	private static $subsite_admin_id;
+
+	/**
+	 * Super administrator used by multisite tests.
+	 *
+	 * @var int
+	 */
+	private static $super_admin_id;
+
+	/**
+	 * Create multisite fixtures outside per-test database transactions.
+	 *
+	 * @param WP_UnitTest_Factory $factory Test fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		self::$subsite_admin_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$site_id          = $factory->blog->create(
+			array(
+				'path'    => '/sqlite-authorization/',
+				'user_id' => self::$subsite_admin_id,
+			)
+		);
+		self::$super_admin_id   = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		add_user_to_blog( self::$site_id, self::$super_admin_id, 'administrator' );
+		grant_super_admin( self::$super_admin_id );
+	}
+
+	/**
+	 * Remove multisite fixtures.
+	 */
+	public static function wpTearDownAfterClass() {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		revoke_super_admin( self::$super_admin_id );
+		wp_delete_site( self::$site_id );
+	}
+
+	/**
+	 * Verify that the required capability follows the scope of the drop-in.
+	 */
+	public function test_manage_capability_matches_installation_scope() {
+		$expected = is_multisite() ? 'manage_network_options' : 'manage_options';
+
+		$this->assertSame( $expected, sqlite_plugin_get_manage_capability() );
+	}
+
+	/**
+	 * Verify that a single-site administrator can access the settings page.
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_single_site_administrator_can_access_admin_page() {
+		$this->set_single_site_user( 'administrator' );
+		$this->reset_admin_menu();
+
+		sqlite_add_admin_menu();
+
+		$this->assertSame( 10, has_action( 'settings_page_sqlite-integration', 'sqlite_integration_admin_screen' ) );
+		$this->assert_admin_screen_is_accessible();
+	}
+
+	/**
+	 * Verify that the existing single-site admin-bar behavior is preserved.
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_single_site_admin_bar_item_remains_visible_to_subscribers() {
+		$this->set_single_site_user( 'subscriber' );
+		$admin_bar = new WP_Admin_Bar();
+
+		sqlite_plugin_adminbar_item( $admin_bar );
+
+		$this->assertNotNull( $admin_bar->get_node( 'sqlite-db-integration' ) );
+	}
+
+	/**
+	 * Verify that a single-site administrator is redirected after activation.
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_single_site_administrator_is_redirected_after_activation() {
+		$this->set_single_site_user( 'administrator' );
+
+		$this->assertSame(
+			admin_url( 'options-general.php?page=sqlite-integration' ),
+			$this->get_activation_redirect( plugin_basename( SQLITE_MAIN_FILE ) )
+		);
+	}
+
+	/**
+	 * Verify that activating another plugin does not trigger the redirect.
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_other_plugin_activation_does_not_redirect() {
+		$this->set_single_site_user( 'administrator' );
+
+		$this->assertNull( $this->get_activation_redirect( 'another-plugin/plugin.php' ) );
+	}
+
+	/**
+	 * Verify that a single-site administrator can submit a valid install nonce.
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_single_site_administrator_with_valid_nonce_reaches_install_redirect() {
+		$this->set_single_site_user( 'administrator' );
+
+		$this->assert_valid_nonce_reaches_install_redirect();
+	}
+
+	/**
+	 * Verify that a single-site administrator still needs a valid nonce.
+	 *
+	 * @group ms-excluded
+	 */
+	public function test_single_site_administrator_with_invalid_nonce_is_denied() {
+		$this->set_single_site_user( 'administrator' );
+
+		$this->assert_invalid_nonce_is_denied();
+	}
+
+	/**
+	 * Verify that a subsite administrator cannot register the settings page.
+	 *
+	 * @group ms-required
+	 */
+	public function test_subsite_administrator_cannot_register_admin_page() {
+		$this->set_multisite_user( false );
+		$this->reset_admin_menu();
+
+		sqlite_add_admin_menu();
+
+		$this->assertFalse( has_action( 'settings_page_sqlite-integration', 'sqlite_integration_admin_screen' ) );
+		$this->assertTrue( $GLOBALS['_wp_submenu_nopriv']['options-general.php']['sqlite-integration'] );
+	}
+
+	/**
+	 * Verify that a direct page callback cannot expose an install nonce.
+	 *
+	 * @group ms-required
+	 */
+	public function test_subsite_administrator_cannot_render_admin_page() {
+		$this->set_multisite_user( false );
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionCode( 403 );
+
+		sqlite_integration_admin_screen();
+	}
+
+	/**
+	 * Verify that a subsite administrator does not see the admin-bar item.
+	 *
+	 * @group ms-required
+	 */
+	public function test_subsite_administrator_does_not_see_admin_bar_item() {
+		$this->set_multisite_user( false );
+		$admin_bar = new WP_Admin_Bar();
+
+		sqlite_plugin_adminbar_item( $admin_bar );
+
+		$this->assertNull( $admin_bar->get_node( 'sqlite-db-integration' ) );
+	}
+
+	/**
+	 * Verify that activation does not redirect a subsite administrator to a forbidden page.
+	 *
+	 * @group ms-required
+	 */
+	public function test_subsite_administrator_is_not_redirected_after_activation() {
+		$this->set_multisite_user( false );
+
+		$this->assertNull( $this->get_activation_redirect( plugin_basename( SQLITE_MAIN_FILE ) ) );
+	}
+
+	/**
+	 * Verify that a valid nonce cannot replace authorization.
+	 *
+	 * @group ms-required
+	 */
+	public function test_subsite_administrator_with_valid_nonce_cannot_install_dropin() {
+		$this->set_multisite_user( false );
+
+		$dropin_before = file_get_contents( WP_CONTENT_DIR . '/db.php' );
+		$nonce         = wp_create_nonce( 'sqlite-install' );
+		$nonce_checked = false;
+
+		$this->assertNotFalse( wp_verify_nonce( $nonce, 'sqlite-install' ) );
+
+		add_action(
+			'check_admin_referer',
+			function () use ( &$nonce_checked ) {
+				$nonce_checked = true;
+			}
+		);
+		$this->set_install_request( $nonce );
+
+		try {
+			sqlite_activation();
+			$this->fail( 'The install request was not denied.' );
+		} catch ( WPDieException $exception ) {
+			$this->assertSame( 403, $exception->getCode() );
+		}
+
+		$this->assertFalse( $nonce_checked, 'The capability check must run before nonce validation.' );
+		$this->assertSame( $dropin_before, file_get_contents( WP_CONTENT_DIR . '/db.php' ) );
+	}
+
+	/**
+	 * Verify that a multisite super administrator can access the settings page.
+	 *
+	 * @group ms-required
+	 */
+	public function test_multisite_super_administrator_can_access_admin_page() {
+		$this->set_multisite_user( true );
+		$this->reset_admin_menu();
+
+		sqlite_add_admin_menu();
+
+		$this->assertSame( 10, has_action( 'settings_page_sqlite-integration', 'sqlite_integration_admin_screen' ) );
+		$this->assert_admin_screen_is_accessible();
+	}
+
+	/**
+	 * Verify that a multisite super administrator sees the admin-bar item.
+	 *
+	 * @group ms-required
+	 */
+	public function test_multisite_super_administrator_sees_admin_bar_item() {
+		$this->set_multisite_user( true );
+		$admin_bar = new WP_Admin_Bar();
+
+		sqlite_plugin_adminbar_item( $admin_bar );
+
+		$this->assertNotNull( $admin_bar->get_node( 'sqlite-db-integration' ) );
+	}
+
+	/**
+	 * Verify that a multisite super administrator is redirected after activation.
+	 *
+	 * @group ms-required
+	 */
+	public function test_multisite_super_administrator_is_redirected_after_activation() {
+		$this->set_multisite_user( true );
+
+		$this->assertSame(
+			admin_url( 'options-general.php?page=sqlite-integration' ),
+			$this->get_activation_redirect( plugin_basename( SQLITE_MAIN_FILE ) )
+		);
+	}
+
+	/**
+	 * Verify that a multisite super administrator can submit a valid nonce.
+	 *
+	 * @group ms-required
+	 */
+	public function test_multisite_super_administrator_with_valid_nonce_reaches_install_redirect() {
+		$this->set_multisite_user( true );
+
+		$this->assert_valid_nonce_reaches_install_redirect();
+	}
+
+	/**
+	 * Verify that a multisite super administrator still needs a valid nonce.
+	 *
+	 * @group ms-required
+	 */
+	public function test_multisite_super_administrator_with_invalid_nonce_is_denied() {
+		$this->set_multisite_user( true );
+
+		$this->assert_invalid_nonce_is_denied();
+	}
+
+	/**
+	 * Set the current user on a single-site installation.
+	 *
+	 * @param string $role User role.
+	 */
+	private function set_single_site_user( $role ) {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
+
+		wp_set_current_user( $user_id );
+	}
+
+	/**
+	 * Set the current user as an administrator of a subsite.
+	 *
+	 * @param bool $is_super_admin Whether to make the user a super administrator.
+	 */
+	private function set_multisite_user( $is_super_admin ) {
+		$user_id = $is_super_admin ? self::$super_admin_id : self::$subsite_admin_id;
+
+		switch_to_blog( self::$site_id );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( current_user_can( 'manage_options' ) );
+		$this->assertSame( $is_super_admin, current_user_can( 'manage_network_options' ) );
+	}
+
+	/**
+	 * Reset the globals used to register admin pages.
+	 */
+	private function reset_admin_menu() {
+		$GLOBALS['menu']                 = array();
+		$GLOBALS['submenu']              = array();
+		$GLOBALS['_wp_submenu_nopriv']   = array();
+		$GLOBALS['_registered_pages']    = array();
+		$GLOBALS['_parent_pages']        = array();
+		$GLOBALS['admin_page_hooks']     = array( 'options-general.php' => 'settings' );
+		$GLOBALS['_wp_real_parent_file'] = array();
+	}
+
+	/**
+	 * Get the redirect triggered by a plugin activation.
+	 *
+	 * @param string $plugin Plugin basename.
+	 * @return string|null Redirect URL, or null when no redirect was attempted.
+	 */
+	private function get_activation_redirect( $plugin ) {
+		$redirect_url = null;
+		$filter       = function ( $location ) use ( &$redirect_url ) {
+			$redirect_url = $location;
+			return false;
+		};
+
+		add_filter( 'wp_redirect', $filter );
+		sqlite_plugin_activation_redirect( $plugin );
+		remove_filter( 'wp_redirect', $filter );
+
+		return $redirect_url;
+	}
+
+	/**
+	 * Assert that the settings page renders for the current user.
+	 */
+	private function assert_admin_screen_is_accessible() {
+		ob_start();
+		sqlite_integration_admin_screen();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'SQLite is enabled.', $output );
+	}
+
+	/**
+	 * Assert that a valid install request reaches the redirect.
+	 */
+	private function assert_valid_nonce_reaches_install_redirect() {
+		$nonce        = wp_create_nonce( 'sqlite-install' );
+		$redirect_url = null;
+
+		$this->set_install_request( $nonce );
+		add_filter(
+			'wp_redirect',
+			function ( $location ) use ( &$redirect_url ) {
+				$redirect_url = $location;
+				throw new RuntimeException( 'Install redirect reached.' );
+			}
+		);
+
+		try {
+			sqlite_activation();
+			$this->fail( 'The install request did not redirect.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Install redirect reached.', $exception->getMessage() );
+		}
+
+		$this->assertSame( admin_url(), $redirect_url );
+	}
+
+	/**
+	 * Assert that an invalid install nonce is rejected.
+	 */
+	private function assert_invalid_nonce_is_denied() {
+		$this->set_install_request( 'invalid' );
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionMessage( 'The link you followed has expired.' );
+		$this->expectExceptionCode( 403 );
+
+		sqlite_activation();
+	}
+
+	/**
+	 * Populate an SQLite install request.
+	 *
+	 * @param string $nonce Install nonce.
+	 */
+	private function set_install_request( $nonce ) {
+		$_GET = array(
+			'confirm-install' => '1',
+			'_wpnonce'        => $nonce,
+		);
+
+		$_REQUEST = $_GET;
+	}
+}

--- a/wp-setup.sh
+++ b/wp-setup.sh
@@ -41,6 +41,7 @@ services:
     volumes:
       - ../packages/plugin-sqlite-database-integration:/var/www/src/wp-content/plugins/sqlite-database-integration
       - ../packages/mysql-on-sqlite/src:/var/www/src/wp-content/plugins/sqlite-database-integration/wp-includes/database
+      - ../tests/phpunit:/var/www/tests/phpunit/plugin-sqlite-database-integration
 
   cli:
     # PHP temporarily pinned to 8.3.10, see: https://github.com/WordPress/wordpress-develop/pull/9602


### PR DESCRIPTION
## Summary

- Require `manage_network_options` to manage the shared SQLite drop-in on multisite while preserving `manage_options` behavior on single-site installations.
- Protect the settings UI, admin-bar link, installation request, and post-activation redirect with the same capability.
- Keep permitted multisite plugin activation from redirecting site administrators to a forbidden settings page.
- Add dedicated single-site and multisite PHPUnit coverage and CI jobs for the authorization behavior.

## Why

The `db.php` drop-in is shared across an entire multisite network. A subsite administrator must not be able to replace it, even when multisite plugin activation is enabled for site administrators.

The activation redirect also needs to follow the settings page capability. Otherwise, a site administrator can successfully activate the plugin but finish the request on a 403 page.

## Testing

- `composer run check-cs`
- `composer run wp-test-plugin-php` — 7 tests, 11 assertions
- `composer run wp-test-plugin-php-multisite` — 11 tests, 40 assertions

The full wrapped WordPress 7.0.1 suite was also run locally. It currently reports one error and 47 failures in unrelated existing Site Health, database/charset, and menu compatibility tests; the first failure reproduces independently in `Tests_Admin_wpSiteHealth::test_object_cache_thresholds`.
