### PR TITLE
Prefix SQLite-specific constructor options

### DIFF
--- a/packages/mysql-on-sqlite/README.md
+++ b/packages/mysql-on-sqlite/README.md
@@ -73,9 +73,9 @@ version and configuring the SQLite connection:
 | Option | Description | Default |
 | --- | --- | --- |
 | `mysql_version` | MySQL version to emulate, represented as an integer | `80038` |
-| `pdo` | Existing PDO SQLite connection | A new connection for `path` |
-| `journal_mode` | SQLite journal mode | `WAL` |
-| `synchronous` | SQLite synchronous setting | `NORMAL` in WAL mode; otherwise the SQLite default |
+| `sqlite_pdo` | Existing PDO SQLite connection | A new connection for `path` |
+| `sqlite_journal_mode` | SQLite journal mode | `WAL` |
+| `sqlite_synchronous` | SQLite synchronous setting | `NORMAL` in WAL mode; otherwise the SQLite default |
 
 ## Compatibility
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -774,15 +774,15 @@ class WP_MySQL_On_SQLite extends PDO {
 	 * @param string|null $username Optional. Ignored by this driver.
 	 * @param string|null $password Optional. Ignored by this driver.
 	 * @param array|null  $options  {
-	 *     Optional driver options.
+	 *     Optional PDO attributes and WP_MySQL_On_SQLite options.
 	 *
 	 *     Numeric keys are handled as standard PDO constructor options.
 	 *     Driver-specific PDO options are not supported.
 	 *
-	 *     @type int             $mysql_version Optional. MySQL version to emulate. Default 80038.
-	 *     @type PDO|null        $pdo           Optional. Existing PDO SQLite connection.
-	 *     @type string|null     $journal_mode  Optional. SQLite journal mode. Default 'WAL'.
-	 *     @type string|int|null $synchronous   Optional. SQLite synchronous setting.
+	 *     @type int             $mysql_version       Optional. MySQL version to emulate. Default 80038.
+	 *     @type PDO|null        $sqlite_pdo          Optional. Existing PDO SQLite connection.
+	 *     @type string|null     $sqlite_journal_mode Optional. SQLite journal mode. Default 'WAL'.
+	 *     @type string|int|null $sqlite_synchronous  Optional. SQLite synchronous setting.
 	 * }
 	 *
 	 * @throws InvalidArgumentException     When the MySQL version is invalid.
@@ -862,12 +862,12 @@ class WP_MySQL_On_SQLite extends PDO {
 		}
 
 		$connection_options = array(
-			'journal_mode' => $options['journal_mode'] ?? null,
-			'synchronous'  => $options['synchronous'] ?? null,
+			'journal_mode' => $options['sqlite_journal_mode'] ?? null,
+			'synchronous'  => $options['sqlite_synchronous'] ?? null,
 			'pdo_options'  => $connection_pdo_options,
 		);
-		if ( isset( $options['pdo'] ) ) {
-			$connection_options['pdo'] = $options['pdo'];
+		if ( isset( $options['sqlite_pdo'] ) ) {
+			$connection_options['pdo'] = $options['sqlite_pdo'];
 		} else {
 			$connection_options['path'] = $path;
 		}

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-driver.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-driver.php
@@ -82,9 +82,9 @@ class WP_SQLite_Driver {
 			null,
 			null,
 			array(
-				'mysql_version' => $mysql_version,
-				'pdo'           => $connection->get_pdo(),
-				'journal_mode'  => $connection->query( 'PRAGMA journal_mode' )->fetchColumn(),
+				'mysql_version'       => $mysql_version,
+				'sqlite_pdo'          => $connection->get_pdo(),
+				'sqlite_journal_mode' => $connection->query( 'PRAGMA journal_mode' )->fetchColumn(),
 			)
 		);
 		$this->client_info            = $this->mysql_on_sqlite_driver->client_info;

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Concurrency_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Concurrency_Tests.php
@@ -178,8 +178,8 @@ class WP_MySQL_On_SQLite_Concurrency_Tests extends TestCase {
 			null,
 			null,
 			array(
-				'pdo'          => $connection->get_pdo(),
-				'journal_mode' => $connection->query( 'PRAGMA journal_mode' )->fetchColumn(),
+				'sqlite_pdo'          => $connection->get_pdo(),
+				'sqlite_journal_mode' => $connection->query( 'PRAGMA journal_mode' )->fetchColumn(),
 			)
 		);
 	}

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Metadata_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Metadata_Tests.php
@@ -20,7 +20,7 @@ class WP_MySQL_On_SQLite_Metadata_Tests extends TestCase {
 			'mysql-on-sqlite:dbname=wp',
 			null,
 			null,
-			array( 'pdo' => $this->sqlite )
+			array( 'sqlite_pdo' => $this->sqlite )
 		);
 		$this->engine->setAttribute( PDO::ATTR_STRINGIFY_FETCHES, true );
 	}

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -214,7 +214,7 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 			'mysql-on-sqlite:dbname=wp',
 			null,
 			null,
-			array( 'pdo' => $pdo )
+			array( 'sqlite_pdo' => $pdo )
 		);
 
 		$this->assertTrue( $driver->getAttribute( PDO::ATTR_STRINGIFY_FETCHES ) );
@@ -260,7 +260,7 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 			'mysql-on-sqlite:dbname=wp',
 			null,
 			null,
