### PR TITLE
Align savepoint handling with MySQL semantics

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -712,18 +712,18 @@ class WP_MySQL_On_SQLite extends PDO {
 	private $in_transaction = false;
 
 	/**
-	 * User savepoints active in the current transaction, from outermost to innermost.
+	 * User savepoints in a transaction opened by a SAVEPOINT statement.
+	 *
+	 * On PHP < 8.4, PDO SQLite cannot detect transactions opened with raw SQL.
+	 * Tracking the savepoint stack keeps the inTransaction() polyfill accurate
+	 * when the outermost savepoint is released.
+	 *
+	 * Savepoints inside a transaction opened by BEGIN are not tracked because
+	 * releasing them cannot end the outer transaction.
 	 *
 	 * @var string[]
 	 */
-	private $transaction_savepoints = array();
-
-	/**
-	 * Whether the current transaction was opened by the outermost user savepoint.
-	 *
-	 * @var bool
-	 */
-	private $transaction_started_by_savepoint = false;
+	private $savepoint_transaction_stack = array();
 
 	/**
 	 * Whether a MySQL table lock is active.
@@ -2106,9 +2106,8 @@ class WP_MySQL_On_SQLite extends PDO {
 		 * @see self::begin_wrapper_transaction()
 		 */
 		$this->connection->query( 'BEGIN IMMEDIATE' );
-		$this->in_transaction                   = true;
-		$this->transaction_savepoints           = array();
-		$this->transaction_started_by_savepoint = false;
+		$this->in_transaction              = true;
+		$this->savepoint_transaction_stack = array();
 	}
 
 	/**
@@ -2120,9 +2119,8 @@ class WP_MySQL_On_SQLite extends PDO {
 			return;
 		}
 		$this->connection->query( 'COMMIT' );
-		$this->in_transaction                   = false;
-		$this->transaction_savepoints           = array();
-		$this->transaction_started_by_savepoint = false;
+		$this->in_transaction              = false;
+		$this->savepoint_transaction_stack = array();
 	}
 
 	/**
@@ -2134,9 +2132,8 @@ class WP_MySQL_On_SQLite extends PDO {
 			return;
 		}
 		$this->connection->query( 'ROLLBACK' );
-		$this->in_transaction                   = false;
-		$this->transaction_savepoints           = array();
-		$this->transaction_started_by_savepoint = false;
+		$this->in_transaction              = false;
+		$this->savepoint_transaction_stack = array();
 	}
 
 	/**
@@ -2178,7 +2175,7 @@ class WP_MySQL_On_SQLite extends PDO {
 						$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
 						$savepoint_index = $this->find_transaction_savepoint_index( $savepoint_key );
 						if ( null !== $savepoint_index ) {
-							$this->transaction_savepoints = array_slice( $this->transaction_savepoints, 0, $savepoint_index + 1 );
+							$this->savepoint_transaction_stack = array_slice( $this->savepoint_transaction_stack, 0, $savepoint_index + 1 );
 						}
 					}
 					return;
@@ -2188,11 +2185,10 @@ class WP_MySQL_On_SQLite extends PDO {
 				if ( WP_MySQL_Lexer::SAVEPOINT_SYMBOL === $token->id ) {
 					$starts_transaction = ! $this->inTransaction();
 					$this->execute_sqlite_query( sprintf( 'SAVEPOINT %s', $savepoint_name ) );
-					if ( $starts_transaction ) {
-						$this->transaction_started_by_savepoint = true;
+					if ( $starts_transaction || ! empty( $this->savepoint_transaction_stack ) ) {
+						$this->savepoint_transaction_stack[] = $savepoint_key;
 					}
-					$this->transaction_savepoints[] = $savepoint_key;
-					$this->in_transaction           = true;
+					$this->in_transaction = true;
 					return;
 				}
 
@@ -2201,11 +2197,10 @@ class WP_MySQL_On_SQLite extends PDO {
 					$this->execute_sqlite_query( sprintf( 'RELEASE SAVEPOINT %s', $savepoint_name ) );
 					$savepoint_index = $this->find_transaction_savepoint_index( $savepoint_key );
 					if ( null !== $savepoint_index ) {
-						$this->transaction_savepoints = array_slice( $this->transaction_savepoints, 0, $savepoint_index );
+						$this->savepoint_transaction_stack = array_slice( $this->savepoint_transaction_stack, 0, $savepoint_index );
 					}
-					if ( $this->transaction_started_by_savepoint && empty( $this->transaction_savepoints ) ) {
-						$this->in_transaction                   = false;
-						$this->transaction_started_by_savepoint = false;
+					if ( null !== $savepoint_index && empty( $this->savepoint_transaction_stack ) ) {
+						$this->in_transaction = false;
 					}
 					return;
 				}
@@ -2284,8 +2279,8 @@ class WP_MySQL_On_SQLite extends PDO {
 	 * @return int|null                Savepoint index, or null when not tracked.
 	 */
 	private function find_transaction_savepoint_index( string $savepoint_name ): ?int {
-		for ( $index = count( $this->transaction_savepoints ) - 1; $index >= 0; $index-- ) {
-			if ( $savepoint_name === $this->transaction_savepoints[ $index ] ) {
+		for ( $index = count( $this->savepoint_transaction_stack ) - 1; $index >= 0; $index-- ) {
+			if ( $savepoint_name === $this->savepoint_transaction_stack[ $index ] ) {
 				return $index;
 			}
 		}

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -712,18 +712,15 @@ class WP_MySQL_On_SQLite extends PDO {
 	private $in_transaction = false;
 
 	/**
-	 * User savepoints in a transaction opened by a SAVEPOINT statement.
+	 * Names of active user savepoints, outermost first.
 	 *
-	 * On PHP < 8.4, PDO SQLite cannot detect transactions opened with raw SQL.
-	 * Tracking the savepoint stack keeps the inTransaction() polyfill accurate
-	 * when the outermost savepoint is released.
-	 *
-	 * Savepoints inside a transaction opened by BEGIN are not tracked because
-	 * releasing them cannot end the outer transaction.
+	 * MySQL replaces a savepoint with the same name, while SQLite only shadows it.
+	 * Tracking normalized names prevents shadowed SQLite savepoints from becoming
+	 * visible again and supports case-insensitive lookup.
 	 *
 	 * @var string[]
 	 */
-	private $savepoint_transaction_stack = array();
+	private $savepoint_names = array();
 
 	/**
 	 * Whether a MySQL table lock is active.
@@ -2106,8 +2103,8 @@ class WP_MySQL_On_SQLite extends PDO {
 		 * @see self::begin_wrapper_transaction()
 		 */
 		$this->connection->query( 'BEGIN IMMEDIATE' );
-		$this->in_transaction              = true;
-		$this->savepoint_transaction_stack = array();
+		$this->in_transaction  = true;
+		$this->savepoint_names = array();
 	}
 
 	/**
@@ -2119,8 +2116,8 @@ class WP_MySQL_On_SQLite extends PDO {
 			return;
 		}
 		$this->connection->query( 'COMMIT' );
-		$this->in_transaction              = false;
-		$this->savepoint_transaction_stack = array();
+		$this->in_transaction  = false;
+		$this->savepoint_names = array();
 	}
 
 	/**
@@ -2132,8 +2129,8 @@ class WP_MySQL_On_SQLite extends PDO {
 			return;
 		}
 		$this->connection->query( 'ROLLBACK' );
-		$this->in_transaction              = false;
-		$this->savepoint_transaction_stack = array();
+		$this->in_transaction  = false;
+		$this->savepoint_names = array();
 	}
 
 	/**
@@ -2172,36 +2169,49 @@ class WP_MySQL_On_SQLite extends PDO {
 					if ( null === $savepoint_name ) {
 						$this->rollback_user_transaction();
 					} else {
-						$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
-						$savepoint_index = $this->find_transaction_savepoint_index( $savepoint_key );
-						if ( null !== $savepoint_index ) {
-							$this->savepoint_transaction_stack = array_slice( $this->savepoint_transaction_stack, 0, $savepoint_index + 1 );
+						// ROLLBACK TO keeps the named savepoint and deletes those created after it.
+						$index = array_search( $savepoint_key, $this->savepoint_names, true );
+						if ( false === $index ) {
+							throw $this->new_savepoint_does_not_exist_exception( $savepoint_name );
 						}
+						$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
+						array_splice( $this->savepoint_names, $index + 1 );
 					}
 					return;
 				}
 
 				// SAVEPOINT.
 				if ( WP_MySQL_Lexer::SAVEPOINT_SYMBOL === $token->id ) {
-					$starts_transaction = ! $this->inTransaction();
-					$this->execute_sqlite_query( sprintf( 'SAVEPOINT %s', $savepoint_name ) );
-					if ( $starts_transaction || ! empty( $this->savepoint_transaction_stack ) ) {
-						$this->savepoint_transaction_stack[] = $savepoint_key;
+					// In MySQL with autocommit enabled, a standalone savepoint is discarded
+					// immediately without starting a transaction.
+					if ( ! $this->inTransaction() ) {
+						return;
 					}
-					$this->in_transaction = true;
+					$this->execute_sqlite_query( sprintf( 'SAVEPOINT %s', $savepoint_name ) );
+
+					/*
+					 * MySQL deletes an existing savepoint when its name is reused, while
+					 * SQLite keeps it on the stack, shadowed by the new one. Drop the old
+					 * name so that it can no longer be referenced. The shadowed SQLite
+					 * savepoint is harmless; it is discarded when the transaction ends.
+					 */
+					$index = array_search( $savepoint_key, $this->savepoint_names, true );
+					if ( false !== $index ) {
+						array_splice( $this->savepoint_names, $index, 1 );
+					}
+					$this->savepoint_names[] = $savepoint_key;
 					return;
 				}
 
 				// RELEASE SAVEPOINT.
 				if ( WP_MySQL_Lexer::RELEASE_SYMBOL === $token->id ) {
+					// RELEASE deletes the named savepoint and those created after it.
+					$index = array_search( $savepoint_key, $this->savepoint_names, true );
+					if ( false === $index ) {
+						throw $this->new_savepoint_does_not_exist_exception( $savepoint_name );
+					}
 					$this->execute_sqlite_query( sprintf( 'RELEASE SAVEPOINT %s', $savepoint_name ) );
-					$savepoint_index = $this->find_transaction_savepoint_index( $savepoint_key );
-					if ( null !== $savepoint_index ) {
-						$this->savepoint_transaction_stack = array_slice( $this->savepoint_transaction_stack, 0, $savepoint_index );
-					}
-					if ( null !== $savepoint_index && empty( $this->savepoint_transaction_stack ) ) {
-						$this->in_transaction = false;
-					}
+					array_splice( $this->savepoint_names, $index );
 					return;
 				}
 
@@ -2270,21 +2280,6 @@ class WP_MySQL_On_SQLite extends PDO {
 				$subnode->rule_name
 			)
 		);
-	}
-
-	/**
-	 * Find the innermost active user savepoint with the given name.
-	 *
-	 * @param  string $savepoint_name Normalized savepoint name.
-	 * @return int|null                Savepoint index, or null when not tracked.
-	 */
-	private function find_transaction_savepoint_index( string $savepoint_name ): ?int {
-		for ( $index = count( $this->savepoint_transaction_stack ) - 1; $index >= 0; $index-- ) {
-			if ( $savepoint_name === $this->savepoint_transaction_stack[ $index ] ) {
-				return $index;
-			}
-		}
-		return null;
 	}
 
 	/**
@@ -7864,6 +7859,25 @@ class WP_MySQL_On_SQLite extends PDO {
 			'42S02',
 			$previous,
 			array( '42S02', 1146, $driver_message )
+		);
+	}
+
+	/**
+	 * Create a MySQL-compatible savepoint-not-found exception.
+	 *
+	 * @param  string $savepoint_name The missing savepoint name, as an SQLite identifier.
+	 * @return WP_MySQL_On_SQLite_Exception
+	 */
+	private function new_savepoint_does_not_exist_exception( string $savepoint_name ): WP_MySQL_On_SQLite_Exception {
+		$driver_message = sprintf(
+			'SAVEPOINT %s does not exist',
+			$this->unquote_sqlite_identifier( $savepoint_name )
+		);
+		return $this->new_driver_exception(
+			'SQLSTATE[42000]: Syntax error or access violation: 1305 ' . $driver_message,
+			'42000',
+			null,
+			array( '42000', 1305, $driver_message )
 		);
 	}
 

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -712,6 +712,20 @@ class WP_MySQL_On_SQLite extends PDO {
 	private $in_transaction = false;
 
 	/**
+	 * User savepoints active in the current transaction, from outermost to innermost.
+	 *
+	 * @var string[]
+	 */
+	private $transaction_savepoints = array();
+
+	/**
+	 * Whether the current transaction was opened by the outermost user savepoint.
+	 *
+	 * @var bool
+	 */
+	private $transaction_started_by_savepoint = false;
+
+	/**
 	 * Whether a MySQL table lock is active.
 	 *
 	 * Set to "true" when a lock is acquired using the MySQL LOCK statement.
@@ -2092,7 +2106,9 @@ class WP_MySQL_On_SQLite extends PDO {
 		 * @see self::begin_wrapper_transaction()
 		 */
 		$this->connection->query( 'BEGIN IMMEDIATE' );
-		$this->in_transaction = true;
+		$this->in_transaction                   = true;
+		$this->transaction_savepoints           = array();
+		$this->transaction_started_by_savepoint = false;
 	}
 
 	/**
@@ -2104,7 +2120,9 @@ class WP_MySQL_On_SQLite extends PDO {
 			return;
 		}
 		$this->connection->query( 'COMMIT' );
-		$this->in_transaction = false;
+		$this->in_transaction                   = false;
+		$this->transaction_savepoints           = array();
+		$this->transaction_started_by_savepoint = false;
 	}
 
 	/**
@@ -2116,7 +2134,9 @@ class WP_MySQL_On_SQLite extends PDO {
 			return;
 		}
 		$this->connection->query( 'ROLLBACK' );
-		$this->in_transaction = false;
+		$this->in_transaction                   = false;
+		$this->transaction_savepoints           = array();
+		$this->transaction_started_by_savepoint = false;
 	}
 
 	/**
@@ -2146,6 +2166,9 @@ class WP_MySQL_On_SQLite extends PDO {
 				break;
 			case 'savepointStatement':
 				$savepoint_name = $this->translate( $subnode->get_first_child_node( 'identifier' ) );
+				$savepoint_key  = null === $savepoint_name
+					? null
+					: strtolower( $this->unquote_sqlite_identifier( $savepoint_name ) );
 
 				// ROLLBACK/ROLLBACK TO SAVEPOINT <identifier>.
 				if ( WP_MySQL_Lexer::ROLLBACK_SYMBOL === $token->id ) {
@@ -2153,19 +2176,37 @@ class WP_MySQL_On_SQLite extends PDO {
 						$this->rollback_user_transaction();
 					} else {
 						$this->execute_sqlite_query( sprintf( 'ROLLBACK TO SAVEPOINT %s', $savepoint_name ) );
+						$savepoint_index = $this->find_transaction_savepoint_index( $savepoint_key );
+						if ( null !== $savepoint_index ) {
+							$this->transaction_savepoints = array_slice( $this->transaction_savepoints, 0, $savepoint_index + 1 );
+						}
 					}
 					return;
 				}
 
 				// SAVEPOINT.
 				if ( WP_MySQL_Lexer::SAVEPOINT_SYMBOL === $token->id ) {
+					$starts_transaction = ! $this->inTransaction();
 					$this->execute_sqlite_query( sprintf( 'SAVEPOINT %s', $savepoint_name ) );
+					if ( $starts_transaction ) {
+						$this->transaction_started_by_savepoint = true;
+					}
+					$this->transaction_savepoints[] = $savepoint_key;
+					$this->in_transaction           = true;
 					return;
 				}
 
 				// RELEASE SAVEPOINT.
 				if ( WP_MySQL_Lexer::RELEASE_SYMBOL === $token->id ) {
 					$this->execute_sqlite_query( sprintf( 'RELEASE SAVEPOINT %s', $savepoint_name ) );
+					$savepoint_index = $this->find_transaction_savepoint_index( $savepoint_key );
+					if ( null !== $savepoint_index ) {
+						$this->transaction_savepoints = array_slice( $this->transaction_savepoints, 0, $savepoint_index );
+					}
+					if ( $this->transaction_started_by_savepoint && empty( $this->transaction_savepoints ) ) {
+						$this->in_transaction                   = false;
+						$this->transaction_started_by_savepoint = false;
+					}
 					return;
 				}
 
@@ -2234,6 +2275,21 @@ class WP_MySQL_On_SQLite extends PDO {
 				$subnode->rule_name
 			)
 		);
+	}
+
+	/**
+	 * Find the innermost active user savepoint with the given name.
+	 *
+	 * @param  string $savepoint_name Normalized savepoint name.
+	 * @return int|null                Savepoint index, or null when not tracked.
+	 */
+	private function find_transaction_savepoint_index( string $savepoint_name ): ?int {
+		for ( $index = count( $this->transaction_savepoints ) - 1; $index >= 0; $index-- ) {
+			if ( $savepoint_name === $this->transaction_savepoints[ $index ] ) {
+				return $index;
+			}
+		}
+		return null;
 	}
 
 	/**

--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -1193,11 +1193,16 @@ class WP_MySQL_On_SQLite extends PDO {
 			$this->error_info = array( '00000', null, null );
 			return $stmt;
 		} catch ( Throwable $e ) {
-			try {
-				$this->rollback_user_transaction();
-				$this->table_lock_active = false;
-			} catch ( Throwable $rollback_exception ) {
-				// Ignore rollback errors.
+			// MySQL error 1305 reports a missing savepoint without ending the transaction.
+			$preserves_transaction = $e instanceof WP_MySQL_On_SQLite_Exception
+				&& 1305 === ( $e->errorInfo[1] ?? null );
+			if ( ! $preserves_transaction ) {
+				try {
+					$this->rollback_user_transaction();
+					$this->table_lock_active = false;
+				} catch ( Throwable $rollback_exception ) {
+					// Ignore rollback errors.
+				}
 			}
 			if ( $e instanceof WP_SQLite_Information_Schema_Exception ) {
 				$e = $this->convert_information_schema_exception( $e );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Concurrency_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Concurrency_Tests.php
@@ -72,6 +72,19 @@ class WP_MySQL_On_SQLite_Concurrency_Tests extends TestCase {
 		$this->assertSame( 'BEGIN IMMEDIATE', $driver->get_last_sqlite_queries()[0]['sql'] );
 	}
 
+	public function testWriteQueryAfterSavepointOpensWriteTransaction(): void {
+		$driver = $this->create_in_memory_driver();
+		$driver->query( 'CREATE TABLE t (id INT, name VARCHAR(255))' );
+		$driver->query( "INSERT INTO t VALUES (1, 'Alice')" );
+
+		// A savepoint outside of a transaction must not leave a deferred SQLite
+		// transaction open, which would make the following write skip the lock.
+		$driver->query( 'SAVEPOINT sp1' );
+		$driver->query( "UPDATE t SET name = 'Carol' WHERE id = 1" );
+
+		$this->assertSame( 'BEGIN IMMEDIATE', $driver->get_last_sqlite_queries()[0]['sql'] );
+	}
+
 	public function provideWriteStatements(): array {
 		return array(
 			'INSERT'         => array( "INSERT INTO t VALUES (2, 'Bob')" ),

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -923,36 +923,6 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertSame( array( 'ROLLBACK' ), array_column( $this->driver->get_last_sqlite_queries(), 'sql' ) );
 	}
 
-	public function test_standalone_write_uses_wrapper_transaction(): void {
-		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
-		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
-
-		$statement = $this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
-		$queries   = array_column( $this->driver->get_last_sqlite_queries(), 'sql' );
-
-		$this->assertSame( 1, $statement->rowCount() );
-		$this->assertSame( 'BEGIN IMMEDIATE', $queries[0] );
-		$this->assertSame( 'COMMIT', end( $queries ) );
-	}
-
-	public function test_write_inside_savepoint_commits_on_release(): void {
-		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
-		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
-
-		$this->driver->query( 'SAVEPOINT outer_transaction' );
-		$statement = $this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
-		$queries   = array_column( $this->driver->get_last_sqlite_queries(), 'sql' );
-
-		$this->assertSame( 1, $statement->rowCount() );
-		$this->assertNotContains( 'BEGIN IMMEDIATE', $queries );
-		$this->assertTrue( $this->driver->inTransaction() );
-
-		$this->driver->query( 'RELEASE SAVEPOINT outer_transaction' );
-
-		$this->assertFalse( $this->driver->inTransaction() );
-		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
-	}
-
 	public function test_releasing_savepoint_inside_explicit_transaction_keeps_transaction_active(): void {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
@@ -972,10 +942,14 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
 
+		$this->driver->query( 'START TRANSACTION' );
 		$this->driver->query( 'SAVEPOINT outer_transaction' );
 		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
 		$this->driver->query( 'ROLLBACK TO SAVEPOINT outer_transaction' );
 		$this->driver->query( 'RELEASE SAVEPOINT outer_transaction' );
+
+		$this->assertTrue( $this->driver->inTransaction() );
+		$this->driver->query( 'COMMIT' );
 
 		$this->assertFalse( $this->driver->inTransaction() );
 		$this->assertSame( '1', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
@@ -985,6 +959,7 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
 
+		$this->driver->query( 'START TRANSACTION' );
 		$this->driver->query( 'SAVEPOINT outer_transaction' );
 		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
 		$this->driver->query( 'SAVEPOINT inner_transaction' );
@@ -997,27 +972,28 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 
 		$this->driver->query( 'RELEASE SAVEPOINT outer_transaction' );
 
+		$this->assertTrue( $this->driver->inTransaction() );
+		$this->driver->query( 'COMMIT' );
+
 		$this->assertFalse( $this->driver->inTransaction() );
 		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
 	}
 
-	public function test_duplicate_savepoint_names_track_innermost_scope(): void {
+	public function test_duplicate_savepoint_names_roll_back_to_the_latest(): void {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
 
+		$this->driver->query( 'START TRANSACTION' );
 		$this->driver->query( 'SAVEPOINT repeated' );
 		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
 		$this->driver->query( 'SAVEPOINT repeated' );
 		$this->driver->query( 'UPDATE t SET value = 3 WHERE id = 1' );
-		$this->driver->query( 'ROLLBACK TO SAVEPOINT repeated' );
-		$this->driver->query( 'RELEASE SAVEPOINT repeated' );
 
-		$this->assertTrue( $this->driver->inTransaction() );
+		// A reused name refers to the savepoint that was set last.
+		$this->driver->query( 'ROLLBACK TO SAVEPOINT repeated' );
 		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
 
-		$this->driver->query( 'RELEASE SAVEPOINT repeated' );
-
-		$this->assertFalse( $this->driver->inTransaction() );
+		$this->driver->query( 'COMMIT' );
 		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
 	}
 
@@ -1025,16 +1001,20 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
 
+		$this->driver->query( 'START TRANSACTION' );
 		$this->driver->query( 'SAVEPOINT `MixedCase`' );
 		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
 		$this->driver->query( 'ROLLBACK TO SAVEPOINT `mixedcase`' );
 		$this->driver->query( 'RELEASE SAVEPOINT `MIXEDCASE`' );
 
+		$this->assertTrue( $this->driver->inTransaction() );
+		$this->driver->query( 'COMMIT' );
+
 		$this->assertFalse( $this->driver->inTransaction() );
 		$this->assertSame( '1', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
 	}
 
-	public function test_failed_write_cleans_up_savepoint_transaction_state(): void {
+	public function test_failed_write_after_standalone_savepoint_keeps_autocommit(): void {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1)' );
 		$this->driver->query( 'SAVEPOINT outer_transaction' );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -986,6 +986,39 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
 	}
 
+	public function test_duplicate_savepoint_names_track_innermost_scope(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
+
+		$this->driver->query( 'SAVEPOINT repeated' );
+		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
+		$this->driver->query( 'SAVEPOINT repeated' );
+		$this->driver->query( 'UPDATE t SET value = 3 WHERE id = 1' );
+		$this->driver->query( 'ROLLBACK TO SAVEPOINT repeated' );
+		$this->driver->query( 'RELEASE SAVEPOINT repeated' );
+
+		$this->assertTrue( $this->driver->inTransaction() );
+		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+
+		$this->driver->query( 'RELEASE SAVEPOINT repeated' );
+
+		$this->assertFalse( $this->driver->inTransaction() );
+		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+	}
+
+	public function test_quoted_savepoint_names_are_case_insensitive(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
+
+		$this->driver->query( 'SAVEPOINT `MixedCase`' );
+		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
+		$this->driver->query( 'ROLLBACK TO SAVEPOINT `mixedcase`' );
+		$this->driver->query( 'RELEASE SAVEPOINT `MIXEDCASE`' );
+
+		$this->assertFalse( $this->driver->inTransaction() );
+		$this->assertSame( '1', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+	}
+
 	public function test_failed_write_cleans_up_savepoint_transaction_state(): void {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1)' );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -923,6 +923,90 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertSame( array( 'ROLLBACK' ), array_column( $this->driver->get_last_sqlite_queries(), 'sql' ) );
 	}
 
+	public function test_standalone_write_uses_wrapper_transaction(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
+
+		$statement = $this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
+		$queries   = array_column( $this->driver->get_last_sqlite_queries(), 'sql' );
+
+		$this->assertSame( 1, $statement->rowCount() );
+		$this->assertSame( 'BEGIN IMMEDIATE', $queries[0] );
+		$this->assertSame( 'COMMIT', end( $queries ) );
+	}
+
+	public function test_write_inside_savepoint_commits_on_release(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
+
+		$this->driver->query( 'SAVEPOINT outer_transaction' );
+		$statement = $this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
+		$queries   = array_column( $this->driver->get_last_sqlite_queries(), 'sql' );
+
+		$this->assertSame( 1, $statement->rowCount() );
+		$this->assertNotContains( 'BEGIN IMMEDIATE', $queries );
+		$this->assertTrue( $this->driver->inTransaction() );
+
+		$this->driver->query( 'RELEASE SAVEPOINT outer_transaction' );
+
+		$this->assertFalse( $this->driver->inTransaction() );
+		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+	}
+
+	public function test_write_inside_savepoint_can_be_rolled_back(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
+
+		$this->driver->query( 'SAVEPOINT outer_transaction' );
+		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
+		$this->driver->query( 'ROLLBACK TO SAVEPOINT outer_transaction' );
+		$this->driver->query( 'RELEASE SAVEPOINT outer_transaction' );
+
+		$this->assertFalse( $this->driver->inTransaction() );
+		$this->assertSame( '1', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+	}
+
+	public function test_writes_inside_nested_savepoints_preserve_outer_changes(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
+
+		$this->driver->query( 'SAVEPOINT outer_transaction' );
+		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
+		$this->driver->query( 'SAVEPOINT inner_transaction' );
+		$this->driver->query( 'UPDATE t SET value = 3 WHERE id = 1' );
+		$this->driver->query( 'ROLLBACK TO SAVEPOINT inner_transaction' );
+		$this->driver->query( 'RELEASE SAVEPOINT inner_transaction' );
+
+		$this->assertTrue( $this->driver->inTransaction() );
+		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+
+		$this->driver->query( 'RELEASE SAVEPOINT outer_transaction' );
+
+		$this->assertFalse( $this->driver->inTransaction() );
+		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+	}
+
+	public function test_failed_write_cleans_up_savepoint_transaction_state(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1)' );
+		$this->driver->query( 'SAVEPOINT outer_transaction' );
+
+		try {
+			$this->driver->query( 'INSERT INTO t VALUES (1)' );
+			$this->fail( 'Expected the duplicate insert to fail.' );
+		} catch ( PDOException $e ) {
+			$this->assertStringContainsString( 'UNIQUE constraint failed', $e->getMessage() );
+		}
+
+		$this->assertFalse( $this->driver->inTransaction() );
+		$this->assertSame( '1', $this->driver->query( 'SELECT COUNT(*) FROM t' )->fetchColumn() );
+
+		$this->driver->query( 'INSERT INTO t VALUES (2)' );
+		$queries = array_column( $this->driver->get_last_sqlite_queries(), 'sql' );
+		$this->assertSame( 'BEGIN IMMEDIATE', $queries[0] );
+		$this->assertSame( 'COMMIT', end( $queries ) );
+	}
+
 	public function test_fetch_default(): void {
 		// Default fetch mode is PDO::FETCH_BOTH.
 		$result = $this->driver->query( "SELECT 1, 'abc', 2" );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_PDO_API_Tests.php
@@ -953,6 +953,21 @@ class WP_MySQL_On_SQLite_PDO_API_Tests extends TestCase {
 		$this->assertSame( '2', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
 	}
 
+	public function test_releasing_savepoint_inside_explicit_transaction_keeps_transaction_active(): void {
+		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
+		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );
+
+		$this->driver->query( 'START TRANSACTION' );
+		$this->driver->query( 'SAVEPOINT nested_transaction' );
+		$this->driver->query( 'UPDATE t SET value = 2 WHERE id = 1' );
+		$this->driver->query( 'RELEASE SAVEPOINT nested_transaction' );
+
+		$this->assertTrue( $this->driver->inTransaction() );
+		$this->driver->query( 'ROLLBACK' );
+		$this->assertFalse( $this->driver->inTransaction() );
+		$this->assertSame( '1', $this->driver->query( 'SELECT value FROM t' )->fetchColumn() );
+	}
+
 	public function test_write_inside_savepoint_can_be_rolled_back(): void {
 		$this->driver->query( 'CREATE TABLE t (id INT PRIMARY KEY, value INT)' );
 		$this->driver->query( 'INSERT INTO t VALUES (1, 1)' );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -16,6 +16,8 @@ class WP_MySQL_On_SQLite_Tests extends TestCase {
 	private const SQL_MODE_TIME_TRUNCATE_FRACTIONAL = 1 << 32;
 	private const UNKNOWN_SQL_MODE_BIT              = 1 << 33;
 
+	private const SAVEPOINT_DOES_NOT_EXIST_ERROR = 'SQLSTATE[42000]: Syntax error or access violation: 1305 SAVEPOINT %s does not exist';
+
 	/** @var WP_MySQL_On_SQLite */
 	private $engine;
 
