### PR TITLE
Improve string escaping

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -3524,7 +3524,14 @@ class WP_MySQL_On_SQLite extends PDO {
 
 		if ( WP_MySQL_Lexer::SESSION_SYMBOL === $type ) {
 			if ( 'sql_mode' === $name ) {
-				$modes                  = explode( ',', strtoupper( $value ) );
+				// MySQL ignores trailing ASCII spaces in SQL mode names.
+				$modes = explode( ',', strtoupper( $value ) );
+				foreach ( $modes as $i => $mode ) {
+					$modes[ $i ] = rtrim( $mode, ' ' );
+				}
+				if ( in_array( 'NO_BACKSLASH_ESCAPES', $modes, true ) ) {
+					throw $this->new_not_supported_exception( "SQL mode 'NO_BACKSLASH_ESCAPES'" );
+				}
 				$this->active_sql_modes = $modes;
 			} else {
 				$this->session_system_variables[ $name ] = $value;

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -1010,6 +1010,75 @@ class WP_MySQL_On_SQLite extends PDO {
 	}
 
 	/**
+	 * PDO API: Quote a string for use in a MySQL query.
+	 *
+	 * @param  string $string The string to quote.
+	 * @param  int    $type   The PDO parameter type.
+	 * @return string         The quoted string.
+	 */
+	#[ReturnTypeWillChange]
+	// phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.stringFound
+	public function quote( $string, $type = PDO::PARAM_STR ) {
+		// Mirror PDO\MySQL::quote() value validation.
+		if (
+			is_array( $string )
+			|| is_resource( $string )
+			|| ( is_object( $string ) && ! method_exists( $string, '__toString' ) )
+		) {
+			$given_type = is_object( $string ) ? get_class( $string ) : gettype( $string );
+			throw new TypeError(
+				sprintf(
+					'WP_MySQL_On_SQLite::quote(): Argument #1 ($string) must be of type string, %s given',
+					$given_type
+				)
+			);
+		}
+		$string = (string) $string;
+
+		// Handle binary and national character prefixes.
+		$prefix = '';
+		if ( PDO::PARAM_LOB === ( $type & PDO::PARAM_LOB ) ) {
+			$prefix = '_binary';
+		} elseif (
+			PDO::PARAM_STR_NATL === ( $type & PDO::PARAM_STR_NATL )
+			&& PDO::PARAM_STR_CHAR !== ( $type & PDO::PARAM_STR_CHAR )
+		) {
+			$prefix = 'N';
+		}
+
+		/*
+		 * PDO uses mysqlnd by default and can alternatively use libmysqlclient.
+		 * This escaped character mapping matches the escaping of both drivers.
+		 * Their malformed multibyte sequence handling is not needed for UTF-8.
+		 *
+		 * @see https://github.com/php/php-src/blob/dd6e76cce27aaa0ed9f7520648ed1081dfb6af36/ext/mysqlnd/mysqlnd_charset.c#L905
+		 * @see https://github.com/mysql/mysql-server/blob/dc86e412f18b36ce271f791026714e8caa0ec919/mysys/charset.cc#L413
+		 *
+		 * We can't use "addcslashes()" here, because it has an unusual handling
+		 * of the ASCII NULL and Control+Z characters, escaping them to "\000"
+		 * and "\032" instead of "\0" and "\Z", respectively.
+		 *
+		 * It is important to use "strtr()" and not "str_replace()", because
+		 * "str_replace()" applies replacements one after another, modifying
+		 * intermediate changes rather than just the original string:
+		 *
+		 *   - str_replace( [ 'a', 'b' ], [ 'b', 'c' ], 'ab' ); // 'cc' (bad)
+		 *   - strtr( 'ab', [ 'a' => 'b', 'b' => 'c' ] );       // 'bc' (good)
+		 */
+		$backslash    = chr( 92 );
+		$replacements = array(
+			chr( 0 )   => $backslash . '0',        // An ASCII NULL character (\0).
+			chr( 10 )  => $backslash . 'n',        // A newline (linefeed) character (\n).
+			chr( 13 )  => $backslash . 'r',        // A carriage return character (\r).
+			$backslash => $backslash . $backslash, // A backslash character (\).
+			"'"        => $backslash . "'",        // A single quote character (').
+			'"'        => $backslash . '"',        // A double quote character (").
+			chr( 26 )  => $backslash . 'Z',        // An ASCII 26 (Control+Z) character.
+		);
+		return $prefix . "'" . strtr( $string, $replacements ) . "'";
+	}
+
+	/**
 	 * PDO API: Begin a transaction.
 	 *
 	 * @return bool True on success, false on failure.

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -299,6 +299,64 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertEquals( 0, $result );
 	}
 
+	public function test_quote_matches_mysql_escaping(): void {
+		$backslash = chr( 92 );
+		$value     = chr( 0 ) . "\n\r{$backslash}'\"" . chr( 26 ) . "\tƮềʂᴛ🙂";
+
+		$quoted = $this->driver->quote( $value );
+		$this->assertSame(
+			"'{$backslash}0{$backslash}n{$backslash}r"
+				. "{$backslash}{$backslash}{$backslash}'{$backslash}\"{$backslash}Z\tƮềʂᴛ🙂'",
+			$quoted
+		);
+		$this->assertSame( $value, $this->driver->query( "SELECT $quoted" )->fetchColumn() );
+	}
+
+	public function test_quote_supports_parameter_types(): void {
+		$value  = "\0\n\r\\'\"" . chr( 26 ) . "\tƮềʂᴛ🙂";
+		$quoted = $this->driver->quote( $value );
+
+		$this->assertSame( $quoted, $this->driver->quote( $value, PDO::PARAM_STR ) );
+		$this->assertSame( 'N' . $quoted, $this->driver->quote( $value, PDO::PARAM_STR_NATL ) );
+		$this->assertSame( $quoted, $this->driver->quote( $value, PDO::PARAM_STR_CHAR ) );
+		$this->assertSame(
+			$quoted,
+			$this->driver->quote( $value, PDO::PARAM_STR_NATL | PDO::PARAM_STR_CHAR )
+		);
+		$this->assertSame( '_binary' . $quoted, $this->driver->quote( $value, PDO::PARAM_LOB ) );
+		$this->assertSame(
+			'_binary' . $quoted,
+			$this->driver->quote( $value, PDO::PARAM_LOB | PDO::PARAM_STR_NATL )
+		);
+	}
+
+	public function test_quote_rejects_non_stringable_values(): void {
+		$resource = fopen( 'php://memory', 'r' );
+
+		try {
+			foreach ( array( array(), $resource, new stdClass() ) as $value ) {
+				try {
+					$this->driver->quote( $value );
+					$this->fail( 'Expected quote() to throw a TypeError.' );
+				} catch ( TypeError $e ) {
+					$this->assertStringContainsString( 'must be of type string', $e->getMessage() );
+				}
+			}
+		} finally {
+			fclose( $resource );
+		}
+	}
+
+	public function test_quote_accepts_stringable_objects(): void {
+		$value = new class() {
+			public function __toString(): string {
+				return 'value';
+			}
+		};
+
+		$this->assertSame( "'value'", $this->driver->quote( $value ) );
+	}
+
 	public function test_begin_transaction(): void {
 		$result = $this->driver->beginTransaction();
 		$this->assertTrue( $result );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -5873,6 +5873,35 @@ QUERY
 		$this->assertSame( 'ONLY_FULL_GROUP_BY', $result[0]->{'@@session.SQL_mode'} );
 	}
 
+	public function testNoBackslashEscapesSqlModeIsNotSupported(): void {
+		$queries = array(
+			"SET sql_mode = 'NO_BACKSLASH_ESCAPES'",
+			"SET @@sql_mode = 'NO_BACKSLASH_ESCAPES'",
+			"SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'",
+			"SET @@SESSION.sql_mode = 'NO_BACKSLASH_ESCAPES'",
+			"SET sql_mode = 'STRICT_TRANS_TABLES,NO_BACKSLASH_ESCAPES'",
+			"SET sql_mode = 'STRICT_TRANS_TABLES,NO_BACKSLASH_ESCAPES '",
+			"SET sql_mode = 'no_backslash_escapes'",
+		);
+
+		foreach ( $queries as $query ) {
+			$this->assertQuery( "SET sql_mode = 'ONLY_FULL_GROUP_BY'" );
+
+			try {
+				$this->assertQuery( $query );
+				$this->fail( 'Expected NO_BACKSLASH_ESCAPES to be rejected.' );
+			} catch ( WP_SQLite_Driver_Exception $e ) {
+				$this->assertSame(
+					"MySQL query not supported. Cause: SQL mode 'NO_BACKSLASH_ESCAPES'",
+					$e->getMessage()
+				);
+			}
+
+			$result = $this->assertQuery( 'SELECT @@SESSION.sql_mode' );
+			$this->assertSame( 'ONLY_FULL_GROUP_BY', $result[0]->{'@@SESSION.sql_mode'} );
+		}
+	}
+
 	public function testMultiQueryNotSupported(): void {
 		$this->expectException( WP_SQLite_Driver_Exception::class );
 		$this->expectExceptionMessage( 'Multi-query is not supported.' );
@@ -6108,7 +6137,7 @@ QUERY
 		// Primary and unique key names must be unique per table, not per schema.
 	}
 
-	public function testNoBackslashEscapesSqlMode(): void {
+	public function testBackslashEscapesInStringLiterals(): void {
 		$backslash = chr( 92 );
 
 		$query = "SELECT
@@ -6126,7 +6155,6 @@ QUERY
 			'{$backslash}_'            AS value_12
 		";
 
-		// With NO_BACKSLASH_ESCAPES disabled:
 		$this->assertQuery( "SET SESSION sql_mode = ''" );
 		$result = $this->assertQuery( $query );
 		$this->assertSame( chr( 39 ), $result[0]->value_1 ); // single quote
@@ -6144,25 +6172,9 @@ QUERY
 		// "\%" and "\_" preserve the backslash so it can be used in some contexts.
 		$this->assertSame( $backslash . '%', $result[0]->value_11 );
 		$this->assertSame( $backslash . '_', $result[0]->value_12 );
-
-		// With NO_BACKSLASH_ESCAPES enabled:
-		$this->assertQuery( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
-		$result = $this->assertQuery( $query );
-		$this->assertSame( "'", $result[0]->value_1 );
-		$this->assertSame( $backslash . '"', $result[0]->value_2 );
-		$this->assertSame( $backslash . '0', $result[0]->value_3 );
-		$this->assertSame( $backslash . 'n', $result[0]->value_4 );
-		$this->assertSame( $backslash . 'r', $result[0]->value_5 );
-		$this->assertSame( $backslash . 't', $result[0]->value_6 );
-		$this->assertSame( $backslash . 'b', $result[0]->value_7 );
-		$this->assertSame( $backslash . $backslash, $result[0]->value_8 );
-		$this->assertSame( '🙂', $result[0]->value_9 );
-		$this->assertSame( $backslash . '🙂', $result[0]->value_10 );
-		$this->assertSame( $backslash . '%', $result[0]->value_11 );
-		$this->assertSame( $backslash . '_', $result[0]->value_12 );
 	}
 
-	public function testNoBackslashEscapesSqlModeWithPatternMatching(): void {
+	public function testBackslashEscapesInPatternMatching(): void {
 		$backslash = chr( 92 );
 
 		$this->assertQuery( 'CREATE TABLE t (id INT PRIMARY KEY AUTO_INCREMENT, value TEXT)' );
@@ -6172,8 +6184,6 @@ QUERY
 		$this->assertQuery( "INSERT INTO t (value) VALUES ('abc{$backslash}{$backslash}x')" ); // abc\x
 
 		/*
-		 * 1. With NO_BACKSLASH_ESCAPES disabled:
-		 *
 		 * Backslashes serve as special escape characters on two levels:
 		 *
 		 *   1. In MySQL string literals.
@@ -6282,59 +6292,6 @@ QUERY
 		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}{$backslash}{$backslash}x'" );
 		$this->assertCount( 1, $result );
 		$this->assertSame( "abc{$backslash}x", $result[0]->value );
-
-		/*
-		 * 2. With NO_BACKSLASH_ESCAPES enabled:
-		 *
-		 * Backslashes don't serve as special escape characters at all:
-		 *
-		 *   1. No special meaning in MySQL string literals.
-		 *   2. No special meaning in LIKE patterns.
-		 *      This can be overriden using the "ESCAPE ..." clause of the LIKE
-		 *      expression. This is not implemented in the SQLite driver yet.
-		 */
-		$this->assertQuery( "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'" );
-
-		// A "_" = a wildcard:
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc_' ORDER BY id" );
-		$this->assertCount( 2, $result );
-		$this->assertSame( 'abc_', $result[0]->value );
-		$this->assertSame( 'abc%', $result[1]->value );
-
-		// A "\_" sequence = the "\" character and a wildcard:
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}_'" );
-		$this->assertCount( 1, $result );
-		$this->assertSame( "abc{$backslash}x", $result[0]->value );
-
-		// A "\\_" sequence = two "\" characters and a wildcard:
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}_'" );
-		$this->assertCount( 0, $result );
-
-		// A "%" = a wildcard:
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc%' ORDER BY id" );
-		$this->assertCount( 4, $result );
-		$this->assertSame( 'abc', $result[0]->value );
-		$this->assertSame( 'abc_', $result[1]->value );
-		$this->assertSame( 'abc%', $result[2]->value );
-		$this->assertSame( "abc{$backslash}x", $result[3]->value );
-
-		// A "\%" sequence = the "\" character and a wildcard.
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}%'" );
-		$this->assertCount( 1, $result );
-		$this->assertSame( "abc{$backslash}x", $result[0]->value );
-
-		// A "\\%" sequence = two "\" characters and a wildcard.
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}%'" );
-		$this->assertCount( 0, $result );
-
-		// A "\x" sequence = the "\" and the "x" character.
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}x'" );
-		$this->assertCount( 1, $result );
-		$this->assertSame( "abc{$backslash}x", $result[0]->value );
-
-		// A "\\x" sequence = two "\" characters and the "x" character.
-		$result = $this->assertQuery( "SELECT value FROM t WHERE value LIKE 'abc{$backslash}{$backslash}x'" );
-		$this->assertCount( 0, $result );
 	}
 
 	public function testQuoteMysqlUtf8StringLiteral(): void {

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_DB_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_DB_Tests.php
@@ -1,0 +1,85 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/fixtures/class-wpdb-stub.php';
+require_once __DIR__ . '/../../plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php';
+
+class WP_SQLite_DB_Tests extends TestCase {
+	/** @var WP_MySQL_On_SQLite */
+	private $driver;
+
+	public function setUp(): void {
+		$pdo_class = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
+		$pdo       = new $pdo_class( 'sqlite::memory:' );
+
+		$this->driver = new WP_MySQL_On_SQLite(
+			'mysql-on-sqlite:dbname=wp',
+			null,
+			null,
+			array( 'pdo' => $pdo )
+		);
+	}
+
+	/**
+	 * @dataProvider dataMysqlEscaping
+	 */
+	public function testRealEscapeMatchesMysql( string $value, string $expected ): void {
+		$wpdb = new class( $this->driver ) extends WP_SQLite_DB {
+			public function __construct( ?WP_MySQL_On_SQLite $driver ) {
+				$this->dbh = $driver;
+			}
+
+			public function add_placeholder_escape( $query ) {
+				return $query;
+			}
+		};
+
+		$this->assertSame( $expected, $wpdb->_real_escape( $value ) );
+	}
+
+	public static function dataMysqlEscaping(): array {
+		return array(
+			'ASCII null'      => array( chr( 0 ), '\\0' ),
+			'newline'         => array( "\n", '\\n' ),
+			'carriage return' => array( "\r", '\\r' ),
+			'backslash'       => array( '\\', '\\\\' ),
+			'single quote'    => array( "'", "\\'" ),
+			'double quote'    => array( '"', '\\"' ),
+			'Control+Z'       => array( chr( 26 ), '\\Z' ),
+			'backspace'       => array( chr( 8 ), chr( 8 ) ),
+			'tab'             => array( "\t", "\t" ),
+			'UTF-8'           => array( 'Ʈềʂᴛ🙂', 'Ʈềʂᴛ🙂' ),
+		);
+	}
+
+	public function testRealEscapePreservesValueInSqlStringLiteral(): void {
+		$wpdb = new class( $this->driver ) extends WP_SQLite_DB {
+			public function __construct( ?WP_MySQL_On_SQLite $driver ) {
+				$this->dbh = $driver;
+			}
+
+			public function add_placeholder_escape( $query ) {
+				return $query;
+			}
+		};
+
+		$value   = chr( 0 ) . "\n\r\\'\"" . chr( 26 ) . chr( 8 ) . "\tƮềʂᴛ🙂";
+		$escaped = $wpdb->_real_escape( $value );
+		$result  = $this->driver->query( "SELECT '$escaped'" );
+
+		$this->assertSame( $value, $result->fetchColumn() );
+	}
+
+	public function testRealEscapeRequiresDatabaseConnection(): void {
+		$wpdb = new class( null ) extends WP_SQLite_DB {
+			public function __construct( ?WP_MySQL_On_SQLite $driver ) {
+				$this->dbh = $driver;
+			}
+		};
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Cannot escape data without an active database connection.' );
+		$wpdb->_real_escape( 'value' );
+	}
+}

--- a/packages/mysql-on-sqlite/tests/fixtures/class-wpdb-stub.php
+++ b/packages/mysql-on-sqlite/tests/fixtures/class-wpdb-stub.php
@@ -1,0 +1,9 @@
+<?php
+
+class WPDB_Stub {
+	public function add_placeholder_escape( $query ) {
+		return $query;
+	}
+}
+
+class_alias( WPDB_Stub::class, 'wpdb' );

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -301,12 +301,20 @@ class WP_SQLite_DB extends wpdb {
 	 * @param string $data The string to escape.
 	 *
 	 * @return string escaped
+	 * @throws RuntimeException When the database connection is not initialized.
 	 */
 	public function _real_escape( $data ) {
 		if ( ! is_scalar( $data ) ) {
 			return '';
 		}
-		$escaped = addslashes( $data );
+
+		if ( ! $this->dbh ) {
+			throw new RuntimeException( 'Cannot escape data without an active database connection.' );
+		}
+
+		// Escape the string without bounding quotes to mirror mysqli_real_escape_string().
+		$quoted  = $this->dbh->quote( (string) $data );
+		$escaped = substr( $quoted, 1, -1 );
 		return $this->add_placeholder_escape( $escaped );
 	}
 


### PR DESCRIPTION
## What changed

- Reject `NO_BACKSLASH_ESCAPES` SQL mode with an explicit error.
- Implement mysql-compatible string escaping in `PDO::quote()`.
- Use the active driver connection as the sole escaping source for the WordPress database adapter, without an `addslashes()` fallback.

## Why

The SQLite driver does not consistently emulate `NO_BACKSLASH_ESCAPES` across all query paths. Rejecting the mode prevents partially supported behavior, while centralizing the default-mode escaping in the driver fixes the immediate correctness issue without duplicating escaping logic.

This is a minimal alternative to https://github.com/WordPress/sqlite-database-integration/pull/465 (`NO_BACKSLASH_ESCAPES` implementation).