-			array( 'pdo' => $pdo )
+			array( 'sqlite_pdo' => $pdo )
 		);
 
 		$this->assertSame( $pdo, $driver->get_sqlite_pdo() );
@@ -330,8 +330,8 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 				null,
 				null,
 				array(
-					'journal_mode' => 'DELETE',
-					'synchronous'  => 'FULL',
+					'sqlite_journal_mode' => 'DELETE',
+					'sqlite_synchronous'  => 'FULL',
 				)
 			);
 			$connection = $driver->get_connection();

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Query_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Query_Tests.php
@@ -113,7 +113,7 @@ class WP_MySQL_On_SQLite_Query_Tests extends TestCase {
 			'mysql-on-sqlite:dbname=wp',
 			null,
 			null,
-			array( 'pdo' => $this->sqlite )
+			array( 'sqlite_pdo' => $this->sqlite )
 		);
 		$this->engine->setAttribute( PDO::ATTR_STRINGIFY_FETCHES, true );
 

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -37,7 +37,7 @@ class WP_MySQL_On_SQLite_Tests extends TestCase {
 			'mysql-on-sqlite:dbname=wp',
 			null,
 			null,
-			array( 'pdo' => $this->sqlite )
+			array( 'sqlite_pdo' => $this->sqlite )
 		);
 		$this->engine->setAttribute( PDO::ATTR_STRINGIFY_FETCHES, true );
 		$this->query(
@@ -2932,7 +2932,7 @@ class WP_MySQL_On_SQLite_Tests extends TestCase {
 			null,
 			null,
 			array(
-				'pdo'           => $this->sqlite,
+				'sqlite_pdo'    => $this->sqlite,
 				'mysql_version' => 50744,
 			)
 		);
@@ -2950,7 +2950,7 @@ class WP_MySQL_On_SQLite_Tests extends TestCase {
 			null,
 			null,
 			array(
-				'pdo'           => $this->sqlite,
+				'sqlite_pdo'    => $this->sqlite,
 				'mysql_version' => 50744,
 			)
 		);
@@ -2994,7 +2994,7 @@ class WP_MySQL_On_SQLite_Tests extends TestCase {
 			null,
 			null,
 			array(
-				'pdo'           => $this->sqlite,
+				'sqlite_pdo'    => $this->sqlite,
 				'mysql_version' => 50744,
 			)
 		);
@@ -3048,7 +3048,7 @@ class WP_MySQL_On_SQLite_Tests extends TestCase {
 			null,
 			null,
 			array(
-				'pdo'           => $this->sqlite,
+				'sqlite_pdo'    => $this->sqlite,
 				'mysql_version' => 50744,
 			)
 		);
@@ -7321,7 +7321,7 @@ END;
 			'mysql-on-sqlite:dbname=',
 			null,
 			null,
-			array( 'pdo' => $pdo )
+			array( 'sqlite_pdo' => $pdo )
 		);
 	}
 

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
@@ -183,7 +183,7 @@ class WP_SQLite_Connection_Tests extends TestCase {
 			sprintf( 'mysql-on-sqlite:path=%s;dbname=wp', $this->db_path ),
 			null,
 			null,
-			array( 'journal_mode' => 'DELETE' )
+			array( 'sqlite_journal_mode' => 'DELETE' )
 		);
 
 		$this->assertSame( 'delete', $this->get_journal_mode( $driver->get_connection() ) );

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_DB_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_DB_Tests.php
@@ -17,7 +17,7 @@ class WP_SQLite_DB_Tests extends TestCase {
 			'mysql-on-sqlite:dbname=wp',
 			null,
 			null,
-			array( 'pdo' => $pdo )
+			array( 'sqlite_pdo' => $pdo )
 		);
 	}
 

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
@@ -47,7 +47,7 @@ class WP_SQLite_Information_Schema_Reconstructor_Tests extends TestCase {
 			'mysql-on-sqlite:dbname=wp',
 			null,
 			null,
-			array( 'pdo' => $this->sqlite )
+			array( 'sqlite_pdo' => $this->sqlite )
 		);
 		$this->engine->setAttribute( PDO::ATTR_STRINGIFY_FETCHES, true );
 

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -463,7 +463,7 @@ class WP_SQLite_DB extends wpdb {
 
 		try {
 			$options = array(
-				'journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
+				'sqlite_journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
 			);
 			$dbh     = new WP_MySQL_On_SQLite(
 				sprintf(

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/install-functions.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/install-functions.php
@@ -29,7 +29,7 @@ function sqlite_make_db_sqlite() {
 			null,
 			null,
 			array(
-				'journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
+				'sqlite_journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
 			)
 		);
 		$translator->setAttribute( PDO::ATTR_STRINGIFY_FETCHES, true ); // phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO


### PR DESCRIPTION
## Summary

Rename the SQLite-specific `WP_MySQL_On_SQLite` constructor options so their ownership is explicit:

- `pdo` → `sqlite_pdo`
- `journal_mode` → `sqlite_journal_mode`
- `synchronous` → `sqlite_synchronous`

The documentation, internal callers, and tests now use the prefixed names.

## Rationale

`WP_MySQL_On_SQLite` accepts standard numeric PDO constructor options alongside its own string-keyed options. The generic names did not clearly distinguish SQLite connection configuration from PDO attributes or other driver configuration. The `sqlite_` prefix makes that boundary explicit.
