### PR TITLE
Document the 3.0 driver API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project implements SQLite database support for MySQL-based projects.
 It is a monorepo that includes the following components:
 - **MySQL lexer** — A fast MySQL lexer with multi-version support.
 - **MySQL parser** — An exhaustive MySQL parser with multi-version support.
-- **SQLite driver** — A MySQL emulation layer on top of SQLite with a PDO-compatible API.
+- **SQLite driver** — [`WP_MySQL_On_SQLite`](packages/mysql-on-sqlite/README.md), a MySQL emulation layer on top of SQLite with a PDO-compatible API.
 - **MySQL proxy** — A MySQL binary protocol implementation to support MySQL-based projects beyond PHP.
 - **WordPress plugin** — A plugin that adds SQLite support to WordPress.
 - **Test suites** — A set of extensive test suites to cover MySQL syntax and functionality.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This project implements SQLite database support for MySQL-based projects.
 
 It is a monorepo that includes the following components:
 - **MySQL lexer** — A fast MySQL lexer with multi-version support.
-- **MySQL parser** — An exhaustive MySQL parser with multi-version support.
+- **MySQL parser** *(experimental, development use)* — An exhaustive MySQL parser with multi-version support.
 - **SQLite driver** — [`WP_MySQL_On_SQLite`](packages/mysql-on-sqlite/README.md), a MySQL emulation layer on top of SQLite with a PDO-compatible API.
-- **MySQL proxy** — A MySQL binary protocol implementation to support MySQL-based projects beyond PHP.
+- **MySQL proxy** *(experimental, development use)* — A MySQL binary protocol implementation to support MySQL-based projects beyond PHP.
 - **WordPress plugin** — A plugin that adds SQLite support to WordPress.
 - **Test suites** — A set of extensive test suites to cover MySQL syntax and functionality.
 

--- a/packages/mysql-on-sqlite/README.md
+++ b/packages/mysql-on-sqlite/README.md
@@ -1,0 +1,48 @@
+# MySQL on SQLite
+
+`WP_MySQL_On_SQLite` executes MySQL queries against SQLite through a
+PDO-compatible API. It requires PHP 7.2 or newer with PDO and PDO SQLite.
+
+## Usage
+
+Load the driver and construct it with a `mysql-on-sqlite` DSN:
+
+```php
+require_once __DIR__ . '/src/load.php';
+
+$database = new WP_MySQL_On_SQLite(
+	'mysql-on-sqlite:path=/path/to/database.sqlite;dbname=application'
+);
+
+$statement = $database->query( 'SELECT * FROM users' );
+$rows      = $statement->fetchAll( PDO::FETCH_ASSOC );
+```
+
+The `path` field defaults to `:memory:` and `dbname` defaults to
+`sqlite_database`. Escape a literal semicolon in either value as `;;`.
+Usernames and passwords are accepted for PDO signature compatibility and ignored.
+
+## Constructor options
+
+The fourth constructor argument accepts standard numeric PDO options and these
+driver options:
+
+| Option | Value | Default |
+| --- | --- | --- |
+| `mysql_version` | MySQL version as an integer, such as `80038` | `80038` |
+| `pdo` | Existing PDO SQLite connection | A new connection for `path` |
+| `journal_mode` | `DELETE`, `TRUNCATE`, `PERSIST`, `MEMORY`, `WAL`, or `OFF` | `WAL` |
+| `synchronous` | `OFF`, `NORMAL`, `FULL`, `EXTRA`, or the corresponding integer from `0` to `3` | `NORMAL` when the effective journal mode is `WAL`; otherwise the SQLite default |
+
+PDO driver-specific options, whose integer keys start at `1000`, are not
+supported because PDO MySQL and PDO SQLite assign different meanings to them.
+
+## Configuration
+
+Define `WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS` as `true` before creating
+a connection to allow SQLite 3.27.0 through 3.36.x. This unsafe compatibility
+mode can corrupt databases created by newer SQLite versions and should only be
+enabled when that risk is understood.
+
+WordPress-specific configuration constants are documented in the
+[SQLite Database Integration plugin README](../plugin-sqlite-database-integration/readme.txt).

--- a/packages/mysql-on-sqlite/src/php-polyfills.php
+++ b/packages/mysql-on-sqlite/src/php-polyfills.php
@@ -6,7 +6,7 @@
  *
  * @see https://github.com/symfony/polyfill-php80
  *
