### PR TITLE
Default SQLite synchronization to FULL

### DIFF
--- a/packages/mysql-on-sqlite/README.md
+++ b/packages/mysql-on-sqlite/README.md
@@ -75,7 +75,7 @@ version and configuring the SQLite connection:
 | `mysql_version` | MySQL version to emulate, represented as an integer | `80038` |
 | `sqlite_pdo` | Existing PDO SQLite connection | A new connection for `path` |
 | `sqlite_journal_mode` | SQLite journal mode | `WAL` |
-| `sqlite_synchronous` | SQLite synchronous setting | `NORMAL` in WAL mode; otherwise the SQLite default |
+| `sqlite_synchronous` | SQLite synchronous setting | `FULL` |
 
 ## Compatibility
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -782,7 +782,7 @@ class WP_MySQL_On_SQLite extends PDO {
 	 *     @type int             $mysql_version       Optional. MySQL version to emulate. Default 80038.
 	 *     @type PDO|null        $sqlite_pdo          Optional. Existing PDO SQLite connection.
 	 *     @type string|null     $sqlite_journal_mode Optional. SQLite journal mode. Default 'WAL'.
-	 *     @type string|int|null $sqlite_synchronous  Optional. SQLite synchronous setting.
+	 *     @type string|int|null $sqlite_synchronous  Optional. SQLite synchronous setting. Default 'FULL'.
 	 * }
 	 *
 	 * @throws InvalidArgumentException     When the MySQL version is invalid.

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-connection.php
@@ -79,8 +79,7 @@ class WP_SQLite_Connection {
 	 *     @type int|null        $timeout      Optional. SQLite timeout in seconds.
 	 *                                         The time to wait for a writable lock.
 	 *     @type string|null     $journal_mode Optional. SQLite journal mode. Defaults to WAL.
-	 *     @type string|int|null $synchronous  Optional. SQLite synchronous setting. Defaults to
-	 *                                         NORMAL when the effective journal mode is WAL.
+	 *     @type string|int|null $synchronous  Optional. SQLite synchronous setting. Defaults to FULL.
 	 *     @type array           $pdo_options  Optional. PDO constructor options.
 	 * }
 	 *
