### PR TITLE
Mark the plugin as compatible with WordPress 7.1

### DIFF
--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -6,6 +6,8 @@
  * Version: 3.0.0
  * Requires PHP: 7.2
  * Network: true
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Textdomain: sqlite-database-integration
  *
  * This feature plugin allows WordPress to use SQLite instead of MySQL as its database.

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -2,7 +2,7 @@
 
 Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgicak, bpayton, zaerl
 Requires at least: 6.4
-Tested up to:      7.0
+Tested up to:      7.1
 Requires PHP:      7.2
 Stable tag:        3.0.0
 License:           GPLv2 or later

--- a/wp-setup.sh
+++ b/wp-setup.sh
@@ -8,7 +8,7 @@
 
 set -e
 
-WP_VERSION="7.0.1"
+WP_VERSION="7.1"
 
 DIR="$(dirname "$0")"
 WP_DIR="$DIR/wordpress"


### PR DESCRIPTION
## Summary

This PR confirms that SQLite Database Integration is compatible with **WordPress 7.1**.

It:

- Runs the WordPress compatibility environment against version 7.1.
- Updates the plugin **Tested up to** value to 7.1.
- Declares the GPL license in the main plugin file for Plugin Check.

## Why

WordPress 7.1 has been released, and plugin authors are asked to verify compatibility before updating the directory metadata. The compatibility audit found no required runtime changes.