@@ -7731,6 +7733,95 @@ END;
 		$this->assertSame( array(), (array) array_column( $result, 'id' ) );
 	}
 
+	public function testSavepointWithoutTransactionDoesNotStartTransaction(): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT PRIMARY KEY, v INT)' );
+		$this->assertQuery( 'INSERT INTO t (id, v) VALUES (1, 1)' );
+
+		// With autocommit, each statement forms its own transaction, so a savepoint
+		// is discarded as soon as the SAVEPOINT statement completes.
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertFalse( $this->engine->inTransaction() );
+
+		// The write must succeed and be committed immediately.
+		$this->assertQuery( 'UPDATE t SET v = 2 WHERE id = 1' );
+		$this->assertFalse( $this->engine->inTransaction() );
+		$result = $this->assertQuery( 'SELECT v FROM t WHERE id = 1' );
+		$this->assertSame( '2', $result[0]->v );
+
+		// The savepoint is no longer available.
+		$this->assertQueryError(
+			'ROLLBACK TO SAVEPOINT sp1',
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'sp1' )
+		);
+	}
+
+	public function testReleaseSavepointWithoutTransaction(): void {
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertQueryError(
+			'RELEASE SAVEPOINT sp1',
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'sp1' )
+		);
+	}
+
+	public function testDuplicateSavepointNameReplacesOldSavepoint(): void {
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertQuery( 'SAVEPOINT sp2' );
+		$this->assertQuery( 'SAVEPOINT sp1' );
+
+		// Releasing the replacement must leave sp2 available.
+		$this->assertQuery( 'RELEASE SAVEPOINT sp1' );
+		$this->assertQuery( 'ROLLBACK TO SAVEPOINT sp2' );
+
+		// The original sp1 must remain unavailable.
+		$this->assertQueryError(
+			'ROLLBACK TO SAVEPOINT sp1',
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'sp1' )
+		);
+	}
+
+	public function testReleaseSavepointDeletesNestedSavepoints(): void {
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertQuery( 'SAVEPOINT sp2' );
+		$this->assertQuery( 'RELEASE SAVEPOINT sp1' );
+		$this->assertQueryError(
+			'ROLLBACK TO SAVEPOINT sp2',
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'sp2' )
+		);
+	}
+
+	public function testRollbackToSavepointDeletesNestedSavepoints(): void {
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertQuery( 'SAVEPOINT sp2' );
+		$this->assertQuery( 'ROLLBACK TO SAVEPOINT sp1' );
+		$this->assertQueryError(
+			'ROLLBACK TO SAVEPOINT sp2',
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'sp2' )
+		);
+	}
+
+	public function testCommitDeletesSavepoints(): void {
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertQuery( 'COMMIT' );
+		$this->assertQueryError(
+			'ROLLBACK TO SAVEPOINT sp1',
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'sp1' )
+		);
+	}
+
+	public function testRollbackDeletesSavepoints(): void {
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'SAVEPOINT sp1' );
+		$this->assertQuery( 'ROLLBACK' );
+		$this->assertQueryError(
+			'ROLLBACK TO SAVEPOINT sp1',
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'sp1' )
+		);
+	}
+
 	public function testRowLeveLockingClauses() {
 		$this->assertQuery( 'CREATE TABLE t (name VARCHAR(255), value VARCHAR(255))' );
 		$this->query( "INSERT INTO t (name, value) VALUES ('test_lock', '123')" );
@@ -8011,7 +8102,7 @@ END;
 
 	public function testRollbackNonExistentTransactionSavepoint(): void {
 		$this->expectException( 'WP_MySQL_On_SQLite_Exception' );
-		$this->expectExceptionMessage( 'no such savepoint: sp1' );
+		$this->expectExceptionMessage( 'SAVEPOINT sp1 does not exist' );
 		$this->assertQuery( 'ROLLBACK TO SAVEPOINT sp1' );
 	}
 
@@ -11547,7 +11638,8 @@ END;
 		$this->assertSame( 0, $this->last_statement->columnCount() );
 		$this->assertSame( array(), $this->getLastColumnMeta() );
 
-		// SAVEPOINT
+		// SAVEPOINT (savepoints exist only within a transaction).
+		$this->assertQuery( 'START TRANSACTION' );
 		$this->assertQuery( 'SAVEPOINT s1' );
 		$this->assertSame( 0, $this->last_statement->columnCount() );
 		$this->assertSame( array(), $this->getLastColumnMeta() );
@@ -11561,6 +11653,7 @@ END;
 		$this->assertQuery( 'RELEASE SAVEPOINT s1' );
 		$this->assertSame( 0, $this->last_statement->columnCount() );
 		$this->assertSame( array(), $this->getLastColumnMeta() );
+		$this->assertQuery( 'COMMIT' );
 
 		// LOCK TABLE
 		$this->assertQuery( 'LOCK TABLES t READ' );

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Tests.php
@@ -7763,6 +7763,36 @@ END;
 		);
 	}
 