@@ -116,8 +115,7 @@ class WP_SQLite_Connection {
 		$this->pdo->setAttribute( PDO::ATTR_TIMEOUT, $timeout );
 
 		// Configure SQLite journal mode. Default to WAL for best throughput.
-		$effective_journal_mode = null;
-		$journal_mode           = $options['journal_mode'] ?? 'WAL';
+		$journal_mode = $options['journal_mode'] ?? 'WAL';
 		if ( is_string( $journal_mode ) ) {
 			$journal_mode = strtoupper( $journal_mode );
 		}
@@ -127,9 +125,7 @@ class WP_SQLite_Connection {
 			);
 		}
 		try {
-			$effective_journal_mode = strtoupper(
-				(string) $this->query( 'PRAGMA journal_mode = ' . $journal_mode )->fetchColumn()
-			);
+			$this->query( 'PRAGMA journal_mode = ' . $journal_mode )->fetchColumn();
 		} catch ( PDOException $e ) {
 			// WAL may be unavailable in some environments, such as on network
 			// filesystems. When it is explicitly configured, surface the error.
@@ -140,26 +136,16 @@ class WP_SQLite_Connection {
 		}
 
 		/*
-		 * Configure SQLite synchronous setting. Default to NORMAL for WAL mode.
+		 * Configure SQLite synchronous setting. Default to FULL for durable commits.
 		 *
-		 * WAL improves read/write concurrency and "synchronous = NORMAL" avoids
-		 * frequent sync to the main database, which could become a bottleneck.
-		 * In WAL mode, NORMAL is safe and recommended. From the SQLite docs:
-		 *
-		 *   The synchronous=NORMAL setting provides the best balance between
-		 *   performance and safety for most applications running in WAL mode.
-		 *   You lose durability across power loss with synchronous NORMAL in WAL
-		 *   mode, but that is not important for most applications. Transactions
-		 *   are still atomic, consistent, and isolated, which are the most
-		 *   important characteristics in most use cases.
-		 *
-		 * SQLite defaults to "synchronous = FULL" to avoid data corruption with
-		 * other journal modes. With WAL, this is not necessary.
+		 * In WAL mode, FULL synchronizes the WAL file after each transaction
+		 * commit. NORMAL remains safe from corruption, but a committed transaction
+		 * might roll back after a power loss or operating system crash.
 		 *
 		 * See: https://sqlite.org/pragma.html#pragma_synchronous
 		 */
-		$synchronous = $options['synchronous'] ?? null;
-		if ( isset( $synchronous ) ) {
+		$synchronous = $options['synchronous'] ?? 'FULL';
+		if ( isset( $options['synchronous'] ) ) {
 			// Validate and normalize explicitly provided synchronous value.
 			if ( is_int( $synchronous ) && isset( self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ] ) ) {
 				$synchronous = self::SQLITE_SYNCHRONOUS_SETTINGS[ $synchronous ];
@@ -171,13 +157,8 @@ class WP_SQLite_Connection {
 					sprintf( 'Invalid SQLite synchronous setting: %s.', $options['synchronous'] )
 				);
 			}
-		} elseif ( 'WAL' === $effective_journal_mode ) {
-			// Default to NORMAL for WAL mode.
-			$synchronous = 'NORMAL';
 		}
-		if ( in_array( $synchronous, self::SQLITE_SYNCHRONOUS_SETTINGS, true ) ) {
-			$this->query( 'PRAGMA synchronous = ' . $synchronous );
-		}
+		$this->query( 'PRAGMA synchronous = ' . $synchronous );
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -300,7 +300,7 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertSame( 'w', $driver->query( 'SELECT DATABASE()' )->fetch()[0] );
 	}
 
-	public function test_journal_mode_defaults_to_wal(): void {
+	public function test_journal_mode_and_synchronous_default_to_wal_and_full(): void {
 		$path = tempnam( sys_get_temp_dir(), 'wp_sqlite_' );
 		unlink( $path );
 
@@ -312,7 +312,7 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 				strtolower( (string) $connection->query( 'PRAGMA journal_mode' )->fetchColumn() )
 			);
 			$this->assertSame(
-				'1',
+				'2',
 				(string) $connection->query( 'PRAGMA synchronous' )->fetchColumn()
 			);
 		} finally {
@@ -331,7 +331,7 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 				null,
 				array(
 					'sqlite_journal_mode' => 'DELETE',
-					'sqlite_synchronous'  => 'FULL',
+					'sqlite_synchronous'  => 'NORMAL',
 				)
 			);
 			$connection = $driver->get_connection();
