### PR TITLE
Release 3.0.1

### DIFF
--- a/packages/mysql-on-sqlite/src/version.php
+++ b/packages/mysql-on-sqlite/src/version.php
@@ -9,4 +9,4 @@ if ( defined( 'SQLITE_DRIVER_VERSION' ) ) {
  *
  * This constant needs to be updated on plugin release!
  */
-define( 'SQLITE_DRIVER_VERSION', '3.0.0' );
+define( 'SQLITE_DRIVER_VERSION', '3.0.1' );

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: SQLite Database Integration
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
- * Version: 3.0.0
+ * Version: 3.0.1
  * Requires PHP: 7.2
  * Network: true
  * License: GPL-2.0-or-later

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgic
 Requires at least: 6.4
 Tested up to:      7.1
 Requires PHP:      7.2
-Stable tag:        3.0.0
+Stable tag:        3.0.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              sqlite, database
@@ -65,6 +65,11 @@ Contributions are welcome through the [SQLite Database Integration repository on
 Yes. The plugin replaces the default MySQL-based database layer with an SQLite-backed implementation. WordPress continues to use the `wpdb` API, while queries are internally adapted to SQLite syntax and behavior.
 
 == Changelog ==
+
+= 3.0.1 =
+
+* Mark the plugin as compatible with WordPress 7.1 ([#497](https://github.com/WordPress/sqlite-database-integration/pull/497))
+* Fix fresh multisite database setup ([#492](https://github.com/WordPress/sqlite-database-integration/pull/492))
 
 = 3.0.0 =
 


### PR DESCRIPTION
## Release `3.0.1`

Version bump and changelog update for release `3.0.1`.

**Changelog draft:**
* Mark the plugin as compatible with WordPress 7.1 ([#497](https://github.com/WordPress/sqlite-database-integration/pull/497))
* Fix fresh multisite database setup ([#492](https://github.com/WordPress/sqlite-database-integration/pull/492))

**Full changelog:** https://github.com/WordPress/sqlite-database-integration/compare/v3.0.0...release/v3.0.1

## Next steps

1. **Review** the changes in this pull request.
2. **Push** any additional edits to this branch (`release/v3.0.1`).
3. **Merge** this pull request to complete the release.

Merging will automatically build the plugin ZIP, create a [GitHub release](https://github.com/WordPress/sqlite-database-integration/releases), and deploy to [WordPress.org](https://wordpress.org/plugins/sqlite-database-integration/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed fresh multisite database setup for improved reliability.
  - Added compatibility with WordPress 7.1.

- **Chores**
  - Updated the SQLite driver and integration plugin to version 3.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->