+	/**
+	 * @dataProvider missingSavepointStatements
+	 */
+	public function testMissingSavepointDoesNotRollbackTransaction( string $statement ): void {
+		$this->assertQuery( 'CREATE TABLE t (id INT)' );
+		$this->assertQuery( 'BEGIN' );
+		$this->assertQuery( 'SAVEPOINT existing' );
+		$this->assertQuery( 'INSERT INTO t VALUES (1)' );
+
+		$this->assertQueryError(
+			$statement,
+			sprintf( self::SAVEPOINT_DOES_NOT_EXIST_ERROR, 'missing' )
+		);
+
+		$this->assertTrue( $this->engine->inTransaction() );
+		$this->assertSame( '1', $this->assertQuery( 'SELECT id FROM t' )[0]->id );
+
+		$this->assertQuery( 'ROLLBACK TO SAVEPOINT existing' );
+		$this->assertQuery( 'RELEASE SAVEPOINT existing' );
+		$this->assertQuery( 'COMMIT' );
+		$this->assertSame( array(), $this->assertQuery( 'SELECT id FROM t' ) );
+	}
+
+	public static function missingSavepointStatements(): array {
+		return array(
+			'ROLLBACK TO SAVEPOINT' => array( 'ROLLBACK TO SAVEPOINT missing' ),
+			'RELEASE SAVEPOINT'     => array( 'RELEASE SAVEPOINT missing' ),
+		);
+	}
+
 	public function testDuplicateSavepointNameReplacesOldSavepoint(): void {
 		$this->assertQuery( 'BEGIN' );
 		$this->assertQuery( 'SAVEPOINT sp1' );

--- a/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
@@ -1,6 +1,6 @@
 <?php
 
-class WP_SQLite_Database_Integration_Savepoint_Test extends WP_UnitTestCase {
+class WP_SQLite_Database_Integration_Savepoint_Test extends PHPUnit_Adapter_TestCase {
 
 	public function test_wpdb_update_inside_savepoint_does_not_open_nested_transaction() {
 		global $wpdb;
@@ -16,6 +16,7 @@ class WP_SQLite_Database_Integration_Savepoint_Test extends WP_UnitTestCase {
 		);
 
 		try {
+			$this->assertFalse( $wpdb->get_driver()->inTransaction() );
 			$this->assertNotFalse( $wpdb->query( 'SAVEPOINT wpdb_update' ) );
 
 			$result  = $wpdb->update( $wpdb->options, array( 'option_value' => '2' ), array( 'option_name' => $option_name ) );
@@ -26,6 +27,7 @@ class WP_SQLite_Database_Integration_Savepoint_Test extends WP_UnitTestCase {
 			$this->assertSame( '', $wpdb->last_error );
 			$this->assertNotContains( 'BEGIN IMMEDIATE', $queries );
 			$this->assertNotFalse( $wpdb->query( 'RELEASE SAVEPOINT wpdb_update' ) );
+			$this->assertFalse( $wpdb->get_driver()->inTransaction() );
 			$this->assertSame(
 				'2',
 				$wpdb->get_var(

--- a/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
@@ -2,7 +2,7 @@
 
 class WP_SQLite_Database_Integration_Savepoint_Test extends PHPUnit_Adapter_TestCase {
 
-	public function test_wpdb_update_inside_savepoint_does_not_open_nested_transaction() {
+	public function test_wpdb_update_after_savepoint_commits_immediately() {
 		global $wpdb;
 
 		$option_name = 'sqlite_savepoint_write_test';
@@ -22,12 +22,20 @@ class WP_SQLite_Database_Integration_Savepoint_Test extends PHPUnit_Adapter_Test
 			$result  = $wpdb->update( $wpdb->options, array( 'option_value' => '2' ), array( 'option_name' => $option_name ) );
 			$queries = array_column( $wpdb->get_driver()->get_last_sqlite_queries(), 'sql' );
 
+			// The savepoint does not open a transaction, so the update takes the
+			// write lock and is committed on its own, as it would be on MySQL.
 			$this->assertSame( 1, $result );
 			$this->assertSame( 1, $wpdb->rows_affected );
 			$this->assertSame( '', $wpdb->last_error );
-			$this->assertNotContains( 'BEGIN IMMEDIATE', $queries );
-			$this->assertNotFalse( $wpdb->query( 'RELEASE SAVEPOINT wpdb_update' ) );
+			$this->assertContains( 'BEGIN IMMEDIATE', $queries );
 			$this->assertFalse( $wpdb->get_driver()->inTransaction() );
+
+			// The savepoint was discarded, so releasing it reports MySQL error 1305.
+			$suppress       = $wpdb->suppress_errors( true );
+			$release_result = $wpdb->query( 'RELEASE SAVEPOINT wpdb_update' );
+			$wpdb->suppress_errors( $suppress );
+			$this->assertFalse( $release_result );
+			$this->assertStringContainsString( 'SAVEPOINT wpdb_update does not exist', $wpdb->last_error );
 			$this->assertSame(
 				'2',
 				$wpdb->get_var(

--- a/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
@@ -1,0 +1,37 @@
+<?php
+
+class WP_SQLite_Database_Integration_Savepoint_Test extends WP_UnitTestCase {
+
+	public function test_wpdb_update_inside_savepoint_does_not_open_nested_transaction() {
+		global $wpdb;
+
+		$table_name = $wpdb->prefix . 'sqlite_savepoint_write_test';
+		$wpdb->query( $wpdb->prepare( 'CREATE TABLE %i (id INT PRIMARY KEY, value INT)', $table_name ) );
+		$wpdb->insert(
+			$table_name,
+			array(
+				'id'    => 1,
+				'value' => 1,
+			)
+		);
+
+		try {
+			$this->assertNotFalse( $wpdb->query( 'SAVEPOINT wpdb_update' ) );
+
+			$result  = $wpdb->update( $table_name, array( 'value' => 2 ), array( 'id' => 1 ) );
+			$queries = array_column( $wpdb->get_driver()->get_last_sqlite_queries(), 'sql' );
+
+			$this->assertSame( 1, $result );
+			$this->assertSame( 1, $wpdb->rows_affected );
+			$this->assertSame( '', $wpdb->last_error );
+			$this->assertNotContains( 'BEGIN IMMEDIATE', $queries );
+			$this->assertNotFalse( $wpdb->query( 'RELEASE SAVEPOINT wpdb_update' ) );
+			$this->assertSame( '2', $wpdb->get_var( $wpdb->prepare( 'SELECT value FROM %i WHERE id = 1', $table_name ) ) );
+		} finally {
+			if ( $wpdb->get_driver()->inTransaction() ) {
+				$wpdb->query( 'ROLLBACK' );
+			}
+			$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ) );
+		}
+	}
+}

--- a/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
+++ b/tests/phpunit/WP_SQLite_Database_Integration_Savepoint_Test.php
@@ -5,20 +5,20 @@ class WP_SQLite_Database_Integration_Savepoint_Test extends WP_UnitTestCase {
 	public function test_wpdb_update_inside_savepoint_does_not_open_nested_transaction() {
 		global $wpdb;
 
-		$table_name = $wpdb->prefix . 'sqlite_savepoint_write_test';
-		$wpdb->query( $wpdb->prepare( 'CREATE TABLE %i (id INT PRIMARY KEY, value INT)', $table_name ) );
+		$option_name = 'sqlite_savepoint_write_test';
 		$wpdb->insert(
-			$table_name,
+			$wpdb->options,
 			array(
-				'id'    => 1,
-				'value' => 1,
+				'option_name'  => $option_name,
+				'option_value' => '1',
+				'autoload'     => 'no',
 			)
 		);
 
 		try {
 			$this->assertNotFalse( $wpdb->query( 'SAVEPOINT wpdb_update' ) );
 
-			$result  = $wpdb->update( $table_name, array( 'value' => 2 ), array( 'id' => 1 ) );
+			$result  = $wpdb->update( $wpdb->options, array( 'option_value' => '2' ), array( 'option_name' => $option_name ) );
 			$queries = array_column( $wpdb->get_driver()->get_last_sqlite_queries(), 'sql' );
 
 			$this->assertSame( 1, $result );
@@ -26,12 +26,17 @@ class WP_SQLite_Database_Integration_Savepoint_Test extends WP_UnitTestCase {
 			$this->assertSame( '', $wpdb->last_error );
 			$this->assertNotContains( 'BEGIN IMMEDIATE', $queries );
 			$this->assertNotFalse( $wpdb->query( 'RELEASE SAVEPOINT wpdb_update' ) );
-			$this->assertSame( '2', $wpdb->get_var( $wpdb->prepare( 'SELECT value FROM %i WHERE id = 1', $table_name ) ) );
+			$this->assertSame(
+				'2',
+				$wpdb->get_var(
+					$wpdb->prepare( 'SELECT option_value FROM %i WHERE option_name = %s', $wpdb->options, $option_name )
+				)
+			);
 		} finally {
 			if ( $wpdb->get_driver()->inTransaction() ) {
 				$wpdb->query( 'ROLLBACK' );
 			}
-			$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table_name ) );
+			$wpdb->delete( $wpdb->options, array( 'option_name' => $option_name ) );
 		}
 	}
 }


### PR DESCRIPTION
## What?

Align SQL savepoint handling with MySQL semantics.

A standalone `SAVEPOINT` in the default autocommit mode no longer opens an SQLite transaction. It is discarded immediately, so following writes use the normal `BEGIN IMMEDIATE` wrapper and commit independently.

Inside explicit transactions, track active savepoint names to emulate MySQL behavior for nested savepoints, reused and case-insensitive names, `ROLLBACK TO`, `RELEASE`, and missing-savepoint error 1305. Missing-savepoint errors leave the surrounding transaction active.

Add regression coverage across the MySQL-on-SQLite, concurrency, PDO API, and WordPress integration test suites.

## Why?

SQLite treats a standalone `SAVEPOINT` as opening a transaction, but MySQL does not. Passing it through to SQLite created a hidden transaction on PHP versions before 8.4. Subsequent writes then either attempted a nested `BEGIN IMMEDIATE` or bypassed the normal write-locking path, depending on how the transaction state was tracked.

The original Data Machine reproduction relied on SQLite-only behavior: issuing a bare `SAVEPOINT`, performing a write, and committing with `RELEASE SAVEPOINT`. Real MySQL and MariaDB discard the standalone savepoint, so the later release reports error 1305. That downstream issue is tracked in Extra-Chill/data-machine#3436.

> [!NOTE]
> Consumers that relied on a bare `SAVEPOINT` opening a transaction on SQLite must open an explicit transaction instead, matching MySQL behavior.

Fixes #495