@@ -340,7 +340,7 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 				strtolower( (string) $connection->query( 'PRAGMA journal_mode' )->fetchColumn() )
 			);
 			$this->assertSame(
-				'2',
+				'1',
 				(string) $connection->query( 'PRAGMA synchronous' )->fetchColumn()
 			);
 		} finally {

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Connection_Tests.php
@@ -44,11 +44,20 @@ class WP_SQLite_Connection_Tests extends TestCase {
 		$this->db_path = null;
 	}
 
-	public function testDefaultJournalModeUsesWal(): void {
+	public function testDefaultJournalModeUsesWalWithFullSynchronous(): void {
 		$connection = new WP_SQLite_Connection( array( 'path' => $this->db_path ) );
 
 		$this->assertSame( 'wal', $this->get_journal_mode( $connection ) );
-		$this->assertSame( '1', $this->get_synchronous( $connection ) );
+		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+	}
+
+	public function testDefaultSynchronousOverridesExistingPdoSetting(): void {
+		$pdo = new PDO( 'sqlite:' . $this->db_path );
+		$pdo->exec( 'PRAGMA synchronous = NORMAL' );
+
+		$connection = new WP_SQLite_Connection( array( 'pdo' => $pdo ) );
+
+		$this->assertSame( '2', $this->get_synchronous( $connection ) );
 	}
 
 	public function testJournalModeCanBeOverridden(): void {
@@ -66,11 +75,11 @@ class WP_SQLite_Connection_Tests extends TestCase {
 		$connection = new WP_SQLite_Connection(
 			array(
 				'path'        => $this->db_path,
-				'synchronous' => 'FULL',
+				'synchronous' => 'NORMAL',
 			)
 		);
 
-		$this->assertSame( '2', $this->get_synchronous( $connection ) );
+		$this->assertSame( '1', $this->get_synchronous( $connection ) );
 	}
 
 	public function testRollbackJournalModeKeepsDefaultSynchronous(): void {


### PR DESCRIPTION
## Summary

Default SQLite connections to `WAL + FULL` synchronization.

Explicit `sqlite_synchronous` overrides remain supported, including `NORMAL`. The connection tests now cover the new default, overrides, and existing PDO connections whose synchronous setting was previously changed.

## Why

Both settings keep a WAL database consistent, but they provide different durability guarantees:

| Failure | WAL + NORMAL | WAL + FULL |
| --- | --- | --- |
| PHP&nbsp;or&nbsp;application&nbsp;crash | Committed transactions survive. | Committed transactions survive. |
| OS&nbsp;crash&nbsp;or&nbsp;power&nbsp;loss | **Database remains consistent, but recent successful commits may disappear.** | Successful commits survive when storage honors synchronization. |
| Transaction&nbsp;not&nbsp;committed | The transaction rolls back. | The transaction rolls back. |

With `FULL`, SQLite flushes to WAL file after each commit. With `NORMAL`, synchronization happens only during checkpointing, so a successful commit can still be lost after a power failure or system crash. See the [SQLite synchronous documentation](https://www.sqlite.org/pragma.html#pragma_synchronous) and [WAL performance considerations](https://sqlite.org/wal.html#performance_considerations).

## Benchmark

A local benchmark ran a WordPress-like 90% read / 10% write workload against one database file with 4, 8, and 16 concurrent workers. Results are the combined median of ten 10-second runs across two independent batches, with a two-second warmup per run (PHP 8.5.9, SQLite 3.53.4, pure-PHP parser).

| Workers | Configuration | Ops/s (speedup) | p50 | p95 | p99 |
| ---: | --- | ---: | ---: | ---: | ---: |
| 4 | DELETE + FULL | 7,631 (1.0×) | 0.100 ms | 1.380 ms | 10.133 ms |
| 4 | WAL + NORMAL | 37,640 (4.9×) | 0.095 ms | 0.115 ms | 0.150 ms |
| 4 | **WAL + FULL** | 34,883 (4.6×) | 0.098 ms | 0.145 ms | 0.176 ms |
| 8 | DELETE + FULL | 7,936 (1.0×) | 0.101 ms | 3.859 ms | 21.135 ms |
| 8 | WAL + NORMAL | 56,103 (7.1×) | 0.097 ms | 0.126 ms | 1.396 ms |
| 8 | **WAL + FULL** | 43,874 (5.5×) | 0.100 ms | 0.157 ms | 1.421 ms |
| 16 | DELETE + FULL | 7,888 (1.0×) | 0.103 ms | 4.151 ms | 38.256 ms |
| 16 | WAL + NORMAL | 59,372 (7.5×) | 0.108 ms | 0.145 ms | 1.443 ms |
| 16 | **WAL + FULL** | 47,829 (6.1×) | 0.101 ms | 0.169 ms | 1.467 ms |

**WAL + FULL** performs worse than **WAL + NORMAL**, but it's still a significant improvement over the DELETE mode.