- * @package wp-sqlite-integration
+ * @package mysql-on-sqlite
  */
 
 if ( ! function_exists( 'str_starts_with' ) ) {

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
@@ -93,7 +93,7 @@ class WP_SQLite_Connection {
 			$this->pdo = $options['pdo'];
 		} else {
 			if ( ! isset( $options['path'] ) || ! is_string( $options['path'] ) ) {
-				throw new InvalidArgumentException( 'Option "path" is required when "connection" is not provided.' );
+				throw new InvalidArgumentException( 'Option "path" is required when "pdo" is not provided.' );
 			}
 			$pdo_class   = PHP_VERSION_ID >= 80400 ? PDO\SQLite::class : PDO::class;
 			$pdo_options = $options['pdo_options'] ?? array();

--- a/packages/mysql-parser/README.md
+++ b/packages/mysql-parser/README.md
@@ -1,5 +1,9 @@
 # MySQL Parser
 
+> [!WARNING]
+> This standalone package is experimental and intended for development use. Its
+> APIs may change without notice.
+
 A fast and complete **MySQL parser** in pure PHP with zero dependencies, generated
 directly from the **official MySQL grammar**.
 

--- a/packages/mysql-proxy/README.md
+++ b/packages/mysql-proxy/README.md
@@ -1,4 +1,10 @@
 # WP MySQL Proxy
+
+> [!WARNING]
+> This package is experimental and intended for local development. Authentication
+> is not implemented, and the proxy listens on all network interfaces. Do not
+> expose it to an untrusted network.
+
 A MySQL proxy that bridges the MySQL wire protocol to a PDO-like interface.
 
 This is a zero-dependency, pure PHP implementation of a MySQL proxy that acts as

--- a/packages/plugin-sqlite-database-integration/admin-page.php
+++ b/packages/plugin-sqlite-database-integration/admin-page.php
@@ -132,8 +132,6 @@ function sqlite_integration_admin_screen() {
 /**
  * Adds a link to the admin bar.
  *
- * @since n.e.x.t
- *
  * @global wpdb $wpdb WordPress database abstraction object.
  *
  * @param WP_Admin_Bar $admin_bar The admin bar object.

--- a/packages/plugin-sqlite-database-integration/db.copy
+++ b/packages/plugin-sqlite-database-integration/db.copy
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: SQLite integration (Drop-in)
- * Version: 1.0.0
+ * Version: 1.8.0
  * Author: WordPress Performance Team
  * Author URI: https://make.wordpress.org/performance/
  *

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -42,6 +42,20 @@ SQLite-backed implementation. Core WordPress code continues to use
 the wpdb API, while queries are internally adapted to be compatible
 with SQLite syntax and behavior.
 
+== Configuration ==
+
+Define configuration constants in `wp-config.php` before WordPress loads:
+
+* `DB_ENGINE`: Set to `sqlite` to select the SQLite drop-in.
+* `DB_DIR`: Directory containing the SQLite database. Defaults to `wp-content/database`.
+* `DB_FILE`: SQLite database filename. Defaults to `.ht.sqlite`.
+* `FQDBDIR`: Absolute database-directory override. If unset, it is derived from `DB_DIR`.
+* `FQDB`: Absolute database-file override. If unset, it is derived from `FQDBDIR` and `DB_FILE`.
+* `SQLITE_JOURNAL_MODE`: SQLite journal mode. Defaults to `WAL`.
+* `WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS`: Allow SQLite 3.27.0 through 3.36.x. This unsafe compatibility mode can corrupt databases created with newer SQLite versions.
+* `ERRORLOGFILE`: On multisite, also write displayed database errors to this file.
+* `DIEONDBERROR`: On multisite, stop execution after displaying a database error.
+
 == Changelog ==
 
 = 3.0.0-rc.8 =


### PR DESCRIPTION
## Summary

- document the public `WP_MySQL_On_SQLite` DSN, constructor options, and configuration constants
- mark the standalone MySQL parser and proxy packages as experimental development tools
- correct stale option names, package metadata, placeholder version annotations, and the drop-in header version

## Why

The 3.0 release defines a PDO-compatible public API. Publishing the DSN and option names makes that contract discoverable outside source docblocks, while the package warnings and metadata corrections clarify the intended stability boundary before the release is tagged.

These changes do not alter database behavior.

## Testing

- `composer run check-cs`
- `cd packages/mysql-on-sqlite && composer run test` — 841 tests, 1,428,637 assertions
