### PR TITLE
Release 3.0.0-rc.8

### DIFF
--- a/bin/prepare-release.sh
+++ b/bin/prepare-release.sh
@@ -19,7 +19,8 @@ fail() {
 	exit 1
 }
 
-REPO_URL="https://github.com/WordPress/sqlite-database-integration"
+REPO="WordPress/sqlite-database-integration"
+REPO_URL="https://github.com/$REPO"
 VERSION_PHP="packages/mysql-on-sqlite/src/version.php"
 LOAD_PHP="packages/plugin-sqlite-database-integration/load.php"
 README_TXT="packages/plugin-sqlite-database-integration/readme.txt"
@@ -58,19 +59,45 @@ git pull --ff-only origin trunk --quiet || fail "trunk is not up to date with or
 LATEST_TAG="v$CURRENT_VERSION"
 
 echo "Generating changelog from merged PRs since $LATEST_TAG..."
+git fetch --quiet origin "refs/tags/$LATEST_TAG:refs/tags/$LATEST_TAG" \
+	|| fail "Failed to fetch release tag $LATEST_TAG from origin."
+git merge-base --is-ancestor "$LATEST_TAG" origin/trunk \
+	|| fail "Release tag $LATEST_TAG is not an ancestor of origin/trunk."
+
+COMMITS="$(git rev-list --first-parent "$LATEST_TAG..origin/trunk")"
 CHANGELOG=""
 
-if git rev-parse "$LATEST_TAG" >/dev/null 2>&1; then
-	TAG_TIMESTAMP="$(git log -1 --format='%aI' "$LATEST_TAG")"
+if [ -n "$COMMITS" ]; then
+	QUERY='query($owner: String!, $name: String!) {
+		repository(owner: $owner, name: $name) {'
+	while IFS= read -r commit; do
+		QUERY="$QUERY
+			commit_$commit: object(oid: \"$commit\") {
+				... on Commit {
+					associatedPullRequests(first: 100) {
+						nodes { number title mergedAt baseRefName }
+					}
+				}
+		}"
+	done <<< "$COMMITS"
+	QUERY="$QUERY
+		}
+	}"
 
