### PR TITLE
Release 3.0.0-rc.9

### DIFF
--- a/packages/mysql-on-sqlite/src/version.php
+++ b/packages/mysql-on-sqlite/src/version.php
@@ -9,4 +9,4 @@ if ( defined( 'SQLITE_DRIVER_VERSION' ) ) {
  *
  * This constant needs to be updated on plugin release!
  */
-define( 'SQLITE_DRIVER_VERSION', '3.0.0-rc.8' );
+define( 'SQLITE_DRIVER_VERSION', '3.0.0-rc.9' );

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: SQLite Database Integration
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
- * Version: 3.0.0-rc.8
+ * Version: 3.0.0-rc.9
  * Requires PHP: 7.2
  * Network: true
  * Textdomain: sqlite-database-integration

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgic
 Requires at least: 6.4
 Tested up to:      7.0
 Requires PHP:      7.2
-Stable tag:        3.0.0-rc.8
+Stable tag:        3.0.0-rc.9
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              performance, database
@@ -43,6 +43,20 @@ the wpdb API, while queries are internally adapted to be compatible
 with SQLite syntax and behavior.
 
 == Changelog ==
+
+= 3.0.0-rc.9 =
+
+* Reject invalid `BIT` column defaults ([#487](https://github.com/WordPress/sqlite-database-integration/pull/487))
+* Make Composer packages installable ([#486](https://github.com/WordPress/sqlite-database-integration/pull/486))
+* Remove `INET_ATON()` WordPress dependency ([#485](https://github.com/WordPress/sqlite-database-integration/pull/485))
+* Restore database version support for older WordPress releases ([#484](https://github.com/WordPress/sqlite-database-integration/pull/484))
+* Finalize MySQL-on-SQLite 3.0 refinements ([#482](https://github.com/WordPress/sqlite-database-integration/pull/482))
+* Prefix SQLite-specific constructor options ([#481](https://github.com/WordPress/sqlite-database-integration/pull/481))
+* Unify emulated MySQL server identity ([#479](https://github.com/WordPress/sqlite-database-integration/pull/479))
+* Document the 3.0 driver API ([#477](https://github.com/WordPress/sqlite-database-integration/pull/477))
+* Expand PDO API coverage ([#471](https://github.com/WordPress/sqlite-database-integration/pull/471))
+* Refine the 3.0 API surface ([#469](https://github.com/WordPress/sqlite-database-integration/pull/469))
+* Add `ANSI_QUOTES` and SQL mode validation ([#452](https://github.com/WordPress/sqlite-database-integration/pull/452))
 
 = 3.0.0-rc.8 =
 


### PR DESCRIPTION
## Release `3.0.0-rc.9`

Version bump and changelog update for release `3.0.0-rc.9`.

**Changelog draft:**
* Reject invalid BIT column defaults ([#487](https://github.com/WordPress/sqlite-database-integration/pull/487))
* Make Composer packages installable ([#486](https://github.com/WordPress/sqlite-database-integration/pull/486))
* Remove INET_ATON WordPress dependency ([#485](https://github.com/WordPress/sqlite-database-integration/pull/485))
* Restore database version support for older WordPress releases ([#484](https://github.com/WordPress/sqlite-database-integration/pull/484))
* Finalize MySQL-on-SQLite 3.0 refinements ([#482](https://github.com/WordPress/sqlite-database-integration/pull/482))
* Prefix SQLite-specific constructor options ([#481](https://github.com/WordPress/sqlite-database-integration/pull/481))
* Unify emulated MySQL server identity ([#479](https://github.com/WordPress/sqlite-database-integration/pull/479))
* Document the 3.0 driver API ([#477](https://github.com/WordPress/sqlite-database-integration/pull/477))
* Expand PDO API coverage ([#471](https://github.com/WordPress/sqlite-database-integration/pull/471))
* Refine the 3.0 API surface ([#469](https://github.com/WordPress/sqlite-database-integration/pull/469))
* Add ANSI_QUOTES and SQL mode validation ([#452](https://github.com/WordPress/sqlite-database-integration/pull/452))

**Full changelog:** https://github.com/WordPress/sqlite-database-integration/compare/v3.0.0-rc.8...release/v3.0.0-rc.9

## Next steps

1. **Review** the changes in this pull request.
2. **Push** any additional edits to this branch (`release/v3.0.0-rc.9`).
3. **Merge** this pull request to complete the release.

Merging will automatically build the plugin ZIP and create a [GitHub release](https://github.com/WordPress/sqlite-database-integration/releases).

> [!NOTE]
> This is a **pre-release**. It will not be deployed to [WordPress.org](https://wordpress.org/plugins/sqlite-database-integration/).