### PR TITLE
Restrict SQLite installation permissions

### DIFF
--- a/.github/workflows/sqlite-plugin-phpunit-tests.yml
+++ b/.github/workflows/sqlite-plugin-phpunit-tests.yml
@@ -1,0 +1,45 @@
+name: SQLite Plugin PHPUnit Tests
+
+on:
+  push:
+    branches:
+      - trunk
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+  test:
+    name: SQLite Plugin PHPUnit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # Required to clone the repo.
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set UID and GID for PHP in WordPress images
+        run: |
+          echo "PHP_FPM_UID=$(id -u)" >> $GITHUB_ENV
+          echo "PHP_FPM_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Run SQLite plugin single-site PHPUnit tests
+        run: composer run wp-test-sqlite-plugin-php
+
+      - name: Run SQLite plugin multisite PHPUnit tests
+        run: composer run wp-test-sqlite-plugin-php-multisite
+
+      - name: Stop Docker containers
+        if: always()
+        run: composer run wp-test-clean

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,10 @@ composer run test                       # Run unit tests
 composer run test tests/SomeTest.php    # Run specific unit test file
 composer run test -- --filter testName  # Run specific unit test class/method
 
+# SQLite Database Integration plugin PHPUnit tests
+composer run wp-test-sqlite-plugin-php           # Run single-site plugin tests
+composer run wp-test-sqlite-plugin-php-multisite # Run multisite plugin tests
+
 # SQLite Database Integration plugin E2E tests
 composer run test-e2e                   # Run E2E tests (Playwright via WP env)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ composer run test                       # Run unit tests
 composer run test tests/SomeTest.php    # Run specific unit test file
 composer run test -- --filter testName  # Run specific unit test class/method
 
+# SQLite Database Integration plugin PHPUnit tests
+composer run wp-test-sqlite-plugin-php           # Run single-site plugin tests
+composer run wp-test-sqlite-plugin-php-multisite # Run multisite plugin tests
+
 # SQLite Database Integration plugin E2E tests
 composer run test-e2e                   # Run E2E tests (Playwright via WP env)
 

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,12 @@
 			"rm -rf wordpress/src/wp-content/database/.ht.sqlite @no_additional_args",
 			"npm --prefix wordpress run test:php -- @additional_args"
 		],
