### PR TITLE
Restore database version support for older WordPress releases

### DIFF
--- a/packages/mysql-on-sqlite/tests/fixtures/class-wpdb-stub.php
+++ b/packages/mysql-on-sqlite/tests/fixtures/class-wpdb-stub.php
@@ -4,10 +4,6 @@ class WPDB_Stub {
 	public function add_placeholder_escape( $query ) {
 		return $query;
 	}
-
-	public function db_version() {
-		return preg_replace( '/[^0-9.].*/', '', $this->db_server_info() );
-	}
 }
 
 class_alias( WPDB_Stub::class, 'wpdb' );

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -746,6 +746,21 @@ class WP_SQLite_DB extends wpdb {
 	}
 
 	/**
+	 * Retrieves the emulated database server version number.
+	 *
+	 * This mirrors wpdb::db_version(), but must also be defined here because
+	 * WordPress 5.4 and older fetch server information directly from the MySQL
+	 * extension instead of delegating to wpdb::db_server_info().
+	 *
+	 * @see wpdb::db_version()
+	 *
+	 * @return string Version number on success, or an empty string while disconnected.
+	 */
+	public function db_version() {
+		return preg_replace( '/[^0-9.].*/', '', $this->db_server_info() );
+	}
+
+	/**
 	 * Returns the raw version string of the emulated MySQL server.
 	 *
 	 * @see wpdb::db_server_info()


### PR DESCRIPTION
## Summary

Restore `WP_SQLite_DB::db_version()` and remove the redundant implementation from the unit-test `wpdb` stub.

## Why

WordPress 5.4 and older do not provide `wpdb::db_server_info()`. Their inherited `db_version()` asks the MySQL extension for server information directly, which does not work with the SQLite-backed connection used by Playground. Defining the method on the drop-in makes these releases read the emulated MySQL version through the driver API.

Fixes https://github.com/WordPress/wordpress-playground/issues/4256
