### PR TITLE
Remove INET_ATON WordPress dependency

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-pdo-user-defined-functions.php
@@ -833,7 +833,7 @@ class WP_SQLite_PDO_User_Defined_Functions {
 	 * @return int long integer
 	 */
 	public function inet_aton( $addr ) {
-		return absint( ip2long( $addr ) );
+		return abs( (int) ip2long( $addr ) );
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -405,6 +405,12 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		}
 	}
 
+	public function test_inet_aton(): void {
+		$result = $this->driver->query( "SELECT INET_ATON('1.2.3.4')" );
+
+		$this->assertSame( '16909060', $result->fetchColumn() );
+	}
+
 	public function test_statement_query_string(): void {
 		$query = 'SELECT 1 AS value';
 		$stmt  = $this->driver->query( $query );


### PR DESCRIPTION
## Summary

Removes the driver's dependency on WordPress's `absint()` helper in `INET_ATON()`. The replacement uses native PHP logic, allowing the Composer package to run in standalone PHP applications.

A regression test covers the function through the public PDO-compatible API. The package test suite and coding-standards check pass.

## Why

The standalone Composer package autoloads the driver outside WordPress. Calling `INET_ATON()` previously failed because `absint()` is not available in standalone PHP applications.