+		"wp-test-sqlite-plugin-php": [
+			"@wp-test-php /var/www/tests-sqlite-database-integration/phpunit"
+		],
+		"wp-test-sqlite-plugin-php-multisite": [
+			"@wp-test-php -c tests/phpunit/multisite.xml /var/www/tests-sqlite-database-integration/phpunit"
+		],
 		"wp-test-e2e": [
 			"@wp-test-ensure-env @no_additional_args",
 			"npm --prefix wordpress run test:e2e -- @additional_args"

--- a/packages/plugin-sqlite-database-integration/activate.php
+++ b/packages/plugin-sqlite-database-integration/activate.php
@@ -14,10 +14,15 @@
  * @param string $plugin The plugin basename.
  */
 function sqlite_plugin_activation_redirect( $plugin ) {
-	if ( plugin_basename( SQLITE_MAIN_FILE ) === $plugin ) {
-		if ( wp_safe_redirect( sqlite_plugin_get_admin_page_url() ) ) {
-			exit;
-		}
+	if (
+		plugin_basename( SQLITE_MAIN_FILE ) !== $plugin
+		|| ! current_user_can( sqlite_plugin_get_manage_capability() )
+	) {
+		return;
+	}
+
+	if ( wp_safe_redirect( sqlite_plugin_get_admin_page_url() ) ) {
+		exit;
 	}
 }
 add_action( 'activated_plugin', 'sqlite_plugin_activation_redirect' );
@@ -25,36 +30,47 @@ add_action( 'activated_plugin', 'sqlite_plugin_activation_redirect' );
 /**
  * Check the URL to ensure we're on the plugin page,
  * the user has clicked the button to install SQLite,
- * and the nonce is valid.
+ * the user has permission to manage the database drop-in, and the nonce is valid.
  * If the above conditions are met, run the sqlite_plugin_copy_db_file() function,
  * and redirect to the install screen.
  *
  * @since 1.0.0
  */
 function sqlite_activation() {
-	global $current_screen;
-	if ( isset( $current_screen->base ) && 'settings_page_sqlite-integration' === $current_screen->base ) {
+	if (
+		! isset( $_GET['page'], $_GET['confirm-install'] )
+		|| 'sqlite-integration' !== $_GET['page']
+	) {
 		return;
 	}
-	if ( isset( $_GET['confirm-install'] ) && wp_verify_nonce( $_GET['_wpnonce'], 'sqlite-install' ) ) {
 
-		// Handle upgrading from the performance-lab plugin.
-		if ( isset( $_GET['upgrade-from-pl'] ) ) {
-			global $wp_filesystem;
-			require_once ABSPATH . '/wp-admin/includes/file.php';
-			// Delete the previous db.php file.
-			$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
-			// Deactivate the performance-lab SQLite module.
-			$pl_option_name = defined( 'PERFLAB_MODULES_SETTING' ) ? PERFLAB_MODULES_SETTING : 'perflab_modules_settings';
-			$pl_option      = get_option( $pl_option_name, array() );
-			unset( $pl_option['database/sqlite'] );
-			update_option( $pl_option_name, $pl_option );
-		}
-		sqlite_plugin_copy_db_file();
-		// WordPress will automatically redirect to the install screen here.
-		wp_redirect( admin_url() );
-		exit;
+	if ( ! current_user_can( sqlite_plugin_get_manage_capability() ) ) {
+		wp_die(
+			esc_html__( 'Sorry, you are not allowed to install the SQLite database drop-in.', 'sqlite-database-integration' ),
+			403
+		);
 	}
+
+	check_admin_referer( 'sqlite-install' );
+
+	// Handle upgrading from the performance-lab plugin.
+	if ( isset( $_GET['upgrade-from-pl'] ) ) {
+		global $wp_filesystem;
+		require_once ABSPATH . '/wp-admin/includes/file.php';
+		// Delete the previous db.php file.
+		$wp_filesystem->delete( WP_CONTENT_DIR . '/db.php' );
+		// Deactivate the performance-lab SQLite module.
+		$pl_option_name = defined( 'PERFLAB_MODULES_SETTING' ) ? PERFLAB_MODULES_SETTING : 'perflab_modules_settings';
+		$pl_option      = get_option( $pl_option_name, array() );
+		unset( $pl_option['database/sqlite'] );
+		update_option( $pl_option_name, $pl_option );
+	}
+
+	sqlite_plugin_copy_db_file();
+
+	// WordPress will automatically redirect to the install screen here.
+	wp_redirect( admin_url() );
+	exit;
 }
 add_action( 'admin_init', 'sqlite_activation' );
 

--- a/packages/plugin-sqlite-database-integration/activate.php
+++ b/packages/plugin-sqlite-database-integration/activate.php
@@ -15,7 +15,7 @@
  */
 function sqlite_plugin_activation_redirect( $plugin ) {
 	if ( plugin_basename( SQLITE_MAIN_FILE ) === $plugin ) {
-		if ( wp_safe_redirect( admin_url( 'options-general.php?page=sqlite-integration' ) ) ) {
+		if ( wp_safe_redirect( sqlite_plugin_get_admin_page_url() ) ) {
 			exit;
 		}
 	}

--- a/packages/plugin-sqlite-database-integration/admin-notices.php
+++ b/packages/plugin-sqlite-database-integration/admin-notices.php
@@ -12,6 +12,9 @@
  * When the plugin gets merged in wp-core, this is not to be ported.
  */
 function sqlite_plugin_admin_notice() {
+	if ( ! current_user_can( sqlite_plugin_get_manage_capability() ) ) {
+		return;
+	}
 
 	// Don't print notices in the plugin's admin screen.
 	global $current_screen;

--- a/packages/plugin-sqlite-database-integration/admin-notices.php
+++ b/packages/plugin-sqlite-database-integration/admin-notices.php
@@ -66,11 +66,11 @@ function sqlite_plugin_admin_notice() {
 			/* translators: 1: db.php drop-in path, 2: Admin URL to deactivate the module */
 			__( 'The SQLite Integration plugin is active, but the %1$s file is missing. Please <a href="%2$s">deactivate the plugin</a> and re-activate it to try again.', 'sqlite-database-integration' ),
 			'<code>' . esc_html( basename( WP_CONTENT_DIR ) ) . '/db.php</code>',
-			esc_url( admin_url( 'plugins.php' ) )
+			esc_url( self_admin_url( 'plugins.php' ) )
 		)
 	);
 }
-add_action( 'admin_notices', 'sqlite_plugin_admin_notice' ); // Add the admin notices.
+add_action( is_multisite() ? 'network_admin_notices' : 'admin_notices', 'sqlite_plugin_admin_notice' ); // Add the admin notices.
 
 // Remove the PL-plugin admin notices for SQLite.
 remove_action( 'admin_notices', 'perflab_sqlite_plugin_admin_notice' );

--- a/packages/plugin-sqlite-database-integration/admin-page.php
+++ b/packages/plugin-sqlite-database-integration/admin-page.php
@@ -12,15 +12,19 @@
  * @since 1.0.0
  */
 function sqlite_add_admin_menu() {
-	add_options_page(
+	$parent_slug = is_multisite() ? 'settings.php' : 'options-general.php';
+	$capability  = is_multisite() ? 'manage_network_options' : 'manage_options';
+
+	add_submenu_page(
+		$parent_slug,
 		__( 'SQLite integration', 'sqlite-database-integration' ),
 		__( 'SQLite integration', 'sqlite-database-integration' ),
-		'manage_options',
+		$capability,
 		'sqlite-integration',
 		'sqlite_integration_admin_screen'
 	);
 }
-add_action( 'admin_menu', 'sqlite_add_admin_menu' );
+add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', 'sqlite_add_admin_menu' );
 
 /**
  * The admin page contents.
@@ -56,7 +60,7 @@ function sqlite_integration_admin_screen() {
 					printf(
 						/* translators: 1: Admin URL to deactivate the module, 2: db.php drop-in path, */
 						__( 'The SQLite drop-in is enabled. To disable it and get back to your previous, MySQL database, you can <a href="%1$s">deactivate the plugin</a>. Alternatively, you can manually delete the %2$s file from your server.', 'sqlite-database-integration' ),
-						esc_url( admin_url( 'plugins.php' ) ),
+						esc_url( self_admin_url( 'plugins.php' ) ),
 						'<code>' . esc_html( basename( WP_CONTENT_DIR ) ) . '/db.php</code>'
 					);
 				?>
@@ -78,7 +82,16 @@ function sqlite_integration_admin_screen() {
 						?>
 					</p>
 				</div>
-				<a class="button button-primary" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=sqlite-integration&confirm-install&upgrade-from-pl' ), 'sqlite-install' ) ); ?>">
+				<?php
+				$upgrade_url = add_query_arg(
+					array(
+						'confirm-install' => '1',
+						'upgrade-from-pl' => '1',
+					),
+					sqlite_plugin_get_admin_page_url()
+				);
+				?>
+				<a class="button button-primary" href="<?php echo esc_url( wp_nonce_url( $upgrade_url, 'sqlite-install' ) ); ?>">
 					<?php
 					printf(
 						/* translators: %s: db.php drop-in path */
@@ -136,7 +149,7 @@ function sqlite_integration_admin_screen() {
 
 			<p><?php esc_html_e( 'By clicking the button below, you will be redirected to the WordPress installation screen to setup your new database', 'sqlite-database-integration' ); ?></p>
 
-			<a class="button button-primary" href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=sqlite-integration&confirm-install' ), 'sqlite-install' ) ); ?>"><?php esc_html_e( 'Install SQLite database', 'sqlite-database-integration' ); ?></a>
+			<a class="button button-primary" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'confirm-install', '1', sqlite_plugin_get_admin_page_url() ), 'sqlite-install' ) ); ?>"><?php esc_html_e( 'Install SQLite database', 'sqlite-database-integration' ); ?></a>
 		<?php endif; ?>
 	</div>
 	<?php
@@ -166,9 +179,23 @@ function sqlite_plugin_adminbar_item( $admin_bar ) {
 		'id'     => 'sqlite-db-integration',
 		'parent' => 'top-secondary',
 		'title'  => $title,
-		'href'   => esc_url( admin_url( 'options-general.php?page=sqlite-integration' ) ),
+		'href'   => esc_url( sqlite_plugin_get_admin_page_url() ),
 		'meta'   => false,
 	);
 	$admin_bar->add_node( $args );
 }
 add_action( 'admin_bar_menu', 'sqlite_plugin_adminbar_item', 999 );
+
+/**
+ * Get the SQLite integration admin page URL.
+ *
+ * @access private
+ *
+ * @return string Admin page URL.
+ */
+function sqlite_plugin_get_admin_page_url() {
+	if ( is_multisite() ) {
+		return network_admin_url( 'settings.php?page=sqlite-integration' );
+	}
+	return admin_url( 'options-general.php?page=sqlite-integration' );
+}

--- a/packages/plugin-sqlite-database-integration/admin-page.php
+++ b/packages/plugin-sqlite-database-integration/admin-page.php
@@ -13,13 +13,12 @@
  */
 function sqlite_add_admin_menu() {
 	$parent_slug = is_multisite() ? 'settings.php' : 'options-general.php';
-	$capability  = is_multisite() ? 'manage_network_options' : 'manage_options';
 
 	add_submenu_page(
 		$parent_slug,
 		__( 'SQLite integration', 'sqlite-database-integration' ),
 		__( 'SQLite integration', 'sqlite-database-integration' ),
-		$capability,
+		sqlite_plugin_get_manage_capability(),
 		'sqlite-integration',
 		'sqlite_integration_admin_screen'
 	);
@@ -30,6 +29,13 @@ add_action( is_multisite() ? 'network_admin_menu' : 'admin_menu', 'sqlite_add_ad
  * The admin page contents.
  */
 function sqlite_integration_admin_screen() {
+	if ( ! current_user_can( sqlite_plugin_get_manage_capability() ) ) {
+		wp_die(
+			esc_html__( 'Sorry, you are not allowed to access the SQLite integration settings.', 'sqlite-database-integration' ),
+			403
+		);
+	}
+
 	$db_dropin_path = WP_CONTENT_DIR . '/db.php';
 
 	/*
@@ -165,6 +171,10 @@ function sqlite_integration_admin_screen() {
  * @param WP_Admin_Bar $admin_bar The admin bar object.
  */
 function sqlite_plugin_adminbar_item( $admin_bar ) {
+	if ( ! current_user_can( sqlite_plugin_get_manage_capability() ) ) {
+		return;
+	}
+
 	global $wpdb;
 
 	if ( defined( 'SQLITE_DB_DROPIN_VERSION' ) && defined( 'DB_ENGINE' ) && 'sqlite' === DB_ENGINE ) {

--- a/packages/plugin-sqlite-database-integration/capabilities.php
+++ b/packages/plugin-sqlite-database-integration/capabilities.php
@@ -29,6 +29,35 @@ function sqlite_plugin_map_deactivation_capability( $caps, $cap, $user_id, $args
 add_filter( 'map_meta_cap', 'sqlite_plugin_map_deactivation_capability', 10, 4 );
 
 /**
+ * WordPress does not check each plugin's permission when deactivating a Network
+ * Admin batch. Remove SQLite from the batch when the user cannot manage the
+ * network-wide drop-in, while allowing the other selected plugins to continue.
+ *
+ * @access private
+ */
+function sqlite_plugin_filter_network_bulk_deactivation() {
+	$is_network_bulk_deactivation = is_network_admin()
+		&& isset( $_REQUEST['action'] )
+		&& is_string( $_REQUEST['action'] )
+		&& 'deactivate-selected' === wp_unslash( $_REQUEST['action'] );
+
+	if (
+		$is_network_bulk_deactivation
+		&& sqlite_plugin_has_active_dropin()
+		&& ! current_user_can( sqlite_plugin_get_manage_capability() )
+	) {
+		/*
+		 * Remove only SQLite from the submitted list. WordPress will still check
+		 * whether the user may run bulk deactivation and whether the request is
+		 * valid before it deactivates the plugins left in the list.
+		 */
+		$plugins          = isset( $_POST['checked'] ) ? (array) $_POST['checked'] : array();
+		$_POST['checked'] = array_values( array_diff( $plugins, array( plugin_basename( SQLITE_MAIN_FILE ) ) ) );
+	}
+}
+add_action( 'load-plugins.php', 'sqlite_plugin_filter_network_bulk_deactivation' );
+
+/**
  * Check whether the SQLite database drop-in is active.
  *
  * @access private

--- a/packages/plugin-sqlite-database-integration/capabilities.php
+++ b/packages/plugin-sqlite-database-integration/capabilities.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Get the capability required to manage the SQLite integration.
+ *
+ * @access private
+ *
+ * @return string Required capability.
+ */
+function sqlite_plugin_get_manage_capability() {
+	return is_multisite() ? 'manage_network_options' : 'manage_options';
+}

--- a/packages/plugin-sqlite-database-integration/capabilities.php
+++ b/packages/plugin-sqlite-database-integration/capabilities.php
@@ -1,6 +1,45 @@
 <?php
 
 /**
+ * Require SQLite management permission to deactivate an active integration.
+ *
+ * WordPress checks this capability when one plugin is deactivated, including
+ * each plugin in a site-level batch. It skips this per-plugin check for a
+ * Network Admin batch, so that case is handled separately below.
+ *
+ * @access private
+ *
+ * @param string[] $caps    Primitive capabilities required of the user.
+ * @param string   $cap     Capability being checked.
+ * @param int      $user_id User ID.
+ * @param mixed[]  $args    Additional capability arguments.
+ * @return string[] Required primitive capabilities.
+ */
+function sqlite_plugin_map_deactivation_capability( $caps, $cap, $user_id, $args ) {
+	if (
+		'deactivate_plugin' === $cap
+		&& isset( $args[0] )
+		&& plugin_basename( SQLITE_MAIN_FILE ) === $args[0]
+		&& sqlite_plugin_has_active_dropin()
+	) {
+		$caps[] = sqlite_plugin_get_manage_capability();
+	}
+	return $caps;
+}
+add_filter( 'map_meta_cap', 'sqlite_plugin_map_deactivation_capability', 10, 4 );
+
+/**
+ * Check whether the SQLite database drop-in is active.
+ *
+ * @access private
+ *
+ * @return bool Whether the SQLite database drop-in is active.
+ */
+function sqlite_plugin_has_active_dropin() {
+	return defined( 'SQLITE_DB_DROPIN_VERSION' ) && file_exists( WP_CONTENT_DIR . '/db.php' );
+}
+
+/**
  * Get the capability required to manage the SQLite integration.
  *
  * @access private

--- a/packages/plugin-sqlite-database-integration/deactivate.php
+++ b/packages/plugin-sqlite-database-integration/deactivate.php
@@ -14,7 +14,7 @@
  * @param bool $network_deactivating Whether the plugin is being deactivated network-wide.
  */
 function sqlite_plugin_remove_db_file( $network_deactivating = false ) {
-	if ( ! defined( 'SQLITE_DB_DROPIN_VERSION' ) || ! file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
+	if ( ! sqlite_plugin_has_active_dropin() ) {
 		return;
 	}
 

--- a/packages/plugin-sqlite-database-integration/deactivate.php
+++ b/packages/plugin-sqlite-database-integration/deactivate.php
@@ -18,6 +18,12 @@ function sqlite_plugin_remove_db_file( $network_deactivating = false ) {
 		return;
 	}
 
+	// WP-CLI and other programmatic callers may deactivate without a current user.
+	// In those cases, the caller is responsible for authorization.
+	if ( is_user_logged_in() && ! current_user_can( sqlite_plugin_get_manage_capability() ) ) {
+		return;
+	}
+
 	global $wp_filesystem;
 
 	require_once ABSPATH . '/wp-admin/includes/file.php';

--- a/packages/plugin-sqlite-database-integration/deactivate.php
+++ b/packages/plugin-sqlite-database-integration/deactivate.php
@@ -10,8 +10,10 @@
  * Delete the db.php file in wp-content.
  *
  * When the plugin gets merged in wp-core, this is not to be ported.
+ *
+ * @param bool $network_deactivating Whether the plugin is being deactivated network-wide.
  */
-function sqlite_plugin_remove_db_file() {
+function sqlite_plugin_remove_db_file( $network_deactivating = false ) {
 	if ( ! defined( 'SQLITE_DB_DROPIN_VERSION' ) || ! file_exists( WP_CONTENT_DIR . '/db.php' ) ) {
 		return;
 	}
@@ -33,7 +35,7 @@ function sqlite_plugin_remove_db_file() {
 	// Run an action on `shutdown`, to deactivate the option in the MySQL database.
 	add_action(
 		'shutdown',
-		function () {
+		function () use ( $network_deactivating ) {
 			global $table_prefix;
 
 			// Get credentials for the MySQL database.
@@ -46,19 +48,7 @@ function sqlite_plugin_remove_db_file() {
 			$wpdb_mysql = new wpdb( $dbuser, $dbpassword, $dbname, $dbhost );
 			$wpdb_mysql->set_prefix( $table_prefix );
 
-			// Get the perflab options, remove the database/sqlite module and update the option.
-			$row = $wpdb_mysql->get_row( $wpdb_mysql->prepare( "SELECT option_value FROM $wpdb_mysql->options WHERE option_name = %s LIMIT 1", 'active_plugins' ) );
-			if ( is_object( $row ) ) {
-				$value = maybe_unserialize( $row->option_value );
-				if ( is_array( $value ) ) {
-					$value_flipped = array_flip( $value );
-					$items         = array_reverse( explode( DIRECTORY_SEPARATOR, SQLITE_MAIN_FILE ) );
-					$item          = $items[1] . DIRECTORY_SEPARATOR . $items[0];
-					unset( $value_flipped[ $item ] );
-					$value = array_flip( $value_flipped );
-					$wpdb_mysql->update( $wpdb_mysql->options, array( 'option_value' => maybe_serialize( $value ) ), array( 'option_name' => 'active_plugins' ) );
-				}
-			}
+			sqlite_plugin_deactivate_in_mysql( $wpdb_mysql, $network_deactivating );
 		},
 		PHP_INT_MAX
 	);
@@ -66,3 +56,52 @@ function sqlite_plugin_remove_db_file() {
 	wp_cache_flush();
 }
 register_deactivation_hook( SQLITE_MAIN_FILE, 'sqlite_plugin_remove_db_file' ); // Remove db.php file on plugin deactivation.
+
+/**
+ * Deactivate the plugin in the original MySQL database.
+ *
+ * @access private
+ *
+ * @param wpdb $wpdb_mysql          MySQL database connection.
+ * @param bool $network_deactivating Whether the plugin is being deactivated network-wide.
+ */
+function sqlite_plugin_deactivate_in_mysql( $wpdb_mysql, $network_deactivating ) {
+	if ( $network_deactivating ) {
+		$network_id   = get_current_network_id();
+		$row          = $wpdb_mysql->get_row( $wpdb_mysql->prepare( "SELECT meta_value AS active_plugins FROM $wpdb_mysql->sitemeta WHERE site_id = %d AND meta_key = %s LIMIT 1", $network_id, 'active_sitewide_plugins' ) );
+		$table        = $wpdb_mysql->sitemeta;
+		$value_column = 'meta_value';
+		$where        = array(
+			'site_id'  => $network_id,
+			'meta_key' => 'active_sitewide_plugins',
+		);
+	} else {
+		$row          = $wpdb_mysql->get_row( $wpdb_mysql->prepare( "SELECT option_value AS active_plugins FROM $wpdb_mysql->options WHERE option_name = %s LIMIT 1", 'active_plugins' ) );
+		$table        = $wpdb_mysql->options;
+		$value_column = 'option_value';
+		$where        = array( 'option_name' => 'active_plugins' );
+	}
+
+	if ( ! is_object( $row ) ) {
+		return;
+	}
+
+	$active_plugins = maybe_unserialize( $row->active_plugins );
+	if ( ! is_array( $active_plugins ) ) {
+		return;
+	}
+
+	$item = plugin_basename( SQLITE_MAIN_FILE );
+	if ( $network_deactivating ) {
+		$key = $item;
+	} else {
+		$key = array_search( $item, $active_plugins, true );
+	}
+
+	if ( false === $key || ! array_key_exists( $key, $active_plugins ) ) {
+		return;
+	}
+
+	unset( $active_plugins[ $key ] );
+	$wpdb_mysql->update( $table, array( $value_column => maybe_serialize( $active_plugins ) ), $where );
+}

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -21,6 +21,7 @@ require_once __DIR__ . '/wp-includes/database/version.php';
 
 define( 'SQLITE_MAIN_FILE', __FILE__ );
 
+require_once __DIR__ . '/capabilities.php';
 require_once __DIR__ . '/admin-page.php';
 require_once __DIR__ . '/activate.php';
 require_once __DIR__ . '/deactivate.php';

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -5,6 +5,7 @@
  * Author: The WordPress Team
  * Version: 3.0.0-rc.7
  * Requires PHP: 7.2
+ * Network: true
  * Textdomain: sqlite-database-integration
  *
  * This feature plugin allows WordPress to use SQLite instead of MySQL as its database.

--- a/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
@@ -14,6 +14,16 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 	/**
 	 * @var int
 	 */
+	private static $site_id;
+
+	/**
+	 * @var int
+	 */
+	private static $subsite_admin_id;
+
+	/**
+	 * @var int
+	 */
 	private static $super_admin_id;
 
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
@@ -21,13 +31,23 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 			return;
 		}
 
-		self::$super_admin_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$subsite_admin_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		self::$site_id          = $factory->blog->create(
+			array(
+				'path'    => '/sqlite-authorization/',
+				'user_id' => self::$subsite_admin_id,
+			)
+		);
+		self::$super_admin_id   = $factory->user->create( array( 'role' => 'subscriber' ) );
+
+		add_user_to_blog( self::$site_id, self::$super_admin_id, 'administrator' );
 		grant_super_admin( self::$super_admin_id );
 	}
 
 	public static function wpTearDownAfterClass() {
 		if ( is_multisite() ) {
 			revoke_super_admin( self::$super_admin_id );
+			wp_delete_site( self::$site_id );
 		}
 	}
 
@@ -43,6 +63,10 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 			$this->admin_menu_globals = null;
 		}
 
+		while ( is_multisite() && ms_is_switched() ) {
+			restore_current_blog();
+		}
+
 		parent::tear_down();
 	}
 
@@ -55,7 +79,7 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 	 * @group ms-excluded
 	 */
 	public function test_single_site_uses_site_admin() {
-		$this->set_single_site_administrator();
+		$this->set_single_site_user( 'administrator' );
 		$this->reset_admin_menu();
 
 		$this->assertSame( 10, has_action( 'admin_menu', 'sqlite_add_admin_menu' ) );
@@ -67,6 +91,16 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		sqlite_add_admin_menu();
 
 		$this->assertSame( 10, has_action( 'settings_page_sqlite-integration', 'sqlite_integration_admin_screen' ) );
+		$this->assert_admin_screen_is_accessible();
+		$this->assertSame(
+			admin_url( 'options-general.php?page=sqlite-integration' ),
+			$this->get_activation_redirect()
+		);
+		$this->assertSame(
+			admin_url( 'options-general.php?page=sqlite-integration' ),
+			$this->get_admin_bar_node()->href
+		);
+		$this->assertStringContainsString( 'file is missing', $this->get_admin_notice_without_dropin() );
 	}
 
 	/**
@@ -82,7 +116,7 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 	 * @group ms-required
 	 */
 	public function test_multisite_uses_network_admin() {
-		wp_set_current_user( self::$super_admin_id );
+		$this->set_multisite_user( true );
 		$this->reset_admin_menu();
 
 		$this->assertFalse( has_action( 'admin_menu', 'sqlite_add_admin_menu' ) );
@@ -94,54 +128,119 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		sqlite_add_admin_menu();
 
 		$this->assertSame( 10, has_action( 'settings_page_sqlite-integration', 'sqlite_integration_admin_screen' ) );
+		$this->assert_admin_screen_is_accessible();
+		$this->assertSame(
+			network_admin_url( 'settings.php?page=sqlite-integration' ),
+			$this->get_activation_redirect()
+		);
+		$this->assertSame(
+			network_admin_url( 'settings.php?page=sqlite-integration' ),
+			$this->get_admin_bar_node()->href
+		);
+		$this->assertStringContainsString( 'file is missing', $this->get_admin_notice_without_dropin() );
 	}
 
 	/**
 	 * @group ms-excluded
 	 */
-	public function test_single_site_activation_redirects_to_site_admin() {
-		$this->assertSame(
-			admin_url( 'options-general.php?page=sqlite-integration' ),
-			$this->get_activation_redirect()
-		);
+	public function test_single_site_subscriber_cannot_access_management_surfaces() {
+		$this->set_single_site_user( 'subscriber' );
+
+		$this->assertNull( $this->get_admin_bar_node() );
+		$this->assertSame( '', $this->get_admin_notice_without_dropin() );
+		$this->assertNull( $this->get_activation_redirect() );
+
+		$this->reset_admin_menu();
+
+		sqlite_add_admin_menu();
+
+		$this->assertTrue( $GLOBALS['_wp_submenu_nopriv']['options-general.php']['sqlite-integration'] );
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionCode( 403 );
+		$this->expectExceptionMessage( 'Sorry, you are not allowed to access the SQLite integration settings.' );
+
+		sqlite_integration_admin_screen();
 	}
 
 	/**
 	 * @group ms-required
 	 */
-	public function test_multisite_activation_redirects_to_network_admin() {
-		$this->assertSame(
-			network_admin_url( 'settings.php?page=sqlite-integration' ),
-			$this->get_activation_redirect()
-		);
+	public function test_subsite_administrator_cannot_access_management_surfaces() {
+		$this->set_multisite_user( false );
+
+		$this->assertNull( $this->get_admin_bar_node() );
+		$this->assertSame( '', $this->get_admin_notice_without_dropin() );
+		$this->assertNull( $this->get_activation_redirect() );
+
+		$this->reset_admin_menu();
+
+		sqlite_add_admin_menu();
+
+		$this->assertTrue( $GLOBALS['_wp_submenu_nopriv']['settings.php']['sqlite-integration'] );
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionCode( 403 );
+		$this->expectExceptionMessage( 'Sorry, you are not allowed to access the SQLite integration settings.' );
+
+		sqlite_integration_admin_screen();
 	}
 
 	/**
 	 * @group ms-excluded
 	 */
-	public function test_single_site_admin_bar_links_to_site_admin() {
-		$admin_bar = new WP_Admin_Bar();
+	public function test_other_plugin_activation_does_not_redirect() {
+		$this->assertNull( $this->get_activation_redirect( 'another-plugin/plugin.php' ) );
+	}
 
-		sqlite_plugin_adminbar_item( $admin_bar );
-
-		$this->assertSame(
-			admin_url( 'options-general.php?page=sqlite-integration' ),
-			$admin_bar->get_node( 'sqlite-db-integration' )->href
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_confirm_install_is_ignored_on_another_page() {
+		$_GET     = array(
+			'page'            => 'another-page',
+			'confirm-install' => '1',
+			'_wpnonce'        => 'invalid',
 		);
+		$_REQUEST = $_GET;
+
+		$this->assertNull( sqlite_activation() );
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_administrator_with_valid_nonce_can_install() {
+		$this->set_single_site_user( 'administrator' );
+
+		$this->assert_valid_nonce_reaches_install_redirect();
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_administrator_with_invalid_nonce_is_denied() {
+		$this->set_single_site_user( 'administrator' );
+
+		$this->assert_invalid_nonce_is_denied();
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_editor_with_valid_nonce_cannot_install() {
+		$this->set_single_site_user( 'editor' );
+
+		$this->assert_valid_nonce_install_is_denied();
 	}
 
 	/**
 	 * @group ms-required
 	 */
-	public function test_multisite_admin_bar_links_to_network_admin() {
-		$admin_bar = new WP_Admin_Bar();
+	public function test_super_admin_with_valid_nonce_can_install() {
+		$this->set_multisite_user( true );
 
-		sqlite_plugin_adminbar_item( $admin_bar );
-
-		$this->assertSame(
-			network_admin_url( 'settings.php?page=sqlite-integration' ),
-			$admin_bar->get_node( 'sqlite-db-integration' )->href
-		);
+		$this->assert_valid_nonce_reaches_install_redirect();
 	}
 
 	/**
@@ -222,8 +321,26 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		);
 	}
 
-	private function set_single_site_administrator() {
-		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+	/**
+	 * @group ms-required
+	 */
+	public function test_super_admin_with_invalid_nonce_is_denied() {
+		$this->set_multisite_user( true );
+
+		$this->assert_invalid_nonce_is_denied();
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_subsite_administrator_with_valid_nonce_cannot_install() {
+		$this->set_multisite_user( false );
+
+		$this->assert_valid_nonce_install_is_denied();
+	}
+
+	private function set_single_site_user( $role ) {
+		$user_id = self::factory()->user->create( array( 'role' => $role ) );
 
 		wp_set_current_user( $user_id );
 	}
@@ -285,6 +402,16 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		};
 	}
 
+	private function set_multisite_user( $is_super_admin ) {
+		$user_id = $is_super_admin ? self::$super_admin_id : self::$subsite_admin_id;
+
+		switch_to_blog( self::$site_id );
+		wp_set_current_user( $user_id );
+
+		$this->assertTrue( current_user_can( 'manage_options' ) );
+		$this->assertSame( $is_super_admin, current_user_can( 'manage_network_options' ) );
+	}
+
 	private function reset_admin_menu() {
 		$global_names = array(
 			'menu',
@@ -315,7 +442,11 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		$GLOBALS['_wp_real_parent_file'] = array();
 	}
 
-	private function get_activation_redirect() {
+	private function get_activation_redirect( $plugin = null ) {
+		if ( null === $plugin ) {
+			$plugin = plugin_basename( SQLITE_MAIN_FILE );
+		}
+
 		$redirect_url = null;
 		$filter       = function ( $location ) use ( &$redirect_url ) {
 			$redirect_url = $location;
@@ -323,9 +454,156 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		};
 
 		add_filter( 'wp_redirect', $filter );
-		sqlite_plugin_activation_redirect( plugin_basename( SQLITE_MAIN_FILE ) );
+		sqlite_plugin_activation_redirect( $plugin );
 		remove_filter( 'wp_redirect', $filter );
 
 		return $redirect_url;
+	}
+
+	private function get_admin_bar_node() {
+		$admin_bar = new WP_Admin_Bar();
+
+		sqlite_plugin_adminbar_item( $admin_bar );
+
+		return $admin_bar->get_node( 'sqlite-db-integration' );
+	}
+
+	private function assert_admin_screen_is_accessible() {
+		ob_start();
+		sqlite_integration_admin_screen();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'SQLite is enabled.', $output );
+		$this->assertStringContainsString( esc_url( self_admin_url( 'plugins.php' ) ), $output );
+	}
+
+	private function get_admin_notice_without_dropin() {
+		return $this->run_without_dropin(
+			function () {
+				ob_start();
+				sqlite_plugin_admin_notice();
+				return ob_get_clean();
+			}
+		);
+	}
+
+	private function run_without_dropin( $callback ) {
+		$dropin_path        = WP_CONTENT_DIR . '/db.php';
+		$dropin_backup_path = tempnam( WP_CONTENT_DIR, 'db.php.' );
+
+		$this->assertNotFalse( $dropin_backup_path );
+		$this->assertTrue( unlink( $dropin_backup_path ) );
+		$this->assertTrue( rename( $dropin_path, $dropin_backup_path ) );
+
+		$restore_dropin      = function () use ( $dropin_path, $dropin_backup_path ) {
+			if ( ! file_exists( $dropin_backup_path ) ) {
+				return file_exists( $dropin_path );
+			}
+
+			return rename( $dropin_backup_path, $dropin_path );
+		};
+		$restore_on_shutdown = true;
+		register_shutdown_function(
+			function () use ( &$restore_on_shutdown, $restore_dropin ) {
+				if ( $restore_on_shutdown ) {
+					call_user_func( $restore_dropin );
+				}
+			}
+		);
+
+		try {
+			$result = call_user_func( $callback );
+		} finally {
+			$dropin_restored     = call_user_func( $restore_dropin );
+			$restore_on_shutdown = false;
+		}
+
+		$this->assertTrue( $dropin_restored );
+		$this->assertFileExists( $dropin_path );
+
+		return $result;
+	}
+
+	private function assert_valid_nonce_reaches_install_redirect() {
+		$nonce            = wp_create_nonce( 'sqlite-install' );
+		$redirect_url     = null;
+		$redirect_reached = false;
+		$filter           = function ( $location ) use ( &$redirect_url ) {
+			$redirect_url = $location;
+			throw new RuntimeException( 'Install redirect reached.' );
+		};
+
+		$this->set_install_request( $nonce );
+		add_filter( 'wp_redirect', $filter );
+
+		try {
+			sqlite_activation();
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Install redirect reached.', $exception->getMessage() );
+			$redirect_reached = true;
+		} finally {
+			remove_filter( 'wp_redirect', $filter );
+		}
+
+		$this->assertTrue( $redirect_reached, 'The install request did not redirect.' );
+		$this->assertSame( admin_url(), $redirect_url );
+	}
+
+	private function assert_valid_nonce_install_is_denied() {
+		$dropin_before = file_get_contents( WP_CONTENT_DIR . '/db.php' );
+		$nonce         = wp_create_nonce( 'sqlite-install' );
+		$nonce_checked = false;
+		$nonce_action  = function () use ( &$nonce_checked ) {
+			$nonce_checked = true;
+		};
+
+		$this->assertNotFalse( wp_verify_nonce( $nonce, 'sqlite-install' ) );
+		$this->set_install_request( $nonce );
+		add_action( 'check_admin_referer', $nonce_action );
+
+		try {
+			sqlite_activation();
+			$this->fail( 'The install request was not denied.' );
+		} catch ( WPDieException $exception ) {
+			$this->assertSame( 403, $exception->getCode() );
+			$this->assertSame( 'Sorry, you are not allowed to install the SQLite database drop-in.', $exception->getMessage() );
+		} finally {
+			remove_action( 'check_admin_referer', $nonce_action );
+		}
+
+		$this->assertFalse( $nonce_checked, 'The capability check must run before nonce validation.' );
+		$this->assertSame( $dropin_before, file_get_contents( WP_CONTENT_DIR . '/db.php' ) );
+	}
+
+	private function assert_invalid_nonce_is_denied() {
+		$nonce_checked = false;
+		$nonce_action  = function ( $action, $result ) use ( &$nonce_checked ) {
+			$nonce_checked = true;
+			$this->assertSame( 'sqlite-install', $action );
+			$this->assertFalse( $result );
+		};
+
+		$this->set_install_request( 'invalid' );
+		add_action( 'check_admin_referer', $nonce_action, 10, 2 );
+
+		try {
+			sqlite_activation();
+			$this->fail( 'The invalid nonce was accepted.' );
+		} catch ( WPDieException $exception ) {
+			$this->assertSame( 403, $exception->getCode() );
+		} finally {
+			remove_action( 'check_admin_referer', $nonce_action );
+		}
+
+		$this->assertTrue( $nonce_checked );
+	}
+
+	private function set_install_request( $nonce ) {
+		$_GET     = array(
+			'page'            => 'sqlite-integration',
+			'confirm-install' => '1',
+			'_wpnonce'        => $nonce,
+		);
+		$_REQUEST = $_GET;
 	}
 }

--- a/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
@@ -246,7 +246,64 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 	/**
 	 * @group ms-required
 	 */
+	public function test_super_admin_with_invalid_nonce_is_denied() {
+		$this->set_multisite_user( true );
+
+		$this->assert_invalid_nonce_is_denied();
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_subsite_administrator_with_valid_nonce_cannot_install() {
+		$this->set_multisite_user( false );
+
+		$this->assert_valid_nonce_install_is_denied();
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_administrator_can_deactivate_sqlite() {
+		$this->set_single_site_user( 'administrator' );
+
+		$this->assertTrue( current_user_can( 'deactivate_plugin', plugin_basename( SQLITE_MAIN_FILE ) ) );
+		$this->assert_deactivation_removes_dropin();
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_plugin_manager_can_only_deactivate_sqlite_without_dropin() {
+		$this->set_single_site_user( 'administrator' );
+		wp_get_current_user()->add_cap( 'manage_options', false );
+
+		$this->assertFalse( current_user_can( 'manage_options' ) );
+		$this->assertTrue( current_user_can( 'deactivate_plugin', 'another-plugin/plugin.php' ) );
+		$this->assertFalse( current_user_can( 'deactivate_plugin', plugin_basename( SQLITE_MAIN_FILE ) ) );
+
+		$this->run_without_dropin(
+			function () {
+				$this->assertTrue( current_user_can( 'deactivate_plugin', plugin_basename( SQLITE_MAIN_FILE ) ) );
+			}
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_super_admin_can_deactivate_sqlite() {
+		$this->set_multisite_user( true );
+
+		$this->assertTrue( current_user_can( 'deactivate_plugin', plugin_basename( SQLITE_MAIN_FILE ) ) );
+		$this->assert_deactivation_removes_dropin();
+	}
+
+	/**
+	 * @group ms-required
+	 */
 	public function test_network_deactivation_context_is_forwarded_to_mysql_cleanup() {
+		$this->set_multisite_user( true );
 		$shutdown_hook_before = isset( $GLOBALS['wp_filter']['shutdown'] ) ? clone $GLOBALS['wp_filter']['shutdown'] : null;
 
 		try {
@@ -324,25 +381,58 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 	/**
 	 * @group ms-required
 	 */
-	public function test_super_admin_with_invalid_nonce_is_denied() {
-		$this->set_multisite_user( true );
+	public function test_delegated_network_plugin_manager_can_only_deactivate_sqlite_without_dropin() {
+		$this->run_as_delegated_network_plugin_manager(
+			function () {
+				$this->assertTrue( current_user_can( 'deactivate_plugin', 'another-plugin/plugin.php' ) );
+				$this->assertFalse( current_user_can( 'deactivate_plugin', plugin_basename( SQLITE_MAIN_FILE ) ) );
 
-		$this->assert_invalid_nonce_is_denied();
-	}
-
-	/**
-	 * @group ms-required
-	 */
-	public function test_subsite_administrator_with_valid_nonce_cannot_install() {
-		$this->set_multisite_user( false );
-
-		$this->assert_valid_nonce_install_is_denied();
+				$this->run_without_dropin(
+					function () {
+						$this->assertTrue( current_user_can( 'deactivate_plugin', plugin_basename( SQLITE_MAIN_FILE ) ) );
+					}
+				);
+			}
+		);
 	}
 
 	private function set_single_site_user( $role ) {
 		$user_id = self::factory()->user->create( array( 'role' => $role ) );
 
 		wp_set_current_user( $user_id );
+	}
+
+	private function set_multisite_user( $is_super_admin ) {
+		$user_id = $is_super_admin ? self::$super_admin_id : self::$subsite_admin_id;
+
+		switch_to_blog( self::$site_id );
+		wp_set_current_user( $user_id );
+	}
+
+	private function run_as_delegated_network_plugin_manager( $callback ) {
+		$this->set_multisite_user( false );
+
+		$user         = wp_get_current_user();
+		$capabilities = array( 'activate_plugins', 'manage_network_plugins' );
+
+		foreach ( $capabilities as $capability ) {
+			$user->add_cap( $capability );
+		}
+
+		try {
+			return call_user_func( $callback );
+		} finally {
+			foreach ( $capabilities as $capability ) {
+				$user->remove_cap( $capability );
+			}
+		}
+	}
+
+	private function assert_deactivation_removes_dropin() {
+		$filesystem = $this->run_with_deactivation_filesystem( 'sqlite_plugin_remove_db_file' );
+
+		$this->assertSame( WP_CONTENT_DIR . '/db.php', $filesystem->deleted_path );
+		$this->assertFileExists( WP_CONTENT_DIR . '/db.php' );
 	}
 
 	private function run_with_deactivation_filesystem( $callback ) {
@@ -400,16 +490,6 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 				$this->update_args = array( $table, $data, $where );
 			}
 		};
-	}
-
-	private function set_multisite_user( $is_super_admin ) {
-		$user_id = $is_super_admin ? self::$super_admin_id : self::$subsite_admin_id;
-
-		switch_to_blog( self::$site_id );
-		wp_set_current_user( $user_id );
-
-		$this->assertTrue( current_user_can( 'manage_options' ) );
-		$this->assertSame( $is_super_admin, current_user_can( 'manage_network_options' ) );
 	}
 
 	private function reset_admin_menu() {

--- a/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
@@ -1,11 +1,331 @@
 <?php
 
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
+require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
 require_once WP_CONTENT_DIR . '/plugins/sqlite-database-integration/load.php';
 
 class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase {
 
+	/**
+	 * @var array|null
+	 */
+	private $admin_menu_globals;
+
+	/**
+	 * @var int
+	 */
+	private static $super_admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		if ( ! is_multisite() ) {
+			return;
+		}
+
+		self::$super_admin_id = $factory->user->create( array( 'role' => 'subscriber' ) );
+		grant_super_admin( self::$super_admin_id );
+	}
+
+	public static function wpTearDownAfterClass() {
+		if ( is_multisite() ) {
+			revoke_super_admin( self::$super_admin_id );
+		}
+	}
+
+	public function tear_down() {
+		if ( null !== $this->admin_menu_globals ) {
+			foreach ( $this->admin_menu_globals as $name => $state ) {
+				if ( $state['exists'] ) {
+					$GLOBALS[ $name ] = $state['value'];
+				} else {
+					unset( $GLOBALS[ $name ] );
+				}
+			}
+			$this->admin_menu_globals = null;
+		}
+
+		parent::tear_down();
+	}
+
 	public function test_plugin_is_loaded() {
 		$this->assertTrue( defined( 'SQLITE_MAIN_FILE' ) );
 		$this->assertFileExists( SQLITE_MAIN_FILE );
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_uses_site_admin() {
+		$this->set_single_site_administrator();
+		$this->reset_admin_menu();
+
+		$this->assertSame( 10, has_action( 'admin_menu', 'sqlite_add_admin_menu' ) );
+		$this->assertFalse( has_action( 'network_admin_menu', 'sqlite_add_admin_menu' ) );
+		$this->assertSame( 10, has_action( 'admin_notices', 'sqlite_plugin_admin_notice' ) );
+		$this->assertFalse( has_action( 'network_admin_notices', 'sqlite_plugin_admin_notice' ) );
+		$this->assertSame( admin_url( 'options-general.php?page=sqlite-integration' ), sqlite_plugin_get_admin_page_url() );
+
+		sqlite_add_admin_menu();
+
+		$this->assertSame( 10, has_action( 'settings_page_sqlite-integration', 'sqlite_integration_admin_screen' ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_multisite_plugin_is_network_only() {
+		$plugin_data = get_plugin_data( SQLITE_MAIN_FILE, false, false );
+
+		$this->assertTrue( $plugin_data['Network'] );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_multisite_uses_network_admin() {
+		wp_set_current_user( self::$super_admin_id );
+		$this->reset_admin_menu();
+
+		$this->assertFalse( has_action( 'admin_menu', 'sqlite_add_admin_menu' ) );
+		$this->assertSame( 10, has_action( 'network_admin_menu', 'sqlite_add_admin_menu' ) );
+		$this->assertFalse( has_action( 'admin_notices', 'sqlite_plugin_admin_notice' ) );
+		$this->assertSame( 10, has_action( 'network_admin_notices', 'sqlite_plugin_admin_notice' ) );
+		$this->assertSame( network_admin_url( 'settings.php?page=sqlite-integration' ), sqlite_plugin_get_admin_page_url() );
+
+		sqlite_add_admin_menu();
+
+		$this->assertSame( 10, has_action( 'settings_page_sqlite-integration', 'sqlite_integration_admin_screen' ) );
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_activation_redirects_to_site_admin() {
+		$this->assertSame(
+			admin_url( 'options-general.php?page=sqlite-integration' ),
+			$this->get_activation_redirect()
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_multisite_activation_redirects_to_network_admin() {
+		$this->assertSame(
+			network_admin_url( 'settings.php?page=sqlite-integration' ),
+			$this->get_activation_redirect()
+		);
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_admin_bar_links_to_site_admin() {
+		$admin_bar = new WP_Admin_Bar();
+
+		sqlite_plugin_adminbar_item( $admin_bar );
+
+		$this->assertSame(
+			admin_url( 'options-general.php?page=sqlite-integration' ),
+			$admin_bar->get_node( 'sqlite-db-integration' )->href
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_multisite_admin_bar_links_to_network_admin() {
+		$admin_bar = new WP_Admin_Bar();
+
+		sqlite_plugin_adminbar_item( $admin_bar );
+
+		$this->assertSame(
+			network_admin_url( 'settings.php?page=sqlite-integration' ),
+			$admin_bar->get_node( 'sqlite-db-integration' )->href
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_deactivation_context_is_forwarded_to_mysql_cleanup() {
+		$shutdown_hook_before = isset( $GLOBALS['wp_filter']['shutdown'] ) ? clone $GLOBALS['wp_filter']['shutdown'] : null;
+
+		try {
+			$this->run_with_deactivation_filesystem(
+				function () {
+					sqlite_plugin_remove_db_file( true );
+				}
+			);
+
+			$callbacks = $GLOBALS['wp_filter']['shutdown']->callbacks[ PHP_INT_MAX ];
+			$callback  = end( $callbacks );
+			$variables = ( new ReflectionFunction( $callback['function'] ) )->getStaticVariables();
+
+			$this->assertTrue( $variables['network_deactivating'] );
+		} finally {
+			if ( null !== $shutdown_hook_before ) {
+				$GLOBALS['wp_filter']['shutdown'] = $shutdown_hook_before;
+			} else {
+				unset( $GLOBALS['wp_filter']['shutdown'] );
+			}
+		}
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_deactivation_updates_mysql_sitewide_plugins() {
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+		$other_plugin  = 'another-plugin/plugin.php';
+		$network_id    = get_current_network_id();
+		$wpdb_mysql    = $this->create_mysql_test_connection(
+			array(
+				$sqlite_plugin => 123,
+				$other_plugin  => 456,
+			)
+		);
+
+		sqlite_plugin_deactivate_in_mysql( $wpdb_mysql, true );
+
+		$this->assertSame( array( $network_id, 'active_sitewide_plugins' ), $wpdb_mysql->prepared_args );
+		$this->assertSame(
+			array(
+				'wp_sitemeta',
+				array( 'meta_value' => maybe_serialize( array( $other_plugin => 456 ) ) ),
+				array(
+					'site_id'  => $network_id,
+					'meta_key' => 'active_sitewide_plugins',
+				),
+			),
+			$wpdb_mysql->update_args
+		);
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_site_deactivation_updates_mysql_active_plugins() {
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+		$other_plugin  = 'another-plugin/plugin.php';
+		$wpdb_mysql    = $this->create_mysql_test_connection( array( $sqlite_plugin, $other_plugin ) );
+
+		sqlite_plugin_deactivate_in_mysql( $wpdb_mysql, false );
+
+		$this->assertSame( array( 'active_plugins' ), $wpdb_mysql->prepared_args );
+		$this->assertSame(
+			array(
+				'wp_options',
+				array( 'option_value' => maybe_serialize( array( 1 => $other_plugin ) ) ),
+				array( 'option_name' => 'active_plugins' ),
+			),
+			$wpdb_mysql->update_args
+		);
+	}
+
+	private function set_single_site_administrator() {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+
+		wp_set_current_user( $user_id );
+	}
+
+	private function run_with_deactivation_filesystem( $callback ) {
+		$wp_filesystem_was_set = array_key_exists( 'wp_filesystem', $GLOBALS );
+		$wp_filesystem_before  = $wp_filesystem_was_set ? $GLOBALS['wp_filesystem'] : null;
+		$filesystem            = new class() {
+			/**
+			 * @var string|null
+			 */
+			public $deleted_path;
+
+			public function delete( $path ) {
+				$this->deleted_path = $path;
+				return true;
+			}
+		};
+
+		$GLOBALS['wp_filesystem'] = $filesystem;
+
+		try {
+			call_user_func( $callback );
+		} finally {
+			if ( $wp_filesystem_was_set ) {
+				$GLOBALS['wp_filesystem'] = $wp_filesystem_before;
+			} else {
+				unset( $GLOBALS['wp_filesystem'] );
+			}
+		}
+
+		return $filesystem;
+	}
+
+	private function create_mysql_test_connection( $active_plugins ) {
+		return new class( $active_plugins ) {
+			public $options  = 'wp_options';
+			public $sitemeta = 'wp_sitemeta';
+			public $prepared_args;
+			public $update_args;
+			private $active_plugins;
+
+			public function __construct( $active_plugins ) {
+				$this->active_plugins = $active_plugins;
+			}
+
+			public function prepare( $query, ...$args ) {
+				$this->prepared_args = $args;
+				return $query;
+			}
+
+			public function get_row( $query ) {
+				return (object) array( 'active_plugins' => maybe_serialize( $this->active_plugins ) );
+			}
+
+			public function update( $table, $data, $where ) {
+				$this->update_args = array( $table, $data, $where );
+			}
+		};
+	}
+
+	private function reset_admin_menu() {
+		$global_names = array(
+			'menu',
+			'submenu',
+			'_wp_submenu_nopriv',
+			'_registered_pages',
+			'_parent_pages',
+			'admin_page_hooks',
+			'_wp_real_parent_file',
+		);
+
+		$this->admin_menu_globals = array();
+		foreach ( $global_names as $name ) {
+			$this->admin_menu_globals[ $name ] = array(
+				'exists' => array_key_exists( $name, $GLOBALS ),
+				'value'  => array_key_exists( $name, $GLOBALS ) ? $GLOBALS[ $name ] : null,
+			);
+		}
+
+		$GLOBALS['menu']                 = array();
+		$GLOBALS['submenu']              = array();
+		$GLOBALS['_wp_submenu_nopriv']   = array();
+		$GLOBALS['_registered_pages']    = array();
+		$GLOBALS['_parent_pages']        = array();
+		$GLOBALS['admin_page_hooks']     = array(
+			is_multisite() ? 'settings.php' : 'options-general.php' => 'settings',
+		);
+		$GLOBALS['_wp_real_parent_file'] = array();
+	}
+
+	private function get_activation_redirect() {
+		$redirect_url = null;
+		$filter       = function ( $location ) use ( &$redirect_url ) {
+			$redirect_url = $location;
+			return false;
+		};
+
+		add_filter( 'wp_redirect', $filter );
+		sqlite_plugin_activation_redirect( plugin_basename( SQLITE_MAIN_FILE ) );
+		remove_filter( 'wp_redirect', $filter );
+
+		return $redirect_url;
 	}
 }

--- a/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
@@ -1,0 +1,11 @@
+<?php
+
+require_once WP_CONTENT_DIR . '/plugins/sqlite-database-integration/load.php';
+
+class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase {
+
+	public function test_plugin_is_loaded() {
+		$this->assertTrue( defined( 'SQLITE_MAIN_FILE' ) );
+		$this->assertFileExists( SQLITE_MAIN_FILE );
+	}
+}

--- a/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Authorization_Test.php
@@ -396,6 +396,183 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		);
 	}
 
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_single_site_bulk_deactivation_skips_sqlite() {
+		$this->set_single_site_user( 'administrator' );
+		wp_get_current_user()->add_cap( 'manage_options', false );
+		$plugins = array( 'another-plugin/plugin.php', plugin_basename( SQLITE_MAIN_FILE ) );
+
+		foreach ( $plugins as $index => $plugin ) {
+			if ( ! current_user_can( 'deactivate_plugin', $plugin ) ) {
+				unset( $plugins[ $index ] );
+			}
+		}
+
+		$this->assertSame( array( 'another-plugin/plugin.php' ), array_values( $plugins ) );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_bulk_deactivation_skips_sqlite_and_continues() {
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+		$other_plugin  = 'another-plugin/plugin.php';
+		$plugins       = array( $other_plugin, $sqlite_plugin );
+
+		$this->run_as_delegated_network_plugin_manager(
+			function () use ( $plugins, $sqlite_plugin, $other_plugin ) {
+				$this->run_with_network_active_plugins(
+					$plugins,
+					function () use ( $plugins, $sqlite_plugin, $other_plugin ) {
+						$dropin_before = file_get_contents( WP_CONTENT_DIR . '/db.php' );
+
+						$this->set_bulk_deactivation_request( $plugins );
+						$this->run_bulk_deactivation_preflight( 'plugins-network' );
+
+						$this->assertSame( array( $other_plugin ), $_POST['checked'] );
+
+						deactivate_plugins( $_POST['checked'], false, true );
+
+						$this->assertTrue( is_plugin_active_for_network( $sqlite_plugin ) );
+						$this->assertFalse( is_plugin_active_for_network( $other_plugin ) );
+						$this->assertSame( $dropin_before, file_get_contents( WP_CONTENT_DIR . '/db.php' ) );
+					}
+				);
+			}
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_super_admin_can_bulk_deactivate_sqlite() {
+		$this->set_multisite_user( true );
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+
+		$this->run_with_network_active_plugins(
+			array( $sqlite_plugin ),
+			function () use ( $sqlite_plugin ) {
+				$this->set_bulk_deactivation_request( array( $sqlite_plugin ) );
+				$this->run_bulk_deactivation_preflight( 'plugins-network' );
+
+				$this->assertSame( array( $sqlite_plugin ), $_POST['checked'] );
+
+				$filesystem = $this->run_with_deactivation_filesystem(
+					function () use ( $sqlite_plugin ) {
+						deactivate_plugins( $sqlite_plugin, false, true );
+					}
+				);
+
+				$this->assertFalse( is_plugin_active_for_network( $sqlite_plugin ) );
+				$this->assertSame( WP_CONTENT_DIR . '/db.php', $filesystem->deleted_path );
+			}
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_site_admin_bulk_preflight_does_not_modify_request() {
+		$this->set_multisite_user( false );
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+		$plugins       = array( 'another-plugin/plugin.php', $sqlite_plugin );
+
+		$this->set_bulk_deactivation_request( $plugins );
+		$this->run_bulk_deactivation_preflight( 'plugins' );
+
+		$this->assertSame( $plugins, $_POST['checked'] );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_bulk_preflight_preserves_slashed_plugin_names() {
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+		$other_plugin  = "another-plugin/plugin's.php";
+
+		$this->run_as_delegated_network_plugin_manager(
+			function () use ( $sqlite_plugin, $other_plugin ) {
+				$this->set_bulk_deactivation_request( array( $other_plugin, $sqlite_plugin ) );
+				$_POST['checked'] = wp_slash( $_POST['checked'] );
+
+				$this->run_bulk_deactivation_preflight( 'plugins-network' );
+
+				$this->assertSame( wp_slash( array( $other_plugin ) ), $_POST['checked'] );
+			}
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_bulk_preflight_ignores_non_string_action() {
+		$this->set_multisite_user( false );
+		$plugins = array( plugin_basename( SQLITE_MAIN_FILE ) );
+
+		$this->set_bulk_deactivation_request( $plugins );
+		$_REQUEST['action'] = array( 'deactivate-selected' );
+
+		$this->run_bulk_deactivation_preflight( 'plugins-network' );
+
+		$this->assertSame( $plugins, $_POST['checked'] );
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_network_bulk_deactivation_allows_sqlite_without_dropin() {
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+
+		$this->run_as_delegated_network_plugin_manager(
+			function () use ( $sqlite_plugin ) {
+				$this->run_without_dropin(
+					function () use ( $sqlite_plugin ) {
+						$this->set_bulk_deactivation_request( array( $sqlite_plugin ) );
+						$this->run_bulk_deactivation_preflight( 'plugins-network' );
+
+						$this->assertSame( array( $sqlite_plugin ), $_POST['checked'] );
+					}
+				);
+			}
+		);
+	}
+
+	/**
+	 * @group ms-required
+	 */
+	public function test_deactivation_hook_preserves_dropin_when_bulk_preflight_is_bypassed() {
+		$sqlite_plugin = plugin_basename( SQLITE_MAIN_FILE );
+
+		$this->run_as_delegated_network_plugin_manager(
+			function () use ( $sqlite_plugin ) {
+				$this->run_with_network_active_plugins(
+					array( $sqlite_plugin ),
+					function () use ( $sqlite_plugin ) {
+						$filesystem = $this->run_with_deactivation_filesystem(
+							function () use ( $sqlite_plugin ) {
+								deactivate_plugins( $sqlite_plugin, false, true );
+							}
+						);
+
+						$this->assertFalse( is_plugin_active_for_network( $sqlite_plugin ) );
+						$this->assertNull( $filesystem->deleted_path );
+					}
+				);
+			}
+		);
+	}
+
+	/**
+	 * @group ms-excluded
+	 */
+	public function test_deactivation_hook_allows_programmatic_call_without_user() {
+		wp_set_current_user( 0 );
+
+		$this->assert_deactivation_removes_dropin();
+	}
+
 	private function set_single_site_user( $role ) {
 		$user_id = self::factory()->user->create( array( 'role' => $role ) );
 
@@ -424,6 +601,46 @@ class WP_SQLite_Database_Integration_Authorization_Test extends WP_UnitTestCase 
 		} finally {
 			foreach ( $capabilities as $capability ) {
 				$user->remove_cap( $capability );
+			}
+		}
+	}
+
+	private function run_with_network_active_plugins( $plugins, $callback ) {
+		$active_before = get_site_option( 'active_sitewide_plugins', array() );
+		$active        = $active_before;
+
+		foreach ( $plugins as $plugin ) {
+			$active[ $plugin ] = time();
+		}
+		update_site_option( 'active_sitewide_plugins', $active );
+
+		try {
+			return call_user_func( $callback );
+		} finally {
+			update_site_option( 'active_sitewide_plugins', $active_before );
+		}
+	}
+
+	private function set_bulk_deactivation_request( $plugins ) {
+		$_POST    = array( 'checked' => $plugins );
+		$_REQUEST = array(
+			'action' => 'deactivate-selected',
+		);
+	}
+
+	private function run_bulk_deactivation_preflight( $screen_id ) {
+		$screen_was_set = array_key_exists( 'current_screen', $GLOBALS );
+		$screen_before  = $screen_was_set ? $GLOBALS['current_screen'] : null;
+
+		$GLOBALS['current_screen'] = WP_Screen::get( $screen_id );
+
+		try {
+			sqlite_plugin_filter_network_bulk_deactivation();
+		} finally {
+			if ( $screen_was_set ) {
+				$GLOBALS['current_screen'] = $screen_before;
+			} else {
+				unset( $GLOBALS['current_screen'] );
 			}
 		}
 	}

--- a/wp-setup.sh
+++ b/wp-setup.sh
@@ -41,6 +41,7 @@ services:
     volumes:
       - ../packages/plugin-sqlite-database-integration:/var/www/src/wp-content/plugins/sqlite-database-integration
       - ../packages/mysql-on-sqlite/src:/var/www/src/wp-content/plugins/sqlite-database-integration/wp-includes/database
+      - ../tests/phpunit:/var/www/tests-sqlite-database-integration/phpunit
 
   cli:
     # PHP temporarily pinned to 8.3.10, see: https://github.com/WordPress/wordpress-develop/pull/9602


### PR DESCRIPTION
## Summary

The SQLite integration is enabled by creating `wp-content/db.php`, and plugin deactivation removes that file. On **multisite**, the file is shared by the entire network, so the integration cannot meaningfully be configured per site. Site administrators must not be able to install or remove the network-shared file.

> [!NOTE]  
> The commits reflect the logical sequence of changes, so the PR is best reviewed by commit.

> [!IMPORTANT]
> Multisite installation still fails because enabling the SQLite drop-in switches WordPress to an empty database while multisite remains enabled, causing WordPress to query missing network tables before reaching the installer. This pre-existing issue can be addressed separately.

## Multisite changes
To address this, this PR implements the following **multisite** changes:

1. **Make the plugin network-only** on multisites.<br>This includes moving the plugin settings under network admin for multisite installs.
2. **Restrict installation and configuration** that manipulate `db.php` to network admins on multisites.<br>This means gating the plugin management by the `manage_network_options` capability.
3. **Restrict plugin deactivation** to network admins on multisites.<br>This is necessary, because deactivation removes the `db.php` file.
4. **Handle a special case for bulk deactivation.** <br>WordPress Core doesn't perform per-plugin capability checks in network admin. Therefore, we remove the plugin from the batch when the permissions are missing, and the plugin's deactivation hook refuses to delete `db.php`.

The permissions are designed as follows:

| Action | Capabilities |
|---|---|
| Activate,&nbsp;bulk&nbsp;activate | `manage_network_plugins` + `activate_plugins` |
| Enable/configure&nbsp;SQLite | **`manage_network_options`** |
| Deactivate | `manage_network_plugins` + `activate_plugins` + **`manage_network_options`** |
| Bulk&nbsp;deactivate | `manage_network_plugins` + `activate_plugins` + **`manage_network_options`**<br>Without these permissions, the SQLite plugin is removed from the batch, and the plugin's deactivation hook refuses to delete `db.php`. |

_*Added capabilities marked in **bold**._

## Single-site changes
On single-site installs, there is no risk of network-wide effects, but since the `db.php` drop-in significantly alters the site configuration, it makes sense to require `manage_options` capabilities, consistent with the multisite implementation.

This includes the following **single-site** changes:

| Action | Capabilities |
|---|---|
| Activate,&nbsp;bulk&nbsp;activate | `activate_plugins` |
| Enable/configure&nbsp;SQLite | **`manage_options`** |
| Deactivate,&nbsp;bulk&nbsp;deactivate | `activate_plugins` + **`manage_options`** |

_*Added capabilities marked in **bold**._

## Tests
This PR also adds a new single-site and multisite PHPUnit test suite and CI job for the authorization and installation behavior.