-	CHANGELOG="$(gh pr list \
-		--state merged \
-		--base trunk \
-		--search "merged:>$TAG_TIMESTAMP" \
-		--limit 100 \
-		--json number,title,mergedAt \
-		--jq "sort_by(.mergedAt) | reverse | .[]
-			| \"* \\(.title) ([#\\(.number)]($REPO_URL/pull/\\(.number)))\"")"
+	if ! CHANGELOG="$(gh api graphql \
+		-f query="$QUERY" \
+		-F owner="${REPO%%/*}" \
+		-F name="${REPO#*/}" \
+		--jq "[.data.repository[]
+			| .associatedPullRequests.nodes[]
+			| select(.mergedAt != null and .baseRefName == \"trunk\")]
+			| unique_by(.number)
+			| sort_by(.mergedAt)
+			| reverse
+			| .[]
+			| \"* \\(.title) ([#\\(.number)]($REPO_URL/pull/\\(.number)))\"")"; then
+		fail "Failed to generate changelog from merged pull requests."
+	fi
 fi
 
 if [ -z "$CHANGELOG" ]; then

--- a/packages/mysql-on-sqlite/src/version.php
+++ b/packages/mysql-on-sqlite/src/version.php
@@ -5,4 +5,4 @@
  *
  * This constant needs to be updated on plugin release!
  */
-define( 'SQLITE_DRIVER_VERSION', '3.0.0-rc.7' );
+define( 'SQLITE_DRIVER_VERSION', '3.0.0-rc.8' );

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: SQLite Database Integration
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
- * Version: 3.0.0-rc.7
+ * Version: 3.0.0-rc.8
  * Requires PHP: 7.2
  * Network: true
  * Textdomain: sqlite-database-integration

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -46,12 +46,12 @@ with SQLite syntax and behavior.
 
 = 3.0.0-rc.8 =
 
-* Preserve aliases in UPDATE JOIN translation ([#462](https://github.com/WordPress/sqlite-database-integration/pull/462))
+* Preserve aliases in `UPDATE JOIN` translation ([#462](https://github.com/WordPress/sqlite-database-integration/pull/462))
 * Restrict SQLite installation permissions ([#464](https://github.com/WordPress/sqlite-database-integration/pull/464))
 * Improve string escaping ([#466](https://github.com/WordPress/sqlite-database-integration/pull/466))
 * Stabilize WordPress E2E tests ([#459](https://github.com/WordPress/sqlite-database-integration/pull/459))
 * Address WordPress PHPUnit test fails: charset detection, length validation etc ([#331](https://github.com/WordPress/sqlite-database-integration/pull/331))
-* User defined REVERSE() function Unicode support 🎉 ([#453](https://github.com/WordPress/sqlite-database-integration/pull/453))
+* Add Unicode support to the user-defined `REVERSE()` function ([#453](https://github.com/WordPress/sqlite-database-integration/pull/453))
 * Simplify the MySQL-on-SQLite driver API ([#449](https://github.com/WordPress/sqlite-database-integration/pull/449))
 * Add WordPress 7.0 compatibility ([#450](https://github.com/WordPress/sqlite-database-integration/pull/450))
 

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgic
 Requires at least: 6.4
 Tested up to:      7.0
 Requires PHP:      7.2
-Stable tag:        3.0.0-rc.7
+Stable tag:        3.0.0-rc.8
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, database
@@ -43,6 +43,10 @@ the wpdb API, while queries are internally adapted to be compatible
 with SQLite syntax and behavior.
 
 == Changelog ==
+
+= 3.0.0-rc.8 =
+
+* (no changes listed)
 
 = 3.0.0-rc.7 =
 

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -46,7 +46,14 @@ with SQLite syntax and behavior.
 
 = 3.0.0-rc.8 =
 
-* (no changes listed)
+* Preserve aliases in UPDATE JOIN translation ([#462](https://github.com/WordPress/sqlite-database-integration/pull/462))
+* Restrict SQLite installation permissions ([#464](https://github.com/WordPress/sqlite-database-integration/pull/464))
+* Improve string escaping ([#466](https://github.com/WordPress/sqlite-database-integration/pull/466))
+* Stabilize WordPress E2E tests ([#459](https://github.com/WordPress/sqlite-database-integration/pull/459))
+* Address WordPress PHPUnit test fails: charset detection, length validation etc ([#331](https://github.com/WordPress/sqlite-database-integration/pull/331))
+* User defined REVERSE() function Unicode support 🎉 ([#453](https://github.com/WordPress/sqlite-database-integration/pull/453))
+* Simplify the MySQL-on-SQLite driver API ([#449](https://github.com/WordPress/sqlite-database-integration/pull/449))
+* Add WordPress 7.0 compatibility ([#450](https://github.com/WordPress/sqlite-database-integration/pull/450))
 
 = 3.0.0-rc.7 =
 


### PR DESCRIPTION
## Release `3.0.0-rc.8`

Version bump and changelog update for release `3.0.0-rc.8`.

**Changelog draft:**
* Preserve aliases in `UPDATE JOIN` translation ([#462](https://github.com/WordPress/sqlite-database-integration/pull/462))
* Restrict SQLite installation permissions ([#464](https://github.com/WordPress/sqlite-database-integration/pull/464))
* Improve string escaping ([#466](https://github.com/WordPress/sqlite-database-integration/pull/466))
* Stabilize WordPress E2E tests ([#459](https://github.com/WordPress/sqlite-database-integration/pull/459))
* Address WordPress PHPUnit test fails: charset detection, length validation etc ([#331](https://github.com/WordPress/sqlite-database-integration/pull/331))
* Add Unicode support to the user-defined `REVERSE()` function ([#453](https://github.com/WordPress/sqlite-database-integration/pull/453))
* Simplify the MySQL-on-SQLite driver API ([#449](https://github.com/WordPress/sqlite-database-integration/pull/449))
* Add WordPress 7.0 compatibility ([#450](https://github.com/WordPress/sqlite-database-integration/pull/450))

**Full changelog:** https://github.com/WordPress/sqlite-database-integration/compare/v3.0.0-rc.7...release/v3.0.0-rc.8

## Next steps

1. **Review** the changes in this pull request.
2. **Push** any additional edits to this branch (`release/v3.0.0-rc.8`).
3. **Merge** this pull request to complete the release.

Merging will automatically build the plugin ZIP and create a [GitHub release](https://github.com/WordPress/sqlite-database-integration/releases).

> [!NOTE]
> This is a **pre-release**. It will not be deployed to [WordPress.org](https://wordpress.org/plugins/sqlite-database-integration/).