### PR TITLE
Finalize MySQL-on-SQLite 3.0 refinements

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite-statement.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite-statement.php
@@ -208,6 +208,9 @@ class WP_MySQL_On_SQLite_Statement extends PDOStatement implements IteratorAggre
 	 * @return bool         True on success, false on failure.
 	 */
 	public function execute( $params = null ): bool {
+		// The wrapped SQLite statement represents the result of MySQL emulation.
+		// Re-executing it would not repeat the original MySQL operation.
+		// TODO: Implement statement execution together with the prepare() flow.
 		throw new RuntimeException( 'Not implemented' );
 	}
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite-statement.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite-statement.php
@@ -208,7 +208,7 @@ class WP_MySQL_On_SQLite_Statement extends PDOStatement implements IteratorAggre
 	 * @return bool         True on success, false on failure.
 	 */
 	public function execute( $params = null ): bool {
-		return $this->statement->execute( $params );
+		throw new RuntimeException( 'Not implemented' );
 	}
 
 	/**
@@ -340,7 +340,7 @@ class WP_MySQL_On_SQLite_Statement extends PDOStatement implements IteratorAggre
 	}
 
 	/**
-	 * Closes the cursor, enabling the statement to be executed again.
+	 * Close the cursor and release the associated resources.
 	 *
 	 * @return bool True on success, false on failure.
 	 */

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -1191,11 +1191,15 @@ class WP_MySQL_On_SQLite extends PDO {
 			if ( $e instanceof WP_SQLite_Information_Schema_Exception ) {
 				$e = $this->convert_information_schema_exception( $e );
 			}
-			if ( ! ( $e instanceof WP_MySQL_On_SQLite_Exception ) ) {
-				$e = $this->new_driver_exception( $e->getMessage(), $e->getCode(), $e );
+			if ( $e instanceof WP_MySQL_On_SQLite_Exception ) {
+				$driver_exception = $e;
+			} elseif ( $e instanceof PDOException ) {
+				$driver_exception = $this->convert_sqlite_exception( $e );
+			} else {
+				$driver_exception = $this->new_driver_exception( $e->getMessage(), $e->getCode(), $e );
 			}
 
-			return $this->handle_pdo_error( $e );
+			return $this->handle_pdo_error( $driver_exception );
 		} finally {
 			// A query that doesn't return any rows or fails sets found rows to 0.
 			if ( ! $this->is_readonly || isset( $e ) ) {
@@ -2192,9 +2196,9 @@ class WP_MySQL_On_SQLite extends PDO {
 								sprintf( 'SELECT 1 FROM %s LIMIT 0', $table_name )
 							);
 						} catch ( PDOException $e ) {
-							throw $this->new_driver_exception(
-								sprintf( "Table '%s.%s' doesn't exist", $this->db_name, $table_name ),
-								'42S02'
+							throw $this->new_table_not_found_exception(
+								sprintf( '%s.%s', $this->db_name, $table_name ),
+								$e
 							);
 						}
 					}
@@ -3650,10 +3654,7 @@ class WP_MySQL_On_SQLite extends PDO {
 		)->fetchColumn();
 
 		if ( ! $table_exists ) {
-			throw $this->new_driver_exception(
-				sprintf( "Table '%s.%s' doesn't exist", $database, $table_name ),
-				'42S02'
-			);
+			throw $this->new_table_not_found_exception( sprintf( '%s.%s', $database, $table_name ) );
 		}
 
 		// LIKE and WHERE clauses.
@@ -4072,7 +4073,9 @@ class WP_MySQL_On_SQLite extends PDO {
 						);
 				}
 			} catch ( PDOException $e ) {
-				if ( 'HY000' === $e->getCode() ) {
+				if ( '42S02' === $e->getCode() && isset( $e->errorInfo[2] ) ) {
+					$errors = array( $e->errorInfo[2] );
+				} elseif ( 'HY000' === $e->getCode() ) {
 					$errors = array( "Table '$table_name' doesn't exist" );
 				} else {
 					$errors = array( $e->getMessage() );
@@ -5774,13 +5777,7 @@ class WP_MySQL_On_SQLite extends PDO {
 
 		// Check if the table exists.
 		if ( 0 === count( $columns ) ) {
-			throw $this->new_driver_exception(
-				sprintf(
-					"SQLSTATE[42S02]: Base table or view not found: 1146 Table '%s' doesn't exist",
-					$table_name
-				),
-				'42S02'
-			);
+			throw $this->new_table_not_found_exception( $table_name );
 		}
 
 		// Get a list of columns that are targeted by the INSERT or REPLACE query.
@@ -6088,13 +6085,7 @@ class WP_MySQL_On_SQLite extends PDO {
 
 		// Check if the table exists.
 		if ( 0 === count( $columns ) ) {
-			throw $this->new_driver_exception(
-				sprintf(
-					"SQLSTATE[42S02]: Base table or view not found: 1146 Table '%s' doesn't exist",
-					$table_name
-				),
-				'42S02'
-			);
+			throw $this->new_table_not_found_exception( $table_name );
 		}
 
 		$column_map = array_combine( array_column( $columns, 'COLUMN_NAME' ), $columns );
@@ -6833,10 +6824,7 @@ class WP_MySQL_On_SQLite extends PDO {
 		)->fetch( PDO::FETCH_ASSOC );
 
 		if ( false === $table_info ) {
-			throw $this->new_driver_exception(
-				sprintf( "Table '%s' doesn't exist", $table_name ),
-				'42S02'
-			);
+			throw $this->new_table_not_found_exception( $table_name );
 		}
 
 		// 2. Get column info.
@@ -7809,6 +7797,26 @@ class WP_MySQL_On_SQLite extends PDO {
 	}
 
 	/**
+	 * Create a MySQL-compatible table-not-found exception.
+	 *
+	 * @param  string         $table_name The missing table name.
+	 * @param  Throwable|null $previous   The previous exception.
+	 * @return WP_MySQL_On_SQLite_Exception
+	 */
+	private function new_table_not_found_exception(
+		string $table_name,
+		?Throwable $previous = null
+	): WP_MySQL_On_SQLite_Exception {
+		$driver_message = sprintf( "Table '%s' doesn't exist", $table_name );
+		return $this->new_driver_exception(
+			'SQLSTATE[42S02]: Base table or view not found: 1146 ' . $driver_message,
+			'42S02',
+			$previous,
+			array( '42S02', 1146, $driver_message )
+		);
+	}
+
+	/**
 	 * Create a MySQL-compatible exception for an invalid SQL mode value.
 	 *
 	 * @param  mixed $value The invalid SQL mode value.
@@ -7834,6 +7842,25 @@ class WP_MySQL_On_SQLite extends PDO {
 			"Access denied for user 'root'@'%' to database 'information_schema'",
 			'42000'
 		);
+	}
+
+	/**
+	 * Convert a SQLite PDO exception to a MySQL-on-SQLite driver exception.
+	 *
+	 * @param  PDOException $e The SQLite PDO exception.
+	 * @return WP_MySQL_On_SQLite_Exception
+	 */
+	private function convert_sqlite_exception( PDOException $e ): WP_MySQL_On_SQLite_Exception {
+		$error_info    = is_array( $e->errorInfo ) ? $e->errorInfo : array();
+		$sqlstate      = $error_info[0] ?? null;
+		$error_message = $error_info[2] ?? null;
+
+		if ( 'HY000' === $sqlstate && 0 === strpos( $error_message, 'no such table: ' ) ) {
+			$table_name = substr( $error_message, strlen( 'no such table: ' ) );
+			return $this->new_table_not_found_exception( $table_name, $e );
+		}
+
+		return $this->new_driver_exception( $e->getMessage(), $e->getCode(), $e );
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
@@ -574,9 +574,11 @@ class WP_SQLite_Information_Schema_Reconstructor {
 		}
 
 		// HEX literals (numeric). E.g.: 0x1a2f, 0X1A2F
-		$value = filter_var( $no_underscore_default_value, FILTER_VALIDATE_INT, FILTER_FLAG_ALLOW_HEX );
-		if ( false !== $value ) {
-			return $value;
+		if ( 1 === preg_match( '/^0[xX][0-9a-fA-F]+$/D', $no_underscore_default_value ) ) {
+			// Convert to signed 64-bit decimal text in SQLite to avoid PHP integer size limits.
+			return (string) $this->connection->query(
+				'SELECT CAST(' . $no_underscore_default_value . ' AS TEXT)'
+			)->fetchColumn();
 		}
 
 		// BLOB literals (string). E.g.: x'1a2f', X'1A2F'

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Metadata_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Metadata_Tests.php
@@ -957,7 +957,9 @@ class WP_MySQL_On_SQLite_Metadata_Tests extends TestCase {
 	}
 
 	public function testBogusQuery() {
-		$this->expectExceptionMessage( 'no such table: bogus' );
+		$this->expectExceptionMessage(
+			"SQLSTATE[42S02]: Base table or view not found: 1146 Table 'bogus' doesn't exist"
+		);
 		$this->assertQuery(
 			'SELECT 1, BOGUS(1) FROM bogus;'
 		);

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -228,14 +228,45 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 	}
 
 	public function test_driver_exception_preserves_pdo_error_information(): void {
+		$previous            = new PDOException( 'Test PDO error.' );
+		$previous->errorInfo = array( 'HY000', 1, 'Test PDO error.' );
+		$exception           = new WP_MySQL_On_SQLite_Exception(
+			$this->driver,
+			$previous->getMessage(),
+			$previous->getCode(),
+			$previous
+		);
+
+		$this->assertSame( $previous->errorInfo, $exception->errorInfo );
+	}
+
+	/**
+	 * @dataProvider data_missing_table_queries
+	 */
+	public function test_missing_table_errors_use_mysql_identity( string $query ): void {
+		$driver_message = "Table 'missing_table' doesn't exist";
+		$message        = 'SQLSTATE[42S02]: Base table or view not found: 1146 ' . $driver_message;
+
 		try {
-			$this->driver->query( 'SELECT * FROM missing_table' );
+			$this->driver->query( $query );
 			$this->fail( 'Expected query() to throw an exception.' );
 		} catch ( WP_MySQL_On_SQLite_Exception $exception ) {
-			$this->assertSame( 'HY000', $exception->errorInfo[0] );
-			$this->assertSame( 1, $exception->errorInfo[1] );
-			$this->assertSame( 'no such table: missing_table', $exception->errorInfo[2] );
+			$this->assertSame( '42S02', $exception->getCode() );
+			$this->assertSame( $message, $exception->getMessage() );
+			$this->assertSame( array( '42S02', 1146, $driver_message ), $exception->errorInfo );
 		}
+
+		$this->assertSame( '42S02', $this->driver->errorCode() );
+		$this->assertSame( array( '42S02', 1146, $driver_message ), $this->driver->errorInfo() );
+	}
+
+	public function data_missing_table_queries(): array {
+		return array(
+			'Select' => array( 'SELECT * FROM missing_table' ),
+			'Insert' => array( 'INSERT INTO missing_table VALUES (1)' ),
+			'Update' => array( 'UPDATE missing_table SET value = 1' ),
+			'Delete' => array( 'DELETE FROM missing_table' ),
+		);
 	}
 
 	public function test_emulated_driver_exception_exposes_mysql_error_information(): void {
@@ -724,9 +755,11 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->driver->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT );
 
 		$this->assertFalse( $this->driver->query( 'SELECT * FROM missing_table' ) );
-		$this->assertSame( 'HY000', $this->driver->errorCode() );
-		$this->assertSame( 1, $this->driver->errorInfo()[1] );
-		$this->assertSame( 'no such table: missing_table', $this->driver->errorInfo()[2] );
+		$this->assertSame( '42S02', $this->driver->errorCode() );
+		$this->assertSame(
+			array( '42S02', 1146, "Table 'missing_table' doesn't exist" ),
+			$this->driver->errorInfo()
+		);
 		$this->assertFalse( $this->driver->exec( 'SELECT * FROM missing_table' ) );
 
 		$this->assertInstanceOf( PDOStatement::class, $this->driver->query( 'SELECT 1' ) );
@@ -752,7 +785,10 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 			restore_error_handler();
 		}
 
-		$this->assertStringContainsString( 'no such table: missing_table', $warning );
+		$this->assertSame(
+			"SQLSTATE[42S02]: Base table or view not found: 1146 Table 'missing_table' doesn't exist",
+			$warning
+		);
 	}
 
 	public function test_quote_matches_mysql_escaping(): void {

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
@@ -268,6 +268,36 @@ class WP_SQLite_Information_Schema_Reconstructor_Tests extends TestCase {
 		);
 	}
 
+	public function testHexadecimalDefaultValues(): void {
+		$this->engine->get_connection()->query(
+			'
+			CREATE TABLE t (
+				leading_zeroes int DEFAULT 0x00000000000000000001,
+				max_positive int DEFAULT 0x7fffffffffffffff,
+				min_negative int DEFAULT 0x8000000000000000,
+				minus_one int DEFAULT 0xffffffffffffffff
+			)
+		'
+		);
+
+		$this->reconstructor->ensure_correct_information_schema();
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertSame(
+			implode(
+				"\n",
+				array(
+					'CREATE TABLE `t` (',
+					"  `leading_zeroes` int DEFAULT '1',",
+					"  `max_positive` int DEFAULT '9223372036854775807',",
+					"  `min_negative` int DEFAULT '-9223372036854775808',",
+					"  `minus_one` int DEFAULT '-1'",
+					') ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci',
+				)
+			),
+			$result[0]->{'Create Table'}
+		);
+	}
+
 	public function testReconstructBitDefaultValuesFromMysqlDataTypesCache(): void {
 		$connection = $this->engine->get_connection();
 

--- a/packages/plugin-sqlite-database-integration/constants.php
+++ b/packages/plugin-sqlite-database-integration/constants.php
@@ -23,6 +23,8 @@ if ( ! defined( 'DB_ENGINE' ) ) {
 /**
  * FQDBDIR is a directory where the sqlite database file is placed.
  * If DB_DIR is defined, it is used as FQDBDIR.
+ *
+ * @deprecated 3.0.0 Define DB_DIR instead of overriding FQDBDIR.
  */
 if ( ! defined( 'FQDBDIR' ) ) {
 	if ( defined( 'DB_DIR' ) ) {
@@ -37,6 +39,8 @@ if ( ! defined( 'FQDBDIR' ) ) {
 /**
  * FQDB is a database file name. If DB_FILE is defined, it is used
  * as FQDB.
+ *
+ * @deprecated 3.0.0 Define DB_DIR and DB_FILE instead of overriding FQDB.
  */
 if ( ! defined( 'FQDB' ) ) {
 	if ( defined( 'DB_FILE' ) ) {

--- a/packages/plugin-sqlite-database-integration/db.copy
+++ b/packages/plugin-sqlite-database-integration/db.copy
@@ -22,10 +22,15 @@ if ( ! $sqlite_plugin_implementation_folder_path || ! file_exists( $sqlite_plugi
 	return;
 }
 
-// Constant for backward compatibility.
+/**
+ * Legacy database type marker.
+ *
+ * @deprecated 3.0.0 Use DB_ENGINE instead.
+ */
 if ( ! defined( 'DATABASE_TYPE' ) ) {
 	define( 'DATABASE_TYPE', 'sqlite' );
 }
+
 // Define SQLite constant.
 if ( ! defined( 'DB_ENGINE' ) ) {
 	define( 'DB_ENGINE', 'sqlite' );


### PR DESCRIPTION
## Summary

This completes four API and compatibility refinements before 3.0:

- Prevents `PDOStatement::execute()` from bypassing MySQL emulation. Marking it not implemented for now.
- Normalizes missing table failures to the MySQL-compatible SQLSTATE, error code, and message.
- Marks the legacy database constants as deprecated.
- Removes `ext-filter` dependency when reconstructing hexadecimal defaults.