### PR TITLE
Preserve index prefix lengths and order in SHOW CREATE TABLE primary keys

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-mysql-on-sqlite.php
@@ -7320,21 +7320,24 @@ class WP_MySQL_On_SQLite extends PDO {
 		}
 
 		// 7. Generate CREATE TABLE statement constraints, collect indexes.
+		$format_index_column = function ( $column ) {
+			$definition = $this->quote_mysql_identifier( $column['COLUMN_NAME'] );
+			if ( null !== $column['SUB_PART'] ) {
+				$definition .= sprintf( '(%d)', $column['SUB_PART'] );
+			}
+			if ( 'D' === $column['COLLATION'] ) {
+				$definition .= ' DESC';
+			}
+			return $definition;
+		};
+
 		foreach ( $grouped_constraints as $constraint ) {
 			ksort( $constraint );
 			$info = $constraint[1];
 
 			if ( 'PRIMARY' === $info['INDEX_NAME'] ) {
 				$sql  = '  PRIMARY KEY (';
-				$sql .= implode(
-					', ',
-					array_map(
-						function ( $column ) {
-							return $this->quote_mysql_identifier( $column['COLUMN_NAME'] );
-						},
-						$constraint
-					)
-				);
+				$sql .= implode( ', ', array_map( $format_index_column, $constraint ) );
 				$sql .= ')';
 			} else {
 				$is_unique = '0' === $info['NON_UNIQUE'];
@@ -7347,22 +7350,7 @@ class WP_MySQL_On_SQLite extends PDO {
 				);
 				$sql .= $this->quote_mysql_identifier( $info['INDEX_NAME'] );
 				$sql .= ' (';
-				$sql .= implode(
-					', ',
-					array_map(
-						function ( $column ) {
-							$definition = $this->quote_mysql_identifier( $column['COLUMN_NAME'] );
-							if ( null !== $column['SUB_PART'] ) {
-								$definition .= sprintf( '(%d)', $column['SUB_PART'] );
-							}
-							if ( 'D' === $column['COLLATION'] ) {
-								$definition .= ' DESC';
-							}
-							return $definition;
-						},
-						$constraint
-					)
-				);
+				$sql .= implode( ', ', array_map( $format_index_column, $constraint ) );
 				$sql .= ')';
 			}
 

--- a/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Metadata_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_MySQL_On_SQLite_Metadata_Tests.php
@@ -762,6 +762,37 @@ class WP_MySQL_On_SQLite_Metadata_Tests extends TestCase {
 	}
 
 
+	public function testShowCreateTablePrimaryKeyWithIndexPrefix(): void {
+		$this->assertQuery(
+			'CREATE TABLE t (session_id MEDIUMTEXT NOT NULL, value INT, PRIMARY KEY (session_id(100)))'
+		);
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t' );
+		$this->assertStringContainsString(
+			'PRIMARY KEY (`session_id`(100))',
+			$result[0]->{'Create Table'}
+		);
+
+		// A composite primary key preserves the prefix only where it is defined.
+		$this->assertQuery(
+			'CREATE TABLE t2 (a VARCHAR(255) NOT NULL, b MEDIUMTEXT NOT NULL, PRIMARY KEY (a, b(50)))'
+		);
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t2' );
+		$this->assertStringContainsString(
+			'PRIMARY KEY (`a`, `b`(50))',
+			$result[0]->{'Create Table'}
+		);
+
+		// Descending key parts are preserved as well, as in MySQL 8.
+		$this->assertQuery(
+			'CREATE TABLE t3 (a INT NOT NULL, b VARCHAR(10) NOT NULL, PRIMARY KEY (a DESC, b))'
+		);
+		$result = $this->assertQuery( 'SHOW CREATE TABLE t3' );
+		$this->assertStringContainsString(
+			'PRIMARY KEY (`a` DESC, `b`)',
+			$result[0]->{'Create Table'}
+		);
+	}
+
 	public function testCreateTableSetAutoIncrement(): void {
 		$this->assertQuery(
 			'CREATE TABLE t (id INT AUTO_INCREMENT PRIMARY KEY, name TEXT) AUTO_INCREMENT=100'


### PR DESCRIPTION
## Summary

`SHOW CREATE TABLE` reconstructs the `PRIMARY KEY` clause from the information schema, but unlike the branch that handles all other indexes, it emitted only the quoted column names. Index prefix lengths (`SUB_PART`) and descending order (`COLLATION = 'D'`) were dropped, so a table created with `PRIMARY KEY (session_id(100))` on a `MEDIUMTEXT` column came back as `PRIMARY KEY (session_id)`.

The practical impact: exports built on top of `SHOW CREATE TABLE` (for example `wp sqlite export`, which WordPress Studio uses for its push feature) produce a dump that MySQL rejects with `ERROR 1170 (42000): BLOB/TEXT column used in key specification without a key length`. The prefix is recorded correctly in `_wp_sqlite_mysql_information_schema_statistics` (`SUB_PART = 100`); the bug was emission only. Discovered through Automattic/studio#4739.

Fixes #501

## Fix

The column formatting closure that already handled `SUB_PART` and `DESC` for regular keys is hoisted and shared by the `PRIMARY KEY` branch, so both paths emit identical column definitions.

## Testing

- New regression test: a `PRIMARY KEY (session_id(100))` on `MEDIUMTEXT` round-trips through `SHOW CREATE TABLE` with its prefix, a composite key `PRIMARY KEY (a, b(50))` keeps the prefix only where defined, and `PRIMARY KEY (a DESC, b)` keeps its descending key part. The test fails on the previous code.
- Verified against a real MySQL 8 server: its `SHOW CREATE TABLE` emits `PRIMARY KEY (`session_id`(100))` and `PRIMARY KEY (`a` DESC,`b`)` for the same tables, matching the fixed output; the previous output fails to import there with `ERROR 1170`, the fixed output imports cleanly.
- Full `mysql-on-sqlite` unit suite: 875 tests, 1428750 assertions, no failures (the same 17 skipped and 2 incomplete as on trunk, PHP 8.5).
- `composer run check-cs` is clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `SHOW CREATE TABLE` output to preserve primary-key index prefix lengths for single-column and composite keys.
  - Ensured descending key parts and column definitions are represented accurately in generated table-creation statements.
  - Improved consistency between primary-key and secondary-index formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
