### PR TITLE
Honor NO_BACKSLASH_ESCAPES consistently

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -1193,10 +1193,21 @@ class WP_MySQL_On_SQLite extends PDO {
 	 * @return WP_MySQL_Parser        A parser initialized for the MySQL query.
 	 */
 	public function create_parser( string $query ): WP_MySQL_Parser {
+		return $this->create_parser_for_sql_modes( $query, $this->active_sql_modes );
+	}
+
+	/**
+	 * Tokenize a MySQL query using specific SQL modes and initialize a parser.
+	 *
+	 * @param  string   $query     The MySQL query to parse.
+	 * @param  string[] $sql_modes The SQL modes active during tokenization.
+	 * @return WP_MySQL_Parser     A parser initialized for the MySQL query.
+	 */
+	private function create_parser_for_sql_modes( string $query, array $sql_modes ): WP_MySQL_Parser {
 		$lexer  = new WP_MySQL_Lexer(
 			$query,
 			80038,
-			$this->active_sql_modes
+			$sql_modes
 		);
 		$tokens = $lexer instanceof WP_MySQL_Native_Lexer
 			? $lexer->native_token_stream()
@@ -6360,7 +6371,10 @@ class WP_MySQL_On_SQLite extends PDO {
 				} elseif ( str_contains( $column['EXTRA'], 'DEFAULT_GENERATED' ) ) {
 					// Handle DEFAULT values with expressions (DEFAULT_GENERATED).
 					// Translate the default clause from MySQL to SQLite.
-					$ast            = $this->create_parser( 'SELECT ' . $column['COLUMN_DEFAULT'] )->parse();
+					$ast            = $this->create_parser_for_sql_modes(
+						'SELECT ' . $column['COLUMN_DEFAULT'],
+						array()
+					)->parse();
 					$expr           = $ast->get_first_descendant_node( 'selectItem' )->get_first_child_node();
 					$default_clause = $this->translate( $expr );
 					$query         .= sprintf( ' DEFAULT (%s)', $default_clause );
@@ -6486,7 +6500,10 @@ class WP_MySQL_On_SQLite extends PDO {
 			}
 
 			// Translate the check clause from MySQL to SQLite.
-			$ast          = $this->create_parser( 'SELECT ' . $check_constraint['CHECK_CLAUSE'] )->parse();
+			$ast          = $this->create_parser_for_sql_modes(
+				'SELECT ' . $check_constraint['CHECK_CLAUSE'],
+				array()
+			)->parse();
 			$expr         = $ast->get_first_descendant_node( 'selectItem' )->get_first_child_node();
 			$check_clause = $this->translate( $expr );
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -4446,8 +4446,9 @@ class WP_MySQL_On_SQLite extends PDO {
 		if ( true === $is_binary ) {
 			$children = $node->get_children();
 			return sprintf(
-				'GLOB _helper_like_to_glob_pattern(%s)',
-				$this->translate( $children[1] )
+				'GLOB _helper_like_to_glob_pattern(%s, %d)',
+				$this->translate( $children[1] ),
+				$this->is_sql_mode_active( 'NO_BACKSLASH_ESCAPES' ) ? 0 : 1
 			);
 		}
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -1010,6 +1010,34 @@ class WP_MySQL_On_SQLite extends PDO {
 	}
 
 	/**
+	 * PDO API: Quote a string for use in a MySQL query.
+	 *
+	 * @param  string $string The string to quote.
+	 * @param  int    $type   The PDO parameter type. Ignored.
+	 * @return string         The quoted string.
+	 */
+	#[ReturnTypeWillChange]
+	// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.stringFound
+	public function quote( $string, $type = PDO::PARAM_STR ) {
+		$string = (string) $string;
+		if ( $this->is_sql_mode_active( 'NO_BACKSLASH_ESCAPES' ) ) {
+			return "'" . str_replace( "'", "''", $string ) . "'";
+		}
+
+		$backslash    = chr( 92 );
+		$replacements = array(
+			chr( 0 )   => $backslash . '0',
+			chr( 10 )  => $backslash . 'n',
+			chr( 13 )  => $backslash . 'r',
+			$backslash => $backslash . $backslash,
+			"'"        => $backslash . "'",
+			'"'        => $backslash . '"',
+			chr( 26 )  => $backslash . 'Z',
+		);
+		return "'" . strtr( $string, $replacements ) . "'";
+	}
+
+	/**
 	 * PDO API: Begin a transaction.
 	 *
 	 * @return bool True on success, false on failure.

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-builder.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-builder.php
@@ -3110,6 +3110,15 @@ class WP_SQLite_Information_Schema_Builder {
 		$value         = '';
 		$last_token_id = null;
 		foreach ( $node->get_descendant_tokens() as $i => $token ) {
+			if (
+				WP_MySQL_Lexer::SINGLE_QUOTED_TEXT === $token->id
+				|| WP_MySQL_Lexer::DOUBLE_QUOTED_TEXT === $token->id
+			) {
+				$token_bytes = $this->quote_mysql_string_literal( $token->get_value() );
+			} else {
+				$token_bytes = $token->get_bytes();
+			}
+
 			// Do not insert whitespace around parentheses. This is primarily to
 			// avoid inserting whitespace before '(', which may break function
 			// calls, depending on the value of the "IGNORE_SPACE" SQL mode.
@@ -3120,13 +3129,32 @@ class WP_SQLite_Information_Schema_Builder {
 				|| WP_MySQL_Lexer::OPEN_PAR_SYMBOL === $last_token_id
 				|| WP_MySQL_Lexer::CLOSE_PAR_SYMBOL === $last_token_id
 			) {
-				$value .= $token->get_bytes();
+				$value .= $token_bytes;
 			} else {
-				$value .= ' ' . $token->get_bytes();
+				$value .= ' ' . $token_bytes;
 			}
 			$last_token_id = $token->id;
 		}
 		return $value;
+	}
+
+	/**
+	 * Quote a string literal for parsing with the default MySQL SQL mode.
+	 *
+	 * @param  string $value The unquoted string value.
+	 * @return string        The quoted string literal.
+	 */
+	private function quote_mysql_string_literal( string $value ): string {
+		$backslash    = chr( 92 );
+		$replacements = array(
+			"'"        => "''",
+			$backslash => $backslash . $backslash,
+			chr( 0 )   => $backslash . '0',
+			chr( 10 )  => $backslash . 'n',
+			chr( 13 )  => $backslash . 'r',
+			chr( 26 )  => $backslash . 'Z',
+		);
+		return "'" . strtr( $value, $replacements ) . "'";
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
@@ -581,7 +581,9 @@ class WP_SQLite_Information_Schema_Reconstructor {
 		// Checking the prefix is enough as SQLite doesn't allow malformed values.
 		if ( str_starts_with( $uppercase_default_value, "X'" ) ) {
 			// Convert the hex string to ASCII bytes.
-			return "'" . pack( 'H*', substr( $default_value, 2, -1 ) ) . "'";
+			return $this->quote_mysql_utf8_string_literal(
+				pack( 'H*', substr( $default_value, 2, -1 ) )
+			);
 		}
 
 		// Unquoted string literal. E.g.: abc
@@ -772,6 +774,10 @@ class WP_SQLite_Information_Schema_Reconstructor {
 	 * @return string               The escaped string literal.
 	 */
 	private function quote_mysql_utf8_string_literal( string $utf8_literal ): string {
+		if ( $this->driver->is_sql_mode_active( 'NO_BACKSLASH_ESCAPES' ) ) {
+			return "'" . str_replace( "'", "''", $utf8_literal ) . "'";
+		}
+
 		$backslash    = chr( 92 );
 		$replacements = array(
 			"'"        => "''",                    // A single quote character (').

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -960,9 +960,10 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	 *        consider applying some of the conversions more broadly.
 	 *
 	 * @param string $pattern
+	 * @param bool   $backslash_escapes Whether backslashes escape pattern characters.
 	 * @return string
 	 */
-	public function _helper_like_to_glob_pattern( $pattern ) {
+	public function _helper_like_to_glob_pattern( $pattern, $backslash_escapes ) {
 		if ( null === $pattern ) {
 			return null;
 		}
@@ -978,6 +979,10 @@ class WP_SQLite_PDO_User_Defined_Functions {
 		$pattern = str_replace( ']', '[]]', $pattern );
 		$pattern = str_replace( '*', '[*]', $pattern );
 		$pattern = str_replace( '?', '[?]', $pattern );
+
+		if ( ! $backslash_escapes ) {
+			return str_replace( array( '%', '_' ), array( '*', '?' ), $pattern );
+		}
 
 		/*
 		 * 2. Convert LIKE wildcards to GLOB wildcards ("%" -> "*", "_" -> "?").

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -299,6 +299,25 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertEquals( 0, $result );
 	}
 
+	public function test_quote_honors_no_backslash_escapes(): void {
+		$backslash = chr( 92 );
+		$value     = chr( 0 ) . "\n\r{$backslash}'\"" . chr( 26 ) . "\tƮềʂᴛ🙂";
+
+		$this->driver->query( "SET SESSION sql_mode = ''" );
+		$quoted = $this->driver->quote( $value );
+		$this->assertSame(
+			"'{$backslash}0{$backslash}n{$backslash}r"
+				. "{$backslash}{$backslash}{$backslash}'{$backslash}\"{$backslash}Z\tƮềʂᴛ🙂'",
+			$quoted
+		);
+		$this->assertSame( $value, $this->driver->query( "SELECT $quoted" )->fetchColumn() );
+
+		$this->driver->query( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
+		$quoted = $this->driver->quote( $value );
+		$this->assertSame( "'" . str_replace( "'", "''", $value ) . "'", $quoted );
+		$this->assertSame( $value, $this->driver->query( "SELECT $quoted" )->fetchColumn() );
+	}
+
 	public function test_begin_transaction(): void {
 		$result = $this->driver->beginTransaction();
 		$this->assertTrue( $result );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -6174,6 +6174,46 @@ QUERY
 		$this->assertSame( $backslash . '_', $result[0]->value_12 );
 	}
 
+	public function testStoredExpressionsPreserveStringValuesAcrossSqlModeChanges(): void {
+		$backslash = chr( 92 );
+
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+		$this->assertQuery(
+			"CREATE TABLE default_mode (
+				id INT,
+				value VARCHAR(20) DEFAULT (CONCAT('a{$backslash}n', 'b')),
+				CHECK (value = 'a{$backslash}nb')
+			)"
+		);
+		$this->assertQuery( 'INSERT INTO default_mode (id) VALUES (1)' );
+
+		$this->assertQuery( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
+		$this->assertQuery( 'ALTER TABLE default_mode ADD COLUMN extra INT' );
+		$this->assertQuery( 'INSERT INTO default_mode (id) VALUES (2)' );
+
+		$result = $this->assertQuery( 'SELECT value FROM default_mode ORDER BY id' );
+		$this->assertSame( array( "a\nb", "a\nb" ), array_column( $result, 'value' ) );
+
+		$this->assertQuery(
+			"CREATE TABLE no_backslash_mode (
+				id INT,
+				value VARCHAR(20) DEFAULT (CONCAT('a{$backslash}n', 'b')),
+				CHECK (value = 'a{$backslash}nb')
+			)"
+		);
+		$this->assertQuery( 'INSERT INTO no_backslash_mode (id) VALUES (1)' );
+
+		$this->assertQuery( "SET SESSION sql_mode = ''" );
+		$this->assertQuery( 'ALTER TABLE no_backslash_mode ADD COLUMN extra INT' );
+		$this->assertQuery( 'INSERT INTO no_backslash_mode (id) VALUES (2)' );
+
+		$result = $this->assertQuery( 'SELECT value FROM no_backslash_mode ORDER BY id' );
+		$this->assertSame(
+			array( "a{$backslash}nb", "a{$backslash}nb" ),
+			array_column( $result, 'value' )
+		);
+	}
+
 	public function testNoBackslashEscapesSqlModeWithPatternMatching(): void {
 		$backslash = chr( 92 );
 

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -4452,6 +4452,18 @@ QUERY
 		// Test LIKE without BINARY
 		$result = $this->assertQuery( "SELECT * FROM _tmp_table WHERE name LIKE 'FIRST'" );
 		$this->assertCount( 2, $result ); // Should match both 'first' and 'FIRST'
+
+		$this->assertQuery( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
+
+		// Backslashes are literal, while the following "_" remains a wildcard.
+		$result = $this->assertQuery( "SELECT * FROM _tmp_table WHERE name LIKE BINARY 'special\\_hars'" );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'special\chars', $result[0]->name );
+
+		// Backslashes are literal, while the following "%" remains a wildcard.
+		$result = $this->assertQuery( "SELECT * FROM _tmp_table WHERE name LIKE BINARY 'special\\%'" );
+		$this->assertCount( 1, $result );
+		$this->assertEquals( 'special\chars', $result[0]->name );
 	}
 
 	public function testUniqueConstraints() {

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_DB_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_DB_Tests.php
@@ -1,0 +1,116 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/fixtures/class-wp-sqlite-db-test-double.php';
+
+class WP_SQLite_DB_Tests extends TestCase {
+	/** @var WP_MySQL_On_SQLite */
+	private $driver;
+
+	/** @var WP_SQLite_DB_Test_Double */
+	private $wpdb;
+
+	public function setUp(): void {
+		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
+		$pdo       = new $pdo_class( 'sqlite::memory:' );
+
+		$this->driver = new WP_MySQL_On_SQLite(
+			'mysql-on-sqlite:dbname=wp',
+			null,
+			null,
+			array( 'pdo' => $pdo )
+		);
+		$this->wpdb   = new WP_SQLite_DB_Test_Double( $this->driver );
+	}
+
+	/**
+	 * @dataProvider dataMysqlndDefaultEscaping
+	 */
+	public function testRealEscapeMatchesMysqlndWithBackslashEscapes( string $value, string $expected ): void {
+		$this->setSqlMode( '' );
+
+		$this->assertSame( $expected, $this->wpdb->_real_escape( $value ) );
+	}
+
+	public static function dataMysqlndDefaultEscaping(): array {
+		return array(
+			'ASCII null'      => array( chr( 0 ), '\\0' ),
+			'newline'         => array( "\n", '\\n' ),
+			'carriage return' => array( "\r", '\\r' ),
+			'backslash'       => array( '\\', '\\\\' ),
+			'single quote'    => array( "'", "\\'" ),
+			'double quote'    => array( '"', '\\"' ),
+			'Control+Z'       => array( chr( 26 ), '\\Z' ),
+			'backspace'       => array( chr( 8 ), chr( 8 ) ),
+			'tab'             => array( "\t", "\t" ),
+			'UTF-8'           => array( 'Ʈềʂᴛ🙂', 'Ʈềʂᴛ🙂' ),
+		);
+	}
+
+	/**
+	 * @dataProvider dataMysqlndNoBackslashEscapes
+	 */
+	public function testRealEscapeMatchesMysqlndWithoutBackslashEscapes( string $value, string $expected ): void {
+		$this->setSqlMode( 'NO_BACKSLASH_ESCAPES' );
+
+		$this->assertSame( $expected, $this->wpdb->_real_escape( $value ) );
+	}
+
+	public static function dataMysqlndNoBackslashEscapes(): array {
+		return array(
+			'ASCII null'      => array( chr( 0 ), chr( 0 ) ),
+			'newline'         => array( "\n", "\n" ),
+			'carriage return' => array( "\r", "\r" ),
+			'backslash'       => array( '\\', '\\' ),
+			'single quote'    => array( "'", "''" ),
+			'double quote'    => array( '"', '"' ),
+			'Control+Z'       => array( chr( 26 ), chr( 26 ) ),
+			'backspace'       => array( chr( 8 ), chr( 8 ) ),
+			'tab'             => array( "\t", "\t" ),
+			'UTF-8'           => array( 'Ʈềʂᴛ🙂', 'Ʈềʂᴛ🙂' ),
+		);
+	}
+
+	/**
+	 * @dataProvider dataStringRoundTrips
+	 */
+	public function testRealEscapeRoundTripsThroughTheActiveSqlMode( string $mode, string $value ): void {
+		$this->setSqlMode( $mode );
+
+		$escaped = $this->wpdb->_real_escape( $value );
+		$result  = $this->driver->query( "SELECT '$escaped'" );
+
+		$this->assertSame( $value, $result->fetchColumn() );
+	}
+
+	public static function dataStringRoundTrips(): array {
+		$special_characters = implode(
+			'',
+			array( chr( 0 ), "\n", "\r", '\\', "'", '"', chr( 26 ), chr( 8 ), "\t" )
+		);
+
+		return array(
+			'default mode special characters'         => array( '', $special_characters ),
+			'default mode UTF-8'                      => array( '', 'Ʈềʂᴛ🙂' ),
+			'NO_BACKSLASH_ESCAPES special characters' => array( 'NO_BACKSLASH_ESCAPES', $special_characters ),
+			'NO_BACKSLASH_ESCAPES UTF-8'              => array( 'NO_BACKSLASH_ESCAPES', 'Ʈềʂᴛ🙂' ),
+		);
+	}
+
+	public function testRealEscapePreventsSqlInjectionWithoutBackslashEscapes(): void {
+		$this->driver->query( 'CREATE TABLE users (username TEXT, secret TEXT)' );
+		$this->driver->query( "INSERT INTO users VALUES ('admin', 'password-hash')" );
+		$this->setSqlMode( 'NO_BACKSLASH_ESCAPES' );
+
+		$payload = "nobody' UNION SELECT secret FROM users #";
+		$escaped = $this->wpdb->_real_escape( $payload );
+		$result  = $this->driver->query( "SELECT username FROM users WHERE username = '$escaped'" );
+
+		$this->assertSame( array(), $result->fetchAll( PDO::FETCH_COLUMN ) );
+	}
+
+	private function setSqlMode( string $mode ): void {
+		$this->driver->query( "SET SESSION sql_mode = '$mode'" );
+	}
+}

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
@@ -346,6 +346,55 @@ class WP_SQLite_Information_Schema_Reconstructor_Tests extends TestCase {
 		);
 	}
 
+	public function testDefaultValueEscapingWithoutBackslashEscapes(): void {
+		$this->engine->get_connection()->query(
+			"
+			CREATE TABLE t (
+				single_quote text DEFAULT 'abc''xyz',
+				backslash text DEFAULT 'abc\\xyz',
+				newline text DEFAULT 'abc\nxyz',
+				carriage_return text DEFAULT 'abc\rxyz',
+				blob_value blob DEFAULT x'275C'
+			)
+		"
+		);
+		$this->assertQuery( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
+
+		$this->reconstructor->ensure_correct_information_schema();
+		$result = $this->assertQuery(
+			'SELECT column_name, column_default
+			 FROM information_schema.columns
+			 WHERE table_name = "t"
+			 ORDER BY ordinal_position'
+		);
+
+		$this->assertEquals(
+			array(
+				(object) array(
+					'COLUMN_NAME'    => 'single_quote',
+					'COLUMN_DEFAULT' => "abc'xyz",
+				),
+				(object) array(
+					'COLUMN_NAME'    => 'backslash',
+					'COLUMN_DEFAULT' => 'abc\xyz',
+				),
+				(object) array(
+					'COLUMN_NAME'    => 'newline',
+					'COLUMN_DEFAULT' => "abc\nxyz",
+				),
+				(object) array(
+					'COLUMN_NAME'    => 'carriage_return',
+					'COLUMN_DEFAULT' => "abc\rxyz",
+				),
+				(object) array(
+					'COLUMN_NAME'    => 'blob_value',
+					'COLUMN_DEFAULT' => "'\\",
+				),
+			),
+			$result
+		);
+	}
+
 	public function testInvalidDataTypeCacheDataForDecimalDefinition(): void {
 		// Recreate the invalid database state before the following fix:
 		//   https://github.com/WordPress/sqlite-database-integration/pull/126

--- a/packages/mysql-on-sqlite/tests/fixtures/class-wp-sqlite-db-test-double.php
+++ b/packages/mysql-on-sqlite/tests/fixtures/class-wp-sqlite-db-test-double.php
@@ -1,0 +1,14 @@
+<?php
+
+require_once __DIR__ . '/class-wpdb-test-double.php';
+require_once __DIR__ . '/../../../plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php';
+
+class WP_SQLite_DB_Test_Double extends WP_SQLite_DB {
+	public function __construct( WP_MySQL_On_SQLite $driver ) {
+		$this->dbh = $driver;
+	}
+
+	public function add_placeholder_escape( $query ) {
+		return $query;
+	}
+}

--- a/packages/mysql-on-sqlite/tests/fixtures/class-wpdb-test-double.php
+++ b/packages/mysql-on-sqlite/tests/fixtures/class-wpdb-test-double.php
@@ -1,0 +1,5 @@
+<?php
+
+class WPDB_Test_Double {}
+
+class_alias( WPDB_Test_Double::class, 'wpdb' );

--- a/packages/mysql-proxy/src/Adapter/class-adapter.php
+++ b/packages/mysql-proxy/src/Adapter/class-adapter.php
@@ -6,4 +6,6 @@ use WP_MySQL_Proxy\MySQL_Result;
 
 interface Adapter {
 	public function handle_query( string $query ): MySQL_Result;
+
+	public function get_server_status_flags(): int;
 }

--- a/packages/mysql-proxy/src/Adapter/class-sqlite-adapter.php
+++ b/packages/mysql-proxy/src/Adapter/class-sqlite-adapter.php
@@ -52,6 +52,13 @@ class SQLite_Adapter implements Adapter {
 		}
 	}
 
+	public function get_server_status_flags(): int {
+		if ( $this->sqlite_driver->is_sql_mode_active( 'NO_BACKSLASH_ESCAPES' ) ) {
+			return MySQL_Protocol::SERVER_STATUS_NO_BACKSLASH_ESCAPES;
+		}
+		return 0;
+	}
+
 	public function computeColumnInfo() {
 		$columns = array();
 

--- a/packages/mysql-proxy/src/class-mysql-protocol.php
+++ b/packages/mysql-proxy/src/class-mysql-protocol.php
@@ -58,20 +58,21 @@ class MySQL_Protocol {
 	 * @see https://dev.mysql.com/doc/dev/mysql-server/latest/mysql__com_8h.html#a1d854e841086925be1883e4d7b4e8cad
 	 * @see https://github.com/mysql/mysql-server/blob/056a391cdc1af9b17b5415aee243483d1bac532d/include/mysql_com.h#L810
 	 */
-	const SERVER_STATUS_IN_TRANS          = 1 << 0;  // A multi-statement transaction has been started.
-	const SERVER_STATUS_AUTOCOMMIT        = 1 << 1;  // Server in autocommit mode.
-	const SERVER_STATUS_UNUSED_2          = 1 << 2;  // [UNUSED]
-	const SERVER_MORE_RESULTS_EXISTS      = 1 << 3;  // Multi query - next query exists.
-	const SERVER_QUERY_NO_GOOD_INDEX_USED = 1 << 4;  // No good index was used for the query.
-	const SERVER_QUERY_NO_INDEX_USED      = 1 << 5;  // No index was used for the query.
-	const SERVER_STATUS_CURSOR_EXISTS     = 1 << 6;  // A cursor exists for a query. FETCH must be used to get data.
-	const SERVER_STATUS_LAST_ROW_SENT     = 1 << 7;  // A cursor has been exhausted. Sent in reply to FETCH command.
-	const SERVER_STATUS_DB_DROPPED        = 1 << 8;  // A database was dropped.
-	const SERVER_STATUS_METADATA_CHANGED  = 1 << 9;  // A set of columns changed after a prepared statement was reprepared.
-	const SERVER_QUERY_WAS_SLOW           = 1 << 10; // A query was slow.
-	const SERVER_PS_OUT_PARAMS            = 1 << 11; // Mark ResultSet containing output parameter values.
-	const SERVER_STATUS_IN_TRANS_READONLY = 1 << 12; // Set together with SERVER_STATUS_IN_TRANS for read-only transactions.
-	const SERVER_SESSION_STATE_CHANGED    = 1 << 13; // One of the server state information has changed during last statement.
+	const SERVER_STATUS_IN_TRANS             = 1 << 0;  // A multi-statement transaction has been started.
+	const SERVER_STATUS_AUTOCOMMIT           = 1 << 1;  // Server in autocommit mode.
+	const SERVER_STATUS_UNUSED_2             = 1 << 2;  // [UNUSED]
+	const SERVER_MORE_RESULTS_EXISTS         = 1 << 3;  // Multi query - next query exists.
+	const SERVER_QUERY_NO_GOOD_INDEX_USED    = 1 << 4;  // No good index was used for the query.
+	const SERVER_QUERY_NO_INDEX_USED         = 1 << 5;  // No index was used for the query.
+	const SERVER_STATUS_CURSOR_EXISTS        = 1 << 6;  // A cursor exists for a query. FETCH must be used to get data.
+	const SERVER_STATUS_LAST_ROW_SENT        = 1 << 7;  // A cursor has been exhausted. Sent in reply to FETCH command.
+	const SERVER_STATUS_DB_DROPPED           = 1 << 8;  // A database was dropped.
+	const SERVER_STATUS_NO_BACKSLASH_ESCAPES = 1 << 9;  // Backslashes are not used as string escape characters.
+	const SERVER_STATUS_METADATA_CHANGED     = 1 << 10; // A set of columns changed after a prepared statement was reprepared.
+	const SERVER_QUERY_WAS_SLOW              = 1 << 11; // A query was slow.
+	const SERVER_PS_OUT_PARAMS               = 1 << 12; // Mark ResultSet containing output parameter values.
+	const SERVER_STATUS_IN_TRANS_READONLY    = 1 << 13; // Set together with SERVER_STATUS_IN_TRANS for read-only transactions.
+	const SERVER_SESSION_STATE_CHANGED       = 1 << 14; // One of the server state information has changed during last statement.
 
 	/**
 	 * MySQL command types.

--- a/packages/mysql-proxy/src/class-mysql-session.php
+++ b/packages/mysql-proxy/src/class-mysql-session.php
@@ -105,6 +105,7 @@ class MySQL_Session {
 
 		// Generate random auth plugin data (20-byte salt)
 		$this->auth_plugin_data = random_bytes( 20 );
+		$this->sync_status_flags();
 	}
 
 	/**
@@ -334,6 +335,8 @@ class MySQL_Session {
 				);
 			}
 
+			$this->sync_status_flags();
+
 			if ( count( $result->columns ) > 0 ) {
 				return $this->build_result_set_packets(
 					$result->columns,
@@ -357,6 +360,17 @@ class MySQL_Session {
 				'Unknown error: ' . $e->getMessage()
 			);
 		}
+	}
+
+	/**
+	 * Synchronize adapter-managed server status flags.
+	 */
+	private function sync_status_flags(): void {
+		$adapter_flags = $this->adapter->get_server_status_flags();
+		$managed_flags = MySQL_Protocol::SERVER_STATUS_NO_BACKSLASH_ESCAPES;
+
+		$this->status_flags &= ~$managed_flags;
+		$this->status_flags |= $adapter_flags & $managed_flags;
 	}
 
 	/**

--- a/packages/mysql-proxy/tests/WP_MySQL_Protocol_Test.php
+++ b/packages/mysql-proxy/tests/WP_MySQL_Protocol_Test.php
@@ -1,0 +1,15 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use WP_MySQL_Proxy\MySQL_Protocol;
+
+class WP_MySQL_Protocol_Test extends TestCase {
+	public function test_server_status_flag_values(): void {
+		$this->assertSame( 0x0200, MySQL_Protocol::SERVER_STATUS_NO_BACKSLASH_ESCAPES );
+		$this->assertSame( 0x0400, MySQL_Protocol::SERVER_STATUS_METADATA_CHANGED );
+		$this->assertSame( 0x0800, MySQL_Protocol::SERVER_QUERY_WAS_SLOW );
+		$this->assertSame( 0x1000, MySQL_Protocol::SERVER_PS_OUT_PARAMS );
+		$this->assertSame( 0x2000, MySQL_Protocol::SERVER_STATUS_IN_TRANS_READONLY );
+		$this->assertSame( 0x4000, MySQL_Protocol::SERVER_SESSION_STATE_CHANGED );
+	}
+}

--- a/packages/mysql-proxy/tests/WP_MySQL_Proxy_MySQLi_Test.php
+++ b/packages/mysql-proxy/tests/WP_MySQL_Proxy_MySQLi_Test.php
@@ -21,4 +21,14 @@ class WP_MySQL_Proxy_MySQLi_Test extends WP_MySQL_Proxy_Test {
 		// TODO: Implement prepared statements in the MySQL proxy.
 		$this->markTestSkipped( 'Prepared statements are not supported yet.' );
 	}
+
+	public function test_real_escape_string_honors_no_backslash_escapes(): void {
+		$value = "a'b\\c";
+
+		$this->mysqli->query( "SET SESSION sql_mode = ''" );
+		$this->assertSame( "a\\'b\\\\c", $this->mysqli->real_escape_string( $value ) );
+
+		$this->mysqli->query( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
+		$this->assertSame( "a''b\\c", $this->mysqli->real_escape_string( $value ) );
+	}
 }

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -306,7 +306,42 @@ class WP_SQLite_DB extends wpdb {
 		if ( ! is_scalar( $data ) ) {
 			return '';
 		}
-		$escaped = addslashes( $data );
+
+		/*
+		 * Match mysqlnd's escaping for single-quoted strings, which is the
+		 * quoting convention used by wpdb::prepare().
+		 */
+		$data = (string) $data;
+		if ( ! $this->dbh ) {
+			$escaped = addslashes( $data );
+		} elseif ( $this->dbh->is_sql_mode_active( 'NO_BACKSLASH_ESCAPES' ) ) {
+			$escaped = str_replace( "'", "''", $data );
+		} else {
+			/*
+			 * We can't use "addcslashes()" here, because it has an unusual handling
+			 * of the ASCII NULL and Control+Z characters, escaping them to "\000"
+			 * and "\032" instead of "\0" and "\Z", respectively.
+			 *
+			 * It is important to use "strtr()" and not "str_replace()", because
+			 * "str_replace()" applies replacements one after another, modifying
+			 * intermediate changes rather than just the original string:
+			 *
+			 *   - str_replace( [ 'a', 'b' ], [ 'b', 'c' ], 'ab' ); // 'cc' (bad)
+			 *   - strtr( 'ab', [ 'a' => 'b', 'b' => 'c' ] );       // 'bc' (good)
+			 */
+			$backslash    = chr( 92 );
+			$replacements = array(
+				chr( 0 )   => $backslash . '0',        // An ASCII NULL character (\0).
+				chr( 10 )  => $backslash . 'n',        // A newline (linefeed) character (\n).
+				chr( 13 )  => $backslash . 'r',        // A carriage return character (\r).
+				$backslash => $backslash . $backslash, // A backslash character (\).
+				"'"        => $backslash . "'",        // A single quote character (').
+				'"'        => $backslash . '"',        // A double quote character (").
+				chr( 26 )  => $backslash . 'Z',        // An ASCII 26 (Control+Z) character.
+			);
+			$escaped      = strtr( $data, $replacements );
+		}
+
 		return $this->add_placeholder_escape( $escaped );
 	}
 


### PR DESCRIPTION
## What changed

- Match mysqlnd string escaping in both default and `NO_BACKSLASH_ESCAPES` modes.
- Make `LIKE BINARY` pattern translation respect the active SQL mode.
- Preserve stored `DEFAULT` and `CHECK` expression values across SQL mode changes and table rebuilds.
- Quote reconstructed schema literals according to the active SQL mode.
- Expose `SERVER_STATUS_NO_BACKSLASH_ESCAPES` through the MySQL protocol so clients such as mysqli escape strings correctly.
- Implement mode-aware `PDO::quote()` behavior.

## Why

String parsing already understood `NO_BACKSLASH_ESCAPES`, but several quoting, reconstruction, pattern-matching, persistence, and protocol paths still assumed backslash escaping. That could change values during schema rebuilds, produce incorrect patterns or literals, and cause connected clients to escape strings for the wrong server mode.

This makes those paths consistent with MySQL/mysqlnd while retaining the existing default-mode behavior.

## Testing

- Full SQLite driver suite: 774 tests, 1,428,369 assertions
- Full MySQL proxy suite: 12 tests, 28 assertions
- Targeted WordPress escaping and SQL injection regression tests
- Coding standards
- PHP syntax checks
- PHP 7.2 compatibility checks for the added code
- Composer validation and diff whitespace checks