### PR TITLE
Add randomized SQLite database storage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
 		],
 		"wp-test-php": [
 			"@wp-test-ensure-env @no_additional_args",
-			"rm -rf wordpress/src/wp-content/database/.ht.sqlite @no_additional_args",
+			"@wp-test-remove-database @no_additional_args",
 			"npm --prefix wordpress run test:php -- @additional_args"
 		],
 		"wp-test-sqlite-plugin-php": [
@@ -80,8 +80,11 @@
 			"npm --prefix wordpress run test:e2e -- @additional_args"
 		],
 		"wp-test-clean": [
-			"npm --prefix wordpress run env:clean",
-			"rm -rf wordpress/src/wp-content/database/.ht.sqlite"
+			"@wp-test-remove-database",
+			"npm --prefix wordpress run env:clean"
+		],
+		"wp-test-remove-database": [
+			"cd wordpress && node tools/local-env/scripts/docker.js run --rm --no-deps --entrypoint rm php -rf /var/www/src/wp-content/database"
 		]
 	}
 }

--- a/packages/plugin-sqlite-database-integration/constants.php
+++ b/packages/plugin-sqlite-database-integration/constants.php
@@ -37,15 +37,14 @@ if ( ! defined( 'FQDBDIR' ) ) {
 }
 
 /**
- * FQDB is a database file name. If DB_FILE is defined, it is used
- * as FQDB.
+ * FQDB is the absolute path to the SQLite database file.
+ *
+ * If DB_FILE is defined, FQDB is defined here using FQDBDIR. When SQLite is
+ * used without DB_FILE, managed storage defines FQDB after resolving the
+ * randomized database path.
  *
  * @deprecated 3.0.0 Define DB_DIR and DB_FILE instead of overriding FQDB.
  */
-if ( ! defined( 'FQDB' ) ) {
-	if ( defined( 'DB_FILE' ) ) {
-		define( 'FQDB', FQDBDIR . DB_FILE );
-	} else {
-		define( 'FQDB', FQDBDIR . '.ht.sqlite' );
-	}
+if ( ! defined( 'FQDB' ) && defined( 'DB_FILE' ) ) {
+	define( 'FQDB', FQDBDIR . DB_FILE );
 }

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -459,8 +459,6 @@ class WP_SQLite_DB extends wpdb {
 			return false;
 		}
 
-		$this->ensure_database_directory( FQDB );
-
 		try {
 			$options = array(
 				'sqlite_journal_mode' => defined( 'SQLITE_JOURNAL_MODE' ) ? SQLITE_JOURNAL_MODE : null,
@@ -774,54 +772,6 @@ class WP_SQLite_DB extends wpdb {
 
 		return $this->dbh->getAttribute( PDO::ATTR_SERVER_VERSION ); // phpcs:ignore WordPress.DB.RestrictedClasses.mysql__PDO
 	}
-
-	/**
-	 * Make sure the SQLite database directory exists and is writable.
-	 * Create .htaccess and index.php files to prevent direct access.
-	 *
-	 * @param string $database_path The path to the SQLite database file.
-	 */
-	private function ensure_database_directory( string $database_path ) {
-		$dir = dirname( $database_path );
-
-		// Set the umask to 0000 to apply permissions exactly as specified.
-		// A non-zero umask affects new file and directory permissions.
-		$umask = umask( 0 );
-
-		// Ensure database directory.
-		if ( ! is_dir( $dir ) ) {
-			if ( ! @mkdir( $dir, 0700, true ) ) {
-				wp_die( sprintf( 'Failed to create database directory: %s', $dir ), 'Error!' );
-			}
-		}
-		if ( ! is_writable( $dir ) ) {
-			wp_die( sprintf( 'Database directory is not writable: %s', $dir ), 'Error!' );
-		}
-
-		// Ensure .htaccess file to prevent direct access.
-		$path = $dir . DIRECTORY_SEPARATOR . '.htaccess';
-		if ( ! is_file( $path ) ) {
-			$result = file_put_contents( $path, 'DENY FROM ALL', LOCK_EX );
-			if ( false === $result ) {
-				wp_die( sprintf( 'Failed to create file: %s', $path ), 'Error!' );
-			}
-			chmod( $path, 0600 );
-		}
-
-		// Ensure index.php file to prevent direct access.
-		$path = $dir . DIRECTORY_SEPARATOR . 'index.php';
-		if ( ! is_file( $path ) ) {
-			$result = file_put_contents( $path, '<?php // Silence is gold. ?>', LOCK_EX );
-			if ( false === $result ) {
-				wp_die( sprintf( 'Failed to create file: %s', $path ), 'Error!' );
-			}
-			chmod( $path, 0600 );
-		}
-
-		// Restore the original umask value.
-		umask( $umask );
-	}
-
 
 	/**
 	 * Format MySQL-on-SQLite driver error message.

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-db.php
@@ -432,25 +432,6 @@ class WP_SQLite_DB extends wpdb {
 			$this->init_charset();
 		}
 
-		// Migrate the database file from a legacy path, if it exists.
-		if ( ! defined( 'DB_FILE' ) && ! file_exists( FQDB ) ) {
-			$old_db_path = FQDBDIR . '.ht.sqlite.php';
-
-			if ( file_exists( $old_db_path ) ) {
-				if ( ! rename( $old_db_path, FQDB ) ) {
-					wp_die( 'Failed to rename database file.', 'Error!' );
-				}
-
-				foreach ( array( '-wal', '-shm', '-journal' ) as $suffix ) {
-					if ( file_exists( $old_db_path . $suffix ) ) {
-						if ( ! rename( $old_db_path . $suffix, FQDB . $suffix ) ) {
-							wp_die( 'Failed to rename database file.', 'Error!' );
-						}
-					}
-				}
-			}
-		}
-
 		if ( null === $this->dbname || '' === $this->dbname ) {
 			$this->bail(
 				'The database name was not set. The SQLite driver requires a database name to be set to emulate MySQL information schema tables.',

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
@@ -91,7 +91,14 @@ class WP_SQLite_Storage {
 	private $storage_lock_connection;
 
 	/**
-	 * Time to wait for the SQLite storage lock, in milliseconds.
+	 * Connection holding the exclusive transaction on the WordPress SQLite database.
+	 *
+	 * @var PDO|null
+	 */
+	private $database_lock_connection;
+
+	/**
+	 * Time to wait for existing database connections, in milliseconds.
 	 *
 	 * @var int
 	 */
@@ -133,9 +140,16 @@ class WP_SQLite_Storage {
 		// Never resolve a database path while storage maintenance is in progress.
 		$this->wait_until_unlocked();
 
+		// Check if we're already holding a lock.
+		$was_locked = null !== $this->storage_lock_connection;
+
 		// Explicitly configured database path.
 		if ( null !== $this->database_path ) {
 			$this->ensure_database( $this->database_path );
+			if ( $was_locked ) {
+				// If the storage was locked, ensure the database is locked as well.
+				$this->lock();
+			}
 			return $this->database_path;
 		}
 
@@ -156,7 +170,6 @@ class WP_SQLite_Storage {
 
 		// Initialize or repair the managed storage under the storage lock.
 		// Preserve a lock already held by this instance for a larger operation.
-		$keep_lock = null !== $this->storage_lock_connection;
 		$this->lock();
 		try {
 			// Another process may have completed the initialization meanwhile.
@@ -170,9 +183,10 @@ class WP_SQLite_Storage {
 			}
 
 			$this->ensure_database( $database_path );
+			$this->lock();
 			return $database_path;
 		} finally {
-			if ( ! $keep_lock ) {
+			if ( ! $was_locked ) {
 				$this->unlock();
 			}
 		}
@@ -184,27 +198,29 @@ class WP_SQLite_Storage {
 	 * The locking mechanism does the following:
 	 *   - Waits for a lock held by another process, up to the database lock timeout.
 	 *   - Marks maintenance as active so new requests wait.
+	 *   - When a database exists, also acquires an exclusive database lock.
+	 *
+	 * Existing database connections must be closed first to avoid blocking the lock.
 	 *
 	 * The lock is released when unlock() is called or the process ends.
 	 *
 	 * @throws RuntimeException When the lock cannot be acquired.
 	 */
 	public function lock(): void {
-		// Reuse a lock already held by this instance.
-		if ( null !== $this->storage_lock_connection ) {
-			return;
-		}
+		$was_locked = null !== $this->storage_lock_connection;
 
 		// Serialize maintenance through the dedicated locking database.
-		try {
-			$this->ensure_database( $this->lock_path );
-			$connection = new PDO( 'sqlite:' . $this->lock_path );
-			$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
-			$connection->exec( 'PRAGMA busy_timeout = ' . $this->database_lock_timeout );
-			$connection->exec( 'BEGIN EXCLUSIVE' );
-			$this->storage_lock_connection = $connection;
-		} catch ( Throwable $exception ) {
-			throw new RuntimeException( 'Failed to acquire the SQLite storage lock.', 0, $exception );
+		if ( ! $was_locked ) {
+			try {
+				$this->ensure_database( $this->lock_path );
+				$connection = new PDO( 'sqlite:' . $this->lock_path );
+				$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+				$connection->exec( 'PRAGMA busy_timeout = ' . $this->database_lock_timeout );
+				$connection->exec( 'BEGIN EXCLUSIVE' );
+				$this->storage_lock_connection = $connection;
+			} catch ( Throwable $exception ) {
+				throw new RuntimeException( 'Failed to acquire the SQLite storage lock.', 0, $exception );
+			}
 		}
 
 		try {
@@ -215,8 +231,38 @@ class WP_SQLite_Storage {
 				}
 				@chmod( $this->maintenance_path, 0600 );
 			}
+
+			// Reuse a database lock already held by this instance.
+			if ( null !== $this->database_lock_connection ) {
+				return;
+			}
+
+			// Look for an existing database so that it can be locked as well.
+			$database_path = $this->database_path;
+			if ( null === $database_path ) {
+				$database_path = $this->read_recorded_database_path();
+
+				// The managed database may still be at a legacy path.
+				if ( null === $database_path || ! @is_file( $database_path ) ) {
+					$database_path = $this->database_root . self::DATABASE_FILENAME;
+				}
+				if ( ! @is_file( $database_path ) ) {
+					$database_path = $this->database_root . self::DATABASE_FILENAME . '.php';
+				}
+			}
+
+			// Lock the existing database when found.
+			if ( @is_file( $database_path ) ) {
+				try {
+					$this->database_lock_connection = $this->lock_database( $database_path );
+				} catch ( Throwable $exception ) {
+					throw new RuntimeException( 'Failed to lock the SQLite database.', 0, $exception );
+				}
+			}
 		} catch ( Throwable $exception ) {
-			$this->unlock();
+			if ( ! $was_locked ) {
+				$this->unlock();
+			}
 			throw $exception;
 		}
 	}
@@ -225,6 +271,7 @@ class WP_SQLite_Storage {
 	 * Unlock the storage.
 	 */
 	public function unlock(): void {
+		$this->database_lock_connection = null;
 		if ( null !== $this->storage_lock_connection ) {
 			// Remove the marker before releasing the lock that protects it.
 			@unlink( $this->maintenance_path );
@@ -383,5 +430,66 @@ class WP_SQLite_Storage {
 			throw new RuntimeException( 'Failed to create SQLite database protection file.' );
 		}
 		@chmod( $path, 0600 );
+	}
+
+	/**
+	 * Acquire an exclusive transaction on an SQLite database.
+	 *
+	 * @param string $database_path Absolute database path.
+	 * @return PDO Connection holding the transaction.
+	 */
+	private function lock_database( string $database_path ): PDO {
+		// Do not silently create an empty database if the expected file is missing.
+		$pdo_options = array();
+		if ( defined( 'Pdo\Sqlite::ATTR_OPEN_FLAGS' ) ) {
+			$pdo_options[ Pdo\Sqlite::ATTR_OPEN_FLAGS ] = Pdo\Sqlite::OPEN_READWRITE;
+		} elseif ( defined( 'PDO::SQLITE_ATTR_OPEN_FLAGS' ) ) {
+			$pdo_options[ PDO::SQLITE_ATTR_OPEN_FLAGS ] = PDO::SQLITE_OPEN_READWRITE;
+		}
+
+		$connection = null;
+		$deadline   = microtime( true ) + ( $this->database_lock_timeout / 1000 );
+		do {
+			if ( microtime( true ) >= $deadline ) {
+				throw new RuntimeException( 'Failed to acquire an exclusive SQLite database lock.' );
+			}
+
+			if ( null === $connection ) {
+				$connection = new PDO( 'sqlite:' . $database_path, null, null, $pdo_options );
+				$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+				$connection->exec( 'PRAGMA busy_timeout = ' . $this->database_lock_timeout );
+			}
+
+			try {
+				// Disable WAL so we can acquire a truly exclusive READ/WRITE lock.
+				$journal_mode = $connection->query( 'PRAGMA journal_mode = DELETE' )->fetchColumn();
+				if ( 'delete' === strtolower( (string) $journal_mode ) ) {
+					// Acquire exclusive lock.
+					$connection->exec( 'BEGIN EXCLUSIVE' );
+
+					// Another connection may have restored WAL before the transaction started.
+					// If that's the case, release the lock and retry in the next iteration.
+					$journal_mode = $connection->query( 'PRAGMA journal_mode' )->fetchColumn();
+					if ( 'delete' !== strtolower( (string) $journal_mode ) ) {
+						$connection->exec( 'ROLLBACK' );
+					} else {
+						// Connection lock successfully acquired.
+						return $connection;
+					}
+				}
+			} catch ( PDOException $exception ) {
+				$error_info    = $connection->errorInfo();
+				$sqlite_busy   = 5;
+				$database_busy = isset( $error_info[1] ) && ( (int) $error_info[1] & 0xff ) === $sqlite_busy;
+				if ( ! $database_busy ) {
+					throw $exception;
+				}
+
+				// Close the connection so any raw transaction is rolled back before retrying.
+				$connection = null;
+			}
+
+			usleep( 100000 ); // 100 milliseconds.
+		} while ( true );
 	}
 }

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
@@ -6,7 +6,7 @@
  * The storage handles the path of the SQLite database:
  *   - An explicit database path is used as is.
  *   - A managed database is stored under a randomized protected path.
- *   - A database in a legacy path stays in use.
+ *   - A database in a legacy path is migrated to the managed storage.
  *
  * The storage implements a locking mechanism for initialization and maintenance.
  * Locking uses a dedicated empty SQLite database and a maintenance file:
@@ -126,7 +126,7 @@ class WP_SQLite_Storage {
 	 * Initialize the SQLite database storage.
 	 *
 	 * Uses an explicit file path or ":memory:" as configured. Otherwise, initializes
-	 * managed storage with a randomized path. A legacy database stays at its fixed path.
+	 * managed storage with a randomized path and migrates legacy databases as needed.
 	 *
 	 * @return string Absolute path to the SQLite database file, or ":memory:".
 	 * @throws RuntimeException When the storage cannot be initialized.
@@ -159,15 +159,6 @@ class WP_SQLite_Storage {
 			return $database_path;
 		}
 
-		// Keep using a legacy database at its fixed path.
-		$legacy_path = $this->database_root . self::DATABASE_FILENAME;
-		if ( ! @is_file( $legacy_path ) ) {
-			$legacy_path = $this->database_root . self::DATABASE_FILENAME . '.php';
-		}
-		if ( @is_file( $legacy_path ) ) {
-			return $legacy_path;
-		}
-
 		// Initialize or repair the managed storage under the storage lock.
 		// Preserve a lock already held by this instance for a larger operation.
 		$this->lock();
@@ -182,8 +173,17 @@ class WP_SQLite_Storage {
 				$database_path = $this->publish_database_path();
 			}
 
-			$this->ensure_database( $database_path );
-			$this->lock();
+			// Migrate legacy database paths.
+			$legacy_path = $this->database_root . self::DATABASE_FILENAME;
+			if ( ! @is_file( $legacy_path ) ) {
+				$legacy_path = $this->database_root . self::DATABASE_FILENAME . '.php';
+			}
+			if ( @is_file( $legacy_path ) ) {
+				$this->move_legacy_database( $legacy_path, $database_path );
+			} else {
+				$this->ensure_database( $database_path );
+				$this->lock();
+			}
 			return $database_path;
 		} finally {
 			if ( ! $was_locked ) {
@@ -367,6 +367,35 @@ class WP_SQLite_Storage {
 		}
 
 		return $this->database_root . $directory_name . '/' . self::DATABASE_FILENAME;
+	}
+
+	/**
+	 * Move a legacy database into a managed path.
+	 *
+	 * @param string $legacy_path   Absolute path of the legacy database file.
+	 * @param string $database_path Absolute destination path.
+	 */
+	private function move_legacy_database( string $legacy_path, string $database_path ): void {
+		$this->ensure_protected_directory( dirname( $database_path ) );
+
+		/*
+		 * Close the connection just before moving the database. SQLite considers
+		 * renaming an open database undefined, and Windows generally prevents it.
+		 * We cannot fully prevent race conditions, but this makes them unlikely.
+		 *
+		 * See: https://www.sqlite.org/howtocorrupt.html#unlink
+		 */
+		$this->database_lock_connection = null;
+		if ( ! @rename( $legacy_path, $database_path ) ) {
+			throw new RuntimeException( 'Failed to move the SQLite database file.' );
+		}
+		@chmod( $database_path, 0600 );
+
+		try {
+			$this->database_lock_connection = $this->lock_database( $database_path );
+		} catch ( Throwable $exception ) {
+			throw new RuntimeException( 'Failed to lock the migrated SQLite database.', 0, $exception );
+		}
 	}
 
 	/**

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
@@ -1,0 +1,192 @@
+<?php
+
+/**
+ * Manages locking for the WordPress SQLite database storage.
+ *
+ * Locking uses a dedicated empty SQLite database and a maintenance file:
+ *   1. An exclusive lock is acquired on the locking database at ".ht.sqlite.lock".
+ *   2. A maintenance marker file is created at ".ht.sqlite.maintenance":
+ *       - When requests see the file, they use the locking database.
+ *       - Its absence provides a fast path for normal traffic.
+ *   3. When the lock is released, the maintenance file is automatically removed.
+ *
+ * Database locking uses a PDO SQLite connection:
+ * phpcs:disable WordPress.DB.RestrictedClasses.mysql__PDO
+ *
+ * Filesystem warnings are suppressed to avoid exposing database paths:
+ * phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+ */
+class WP_SQLite_Storage {
+	/**
+	 * Filename of the SQLite locking database.
+	 */
+	private const LOCK_FILENAME = '.ht.sqlite.lock';
+
+	/**
+	 * Filename of the marker that makes requests check the storage lock.
+	 */
+	private const MAINTENANCE_FILENAME = '.ht.sqlite.maintenance';
+
+	/**
+	 * Managed database root directory.
+	 *
+	 * @var string
+	 */
+	private $database_root;
+
+	/**
+	 * Absolute path of the SQLite locking database.
+	 *
+	 * @var string
+	 */
+	private $lock_path;
+
+	/**
+	 * Absolute path of the storage maintenance marker.
+	 *
+	 * @var string
+	 */
+	private $maintenance_path;
+
+	/**
+	 * Connection holding the exclusive transaction on the SQLite locking database.
+	 *
+	 * @var PDO|null
+	 */
+	private $storage_lock_connection;
+
+	/**
+	 * Time to wait for the SQLite storage lock, in milliseconds.
+	 *
+	 * @var int
+	 */
+	private $database_lock_timeout = 10000;
+
+	/**
+	 * Create a SQLite storage lock.
+	 *
+	 * @param string|null $database_root Managed database root. Defaults to FQDBDIR.
+	 */
+	public function __construct( ?string $database_root = null ) {
+		$this->database_root    = trailingslashit( $database_root ?? FQDBDIR );
+		$this->lock_path        = $this->database_root . self::LOCK_FILENAME;
+		$this->maintenance_path = $this->database_root . self::MAINTENANCE_FILENAME;
+	}
+
+	/**
+	 * Lock the database storage for maintenance.
+	 *
+	 * The locking mechanism does the following:
+	 *   - Waits for a lock held by another process, up to the database lock timeout.
+	 *   - Marks maintenance as active so new requests wait.
+	 *
+	 * The lock is released when unlock() is called or the process ends.
+	 *
+	 * @throws RuntimeException When the lock cannot be acquired.
+	 */
+	public function lock(): void {
+		// Reuse a lock already held by this instance.
+		if ( null !== $this->storage_lock_connection ) {
+			return;
+		}
+
+		// Serialize maintenance through the dedicated locking database.
+		try {
+			$this->ensure_database( $this->lock_path );
+			$connection = new PDO( 'sqlite:' . $this->lock_path );
+			$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+			$connection->exec( 'PRAGMA busy_timeout = ' . $this->database_lock_timeout );
+			$connection->exec( 'BEGIN EXCLUSIVE' );
+			$this->storage_lock_connection = $connection;
+		} catch ( Throwable $exception ) {
+			throw new RuntimeException( 'Failed to acquire the SQLite storage lock.', 0, $exception );
+		}
+
+		try {
+			// Ensure the maintenance marker exists so new requests use the locking database.
+			if ( ! @is_file( $this->maintenance_path ) ) {
+				if ( false === @file_put_contents( $this->maintenance_path, '' ) ) {
+					throw new RuntimeException( 'Failed to create the SQLite storage maintenance marker.' );
+				}
+				@chmod( $this->maintenance_path, 0600 );
+			}
+		} catch ( Throwable $exception ) {
+			$this->unlock();
+			throw $exception;
+		}
+	}
+
+	/**
+	 * Unlock the storage.
+	 */
+	public function unlock(): void {
+		if ( null !== $this->storage_lock_connection ) {
+			// Remove the marker before releasing the lock that protects it.
+			@unlink( $this->maintenance_path );
+			$this->storage_lock_connection = null;
+		}
+	}
+
+	/**
+	 * Ensure that a database and its protected directory exist.
+	 *
+	 * @param string $database_path Absolute database path.
+	 */
+	private function ensure_database( string $database_path ): void {
+		$this->ensure_protected_directory( dirname( $database_path ) );
+
+		if ( ! @is_file( $database_path ) ) {
+			// Create an empty database file with restricted permissions.
+			$database_handle = @fopen( $database_path, 'c' );
+			if ( false === $database_handle ) {
+				throw new RuntimeException( 'Failed to create the SQLite database file.' );
+			}
+			fclose( $database_handle );
+			@chmod( $database_path, 0600 );
+		}
+	}
+
+	/**
+	 * Ensure that a database directory exists and deny direct access.
+	 *
+	 * @param string $directory Absolute directory path.
+	 */
+	private function ensure_protected_directory( string $directory ): void {
+		if ( ! @is_dir( $directory ) ) {
+			// Create the path one directory at a time to avoid changing the process-wide umask.
+			$missing_directories = array();
+			for ( $path = untrailingslashit( $directory ); ! @is_dir( $path ); $path = dirname( $path ) ) {
+				$missing_directories[] = $path;
+				if ( dirname( $path ) === $path ) {
+					break;
+				}
+			}
+
+			foreach ( array_reverse( $missing_directories ) as $path ) {
+				if ( ! @mkdir( $path, 0700 ) && ! @is_dir( $path ) ) {
+					throw new RuntimeException( 'Failed to create the SQLite database directory.' );
+				}
+				@chmod( $path, 0700 );
+			}
+		}
+
+		$this->ensure_file( trailingslashit( $directory ) . '.htaccess', 'DENY FROM ALL' );
+		$this->ensure_file( trailingslashit( $directory ) . 'index.php', '<?php // Silence is golden.' );
+	}
+
+	/**
+	 * Create a protected file when it does not already exist.
+	 *
+	 * @param string $path     Absolute file path.
+	 * @param string $contents File contents.
+	 */
+	private function ensure_file( string $path, string $contents ): void {
+		if ( @is_file( $path ) ) {
+			return;
+		}
+		if ( false === @file_put_contents( $path, $contents ) ) {
+			throw new RuntimeException( 'Failed to create SQLite database protection file.' );
+		}
+		@chmod( $path, 0600 );
+	}
+}

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php
@@ -1,8 +1,14 @@
 <?php
 
 /**
- * Manages locking for the WordPress SQLite database storage.
+ * Manages the storage for the WordPress SQLite database.
  *
+ * The storage handles the path of the SQLite database:
+ *   - An explicit database path is used as is.
+ *   - A managed database is stored under a randomized protected path.
+ *   - A database in a legacy path stays in use.
+ *
+ * The storage implements a locking mechanism for initialization and maintenance.
  * Locking uses a dedicated empty SQLite database and a maintenance file:
  *   1. An exclusive lock is acquired on the locking database at ".ht.sqlite.lock".
  *   2. A maintenance marker file is created at ".ht.sqlite.maintenance":
@@ -18,6 +24,16 @@
  */
 class WP_SQLite_Storage {
 	/**
+	 * Filename of a script that returns the path to the database file.
+	 */
+	private const DATABASE_PATH_FILENAME = 'db-path.php';
+
+	/**
+	 * Filename of the database file.
+	 */
+	private const DATABASE_FILENAME = '.ht.sqlite';
+
+	/**
 	 * Filename of the SQLite locking database.
 	 */
 	private const LOCK_FILENAME = '.ht.sqlite.lock';
@@ -28,11 +44,30 @@ class WP_SQLite_Storage {
 	private const MAINTENANCE_FILENAME = '.ht.sqlite.maintenance';
 
 	/**
+	 * Number of bytes in a generated random token.
+	 */
+	private const TOKEN_BYTE_LENGTH = 16;
+
+	/**
 	 * Managed database root directory.
 	 *
 	 * @var string
 	 */
 	private $database_root;
+
+	/**
+	 * Explicitly configured database path, if any.
+	 *
+	 * @var string|null
+	 */
+	private $database_path;
+
+	/**
+	 * Absolute path of the database path file.
+	 *
+	 * @var string
+	 */
+	private $database_path_file;
 
 	/**
 	 * Absolute path of the SQLite locking database.
@@ -63,14 +98,84 @@ class WP_SQLite_Storage {
 	private $database_lock_timeout = 10000;
 
 	/**
-	 * Create a SQLite storage lock.
+	 * Create a SQLite storage manager.
 	 *
 	 * @param string|null $database_root Managed database root. Defaults to FQDBDIR.
+	 * @param string|null $database_path Explicit database path or ":memory:". Managed storage is used when null.
+	 * @throws RuntimeException When the database path is invalid.
 	 */
-	public function __construct( ?string $database_root = null ) {
-		$this->database_root    = trailingslashit( $database_root ?? FQDBDIR );
-		$this->lock_path        = $this->database_root . self::LOCK_FILENAME;
-		$this->maintenance_path = $this->database_root . self::MAINTENANCE_FILENAME;
+	public function __construct( ?string $database_root = null, ?string $database_path = null ) {
+		if ( '' === $database_path ) {
+			throw new RuntimeException( 'The SQLite database path is invalid.' );
+		}
+		$this->database_root      = trailingslashit( $database_root ?? FQDBDIR );
+		$this->database_path      = $database_path;
+		$this->database_path_file = $this->database_root . self::DATABASE_PATH_FILENAME;
+		$this->lock_path          = $this->database_root . self::LOCK_FILENAME;
+		$this->maintenance_path   = $this->database_root . self::MAINTENANCE_FILENAME;
+	}
+
+	/**
+	 * Initialize the SQLite database storage.
+	 *
+	 * Uses an explicit file path or ":memory:" as configured. Otherwise, initializes
+	 * managed storage with a randomized path. A legacy database stays at its fixed path.
+	 *
+	 * @return string Absolute path to the SQLite database file, or ":memory:".
+	 * @throws RuntimeException When the storage cannot be initialized.
+	 */
+	public function initialize(): string {
+		// An in-memory database has no files.
+		if ( ':memory:' === $this->database_path ) {
+			return $this->database_path;
+		}
+
+		// Never resolve a database path while storage maintenance is in progress.
+		$this->wait_until_unlocked();
+
+		// Explicitly configured database path.
+		if ( null !== $this->database_path ) {
+			$this->ensure_database( $this->database_path );
+			return $this->database_path;
+		}
+
+		// Initialized managed database path.
+		$database_path = $this->read_recorded_database_path();
+		if ( null !== $database_path && @is_file( $database_path ) ) {
+			return $database_path;
+		}
+
+		// Keep using a legacy database at its fixed path.
+		$legacy_path = $this->database_root . self::DATABASE_FILENAME;
+		if ( ! @is_file( $legacy_path ) ) {
+			$legacy_path = $this->database_root . self::DATABASE_FILENAME . '.php';
+		}
+		if ( @is_file( $legacy_path ) ) {
+			return $legacy_path;
+		}
+
+		// Initialize or repair the managed storage under the storage lock.
+		// Preserve a lock already held by this instance for a larger operation.
+		$keep_lock = null !== $this->storage_lock_connection;
+		$this->lock();
+		try {
+			// Another process may have completed the initialization meanwhile.
+			$database_path = $this->read_recorded_database_path();
+			if ( null !== $database_path && @is_file( $database_path ) ) {
+				return $database_path;
+			}
+
+			if ( null === $database_path ) {
+				$database_path = $this->publish_database_path();
+			}
+
+			$this->ensure_database( $database_path );
+			return $database_path;
+		} finally {
+			if ( ! $keep_lock ) {
+				$this->unlock();
+			}
+		}
 	}
 
 	/**
@@ -125,6 +230,96 @@ class WP_SQLite_Storage {
 			@unlink( $this->maintenance_path );
 			$this->storage_lock_connection = null;
 		}
+	}
+
+	/**
+	 * Wait until no maintenance process holds an active storage lock.
+	 */
+	private function wait_until_unlocked(): void {
+		// A lock held by this instance must not block its own work.
+		if ( null !== $this->storage_lock_connection || ! @is_file( $this->maintenance_path ) ) {
+			return;
+		}
+
+		try {
+			$this->ensure_database( $this->lock_path );
+			$connection = new PDO( 'sqlite:' . $this->lock_path );
+			$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+			$connection->exec( 'PRAGMA busy_timeout = ' . $this->database_lock_timeout );
+			$connection->exec( 'BEGIN EXCLUSIVE' );
+
+			// Clear a stale marker while the transaction prevents new maintenance from starting.
+			@unlink( $this->maintenance_path );
+		} catch ( Throwable $exception ) {
+			throw new RuntimeException( 'Failed to check the SQLite storage lock.', 0, $exception );
+		}
+	}
+
+	/**
+	 * Reads the recorded database path.
+	 *
+	 * @return string|null Absolute database path, or null when none is recorded.
+	 */
+	private function read_recorded_database_path(): ?string {
+		if ( ! @is_file( $this->database_path_file ) ) {
+			return null;
+		}
+
+		try {
+			// Use include so an unreadable file can be handled without terminating on PHP 7.
+			$database_path = @include $this->database_path_file;
+		} catch ( Throwable $exception ) {
+			throw new RuntimeException( 'Failed to read the SQLite database path file.', 0, $exception );
+		}
+
+		if ( false === $database_path ) {
+			throw new RuntimeException( 'Failed to read the SQLite database path file.' );
+		}
+
+		if ( ! is_string( $database_path ) || '' === $database_path ) {
+			throw new RuntimeException( 'The SQLite database path file is invalid.' );
+		}
+
+		return $database_path;
+	}
+
+	/**
+	 * Generate a randomized database path and publish it atomically.
+	 *
+	 * @return string Absolute path to the published SQLite database file.
+	 */
+	private function publish_database_path(): string {
+		$directory_name = '.ht.' . bin2hex( random_bytes( self::TOKEN_BYTE_LENGTH ) );
+		$temporary_path = $this->database_root . 'tmp.' . self::DATABASE_PATH_FILENAME;
+
+		$database_path_contents = sprintf(
+			"<?php\n\n/**\n * SQLite database path.\n *\n * IMPORTANT: Keep this path secret. When possible, point it outside the document root.\n */\nreturn __DIR__ . '/%s/%s';\n",
+			$directory_name,
+			self::DATABASE_FILENAME
+		);
+
+		// Publish the complete file atomically.
+		if ( false === @file_put_contents( $temporary_path, $database_path_contents ) ) {
+			throw new RuntimeException( 'Failed to write the SQLite database path file.' );
+		}
+		@chmod( $temporary_path, 0600 );
+
+		if ( ! @rename( $temporary_path, $this->database_path_file ) ) {
+			@unlink( $temporary_path );
+			throw new RuntimeException( 'Failed to publish the SQLite database path file.' );
+		}
+
+		// This runs before wp_opcache_invalidate() is available.
+		$opcache_restrict_api = ini_get( 'opcache.restrict_api' );
+		$script_filename      = isset( $_SERVER['SCRIPT_FILENAME'] ) ? realpath( $_SERVER['SCRIPT_FILENAME'] ) : false;
+		if (
+			function_exists( 'opcache_invalidate' )
+			&& ( ! $opcache_restrict_api || ( $script_filename && 0 === stripos( $script_filename, $opcache_restrict_api ) ) )
+		) {
+			opcache_invalidate( $this->database_path_file, true );
+		}
+
+		return $this->database_root . $directory_name . '/' . self::DATABASE_FILENAME;
 	}
 
 	/**

--- a/packages/plugin-sqlite-database-integration/wp-includes/sqlite/db.php
+++ b/packages/plugin-sqlite-database-integration/wp-includes/sqlite/db.php
@@ -44,6 +44,20 @@ if ( ! extension_loaded( 'pdo_sqlite' ) ) {
 	);
 }
 
+require_once __DIR__ . '/class-wp-sqlite-storage.php';
+
+try {
+	$database_storage = new WP_SQLite_Storage( FQDBDIR, defined( 'FQDB' ) ? FQDB : null );
+	$database_path    = $database_storage->initialize();
+} catch ( Throwable $exception ) {
+	error_log( 'SQLite database error: ' . (string) $exception );
+	wp_die( esc_html( $exception->getMessage() ), 'SQLite database error', array( 'response' => 503 ) );
+}
+
+if ( ! defined( 'FQDB' ) ) {
+	define( 'FQDB', $database_path );
+}
+
 require_once __DIR__ . '/../database/load.php';
 require_once __DIR__ . '/class-wp-sqlite-db.php';
 require_once __DIR__ . '/install-functions.php';

--- a/tests/phpunit/WP_SQLite_Storage_Test.php
+++ b/tests/phpunit/WP_SQLite_Storage_Test.php
@@ -1,0 +1,236 @@
+<?php
+
+require_once WP_CONTENT_DIR . '/plugins/sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php';
+
+class WP_SQLite_Storage_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var string[]
+	 */
+	private $temporary_directories = array();
+
+	public function tear_down() {
+		foreach ( $this->temporary_directories as $directory ) {
+			$this->remove_directory( $directory );
+		}
+
+		parent::tear_down();
+	}
+
+	public function test_locks_and_unlocks_the_storage() {
+		$database_root    = $this->create_temporary_directory();
+		$lock_path        = $database_root . '/.ht.sqlite.lock';
+		$maintenance_path = $database_root . '/.ht.sqlite.maintenance';
+		$storage          = new WP_SQLite_Storage( $database_root );
+
+		$storage->lock();
+
+		$this->assertFileExists( $lock_path );
+		$this->assertSame( 0600, fileperms( $lock_path ) & 0777 );
+		$this->assertFileExists( $maintenance_path );
+		$this->assertSame( 0600, fileperms( $maintenance_path ) & 0777 );
+
+		$storage->unlock();
+
+		// Keep the database as a stable target for future lock transactions.
+		$this->assertFileExists( $lock_path );
+		$this->assertFileDoesNotExist( $maintenance_path );
+	}
+
+	public function test_waits_for_another_process_to_unlock() {
+		$database_root = $this->create_temporary_directory();
+		$storage       = new WP_SQLite_Storage( $database_root );
+		$storage->lock();
+
+		list( $process, $pipes ) = $this->open_storage_process( $database_root, '$storage->lock(); echo "locked";' );
+		$this->assert_process_is_running( $process );
+
+		$storage->unlock();
+		$result = $this->close_process( $process, $pipes );
+
+		$this->assertSame( 0, $result['exit_code'] );
+		$this->assertSame( '', $result['error'] );
+		$this->assertSame( 'locked', $result['output'] );
+	}
+
+	public function test_does_not_acquire_a_busy_storage_lock() {
+		$database_root = $this->create_temporary_directory();
+		$owner         = new WP_SQLite_Storage( $database_root );
+		$storage       = new WP_SQLite_Storage( $database_root );
+		$owner->lock();
+		$this->set_storage_property( $storage, 'database_lock_timeout', 10 );
+
+		try {
+			$storage->lock();
+			$this->fail( 'A busy storage lock was acquired.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to acquire the SQLite storage lock.', $exception->getMessage() );
+		}
+
+		$this->assertFileExists( $database_root . '/.ht.sqlite.maintenance' );
+		$owner->unlock();
+	}
+
+	public function test_unlocks_the_storage_when_the_owner_dies() {
+		$database_root = $this->create_temporary_directory();
+
+		$result = $this->close_process(
+			...$this->open_storage_process(
+				$database_root,
+				'$storage->lock(); echo "locked"; fflush(STDOUT); set_time_limit(1); while (true) {}'
+			)
+		);
+
+		$this->assertSame( 'locked', $result['output'] );
+		$this->assertNotSame( 0, $result['exit_code'] );
+		$this->assertFileExists( $database_root . '/.ht.sqlite.maintenance' );
+
+		// The process releases its SQLite transaction automatically.
+		$storage = new WP_SQLite_Storage( $database_root );
+		$storage->lock();
+		$storage->unlock();
+		$this->assertFileDoesNotExist( $database_root . '/.ht.sqlite.maintenance' );
+	}
+
+	public function test_fails_when_the_lock_cannot_be_created() {
+		$database_root = $this->create_temporary_directory();
+		$storage       = new WP_SQLite_Storage( $database_root );
+		$storage->lock();
+		$storage->unlock();
+		$this->assertTrue( unlink( $database_root . '/.ht.sqlite.lock' ) );
+		$this->make_read_only( $database_root );
+
+		try {
+			$storage->lock();
+			$this->fail( 'A lock was created in a read-only directory.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to acquire the SQLite storage lock.', $exception->getMessage() );
+			$this->assertStringNotContainsString( $database_root, $exception->getMessage() );
+		} finally {
+			$this->assertTrue( chmod( $database_root, 0700 ) );
+		}
+	}
+
+	public function test_releases_the_lock_when_the_maintenance_marker_cannot_be_created() {
+		$database_root    = $this->create_temporary_directory();
+		$maintenance_path = $database_root . '/.ht.sqlite.maintenance';
+		$this->assertTrue( mkdir( $maintenance_path ) );
+		$storage = new WP_SQLite_Storage( $database_root );
+
+		try {
+			$storage->lock();
+			$this->fail( 'Storage was locked without a maintenance marker.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to create the SQLite storage maintenance marker.', $exception->getMessage() );
+		}
+
+		$this->assertTrue( rmdir( $maintenance_path ) );
+		$storage->lock();
+		$storage->unlock();
+	}
+
+	private function set_storage_property( $storage, $name, $value ) {
+		$set = Closure::bind(
+			function () use ( $name, $value ) {
+				$this->$name = $value;
+			},
+			$storage,
+			WP_SQLite_Storage::class
+		);
+
+		$set();
+	}
+
+	private function make_read_only( $directory ) {
+		$this->assertTrue( chmod( $directory, 0500 ) );
+		clearstatcache( true, $directory );
+		if ( is_writable( $directory ) ) {
+			$this->assertTrue( chmod( $directory, 0700 ) );
+			$this->markTestSkipped( 'Directory permissions are not enforced for the current user.' );
+		}
+	}
+
+	private function open_storage_process( $database_root, $script ) {
+		$prelude = sprintf(
+			'function trailingslashit($value) { return untrailingslashit($value) . "/"; } function untrailingslashit($value) { return rtrim($value, "/\\\\"); } require %s; $storage = new WP_SQLite_Storage(%s); ',
+			var_export( WP_CONTENT_DIR . '/plugins/sqlite-database-integration/wp-includes/sqlite/class-wp-sqlite-storage.php', true ),
+			var_export( $database_root, true )
+		);
+
+		return $this->open_process( $prelude . $script );
+	}
+
+	private function open_process( $script ) {
+		$command = escapeshellarg( PHP_BINARY ) . ' -d display_errors=stderr -r ' . escapeshellarg( $script );
+		$process = proc_open(
+			$command,
+			array(
+				array( 'pipe', 'r' ),
+				array( 'pipe', 'w' ),
+				array( 'pipe', 'w' ),
+			),
+			$pipes
+		);
+
+		$this->assertIsResource( $process );
+		fclose( $pipes[0] );
+
+		return array( $process, $pipes );
+	}
+
+	private function assert_process_is_running( $process ) {
+		usleep( 500000 );
+		$this->assertTrue( proc_get_status( $process )['running'] );
+	}
+
+	private function close_process( $process, $pipes ) {
+		$output = stream_get_contents( $pipes[1] );
+		fclose( $pipes[1] );
+		$error = stream_get_contents( $pipes[2] );
+		fclose( $pipes[2] );
+
+		return array(
+			'exit_code' => proc_close( $process ),
+			'output'    => $output,
+			'error'     => $error,
+		);
+	}
+
+	private function create_temporary_directory() {
+		$path = $this->create_temporary_directory_path();
+		$this->assertTrue( mkdir( $path, 0700 ) );
+
+		return $path;
+	}
+
+	private function create_temporary_directory_path() {
+		$path = tempnam( sys_get_temp_dir(), 'wp-sqlite-storage-' );
+		$this->assertNotFalse( $path );
+		$this->assertTrue( unlink( $path ) );
+		$this->temporary_directories[] = $path;
+
+		return $path;
+	}
+
+	private function remove_directory( $directory ) {
+		if ( ! is_dir( $directory ) ) {
+			return;
+		}
+
+		chmod( $directory, 0700 );
+		foreach ( scandir( $directory ) as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+
+			$path = $directory . DIRECTORY_SEPARATOR . $entry;
+			if ( is_dir( $path ) && ! is_link( $path ) ) {
+				$this->remove_directory( $path );
+			} else {
+				unlink( $path );
+			}
+		}
+
+		rmdir( $directory );
+	}
+}

--- a/tests/phpunit/WP_SQLite_Storage_Test.php
+++ b/tests/phpunit/WP_SQLite_Storage_Test.php
@@ -284,12 +284,12 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		}
 	}
 
-	public function test_keeps_using_the_current_legacy_database() {
-		$this->assert_legacy_database_is_kept( '.ht.sqlite' );
+	public function test_automatically_migrates_the_current_legacy_database() {
+		$this->assert_legacy_database_is_migrated( '.ht.sqlite' );
 	}
 
-	public function test_keeps_using_the_older_legacy_database() {
-		$this->assert_legacy_database_is_kept( '.ht.sqlite.php' );
+	public function test_automatically_migrates_the_older_legacy_database() {
+		$this->assert_legacy_database_is_migrated( '.ht.sqlite.php' );
 	}
 
 	public function test_prefers_the_current_legacy_database() {
@@ -299,9 +299,100 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		$this->create_sqlite_database( $current_path );
 		$this->create_sqlite_database( $older_path );
 
-		$this->assertSame( $current_path, $this->initialize_managed_storage( $database_root ) );
-		$this->assertFileExists( $current_path );
+		$database_path = $this->initialize_managed_storage( $database_root );
+
+		$this->assertFileDoesNotExist( $current_path );
 		$this->assertFileExists( $older_path );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $database_path ) );
+	}
+
+	public function test_waits_for_existing_wal_connections_before_migrating() {
+		$database_root = $this->create_temporary_directory();
+		$legacy_path   = $database_root . '/.ht.sqlite';
+		$this->create_wal_sqlite_database_copy( $legacy_path );
+
+		list( $process, $pipes ) = $this->open_database_connection_process( $legacy_path );
+		try {
+			$database_path = $this->initialize_managed_storage( $database_root );
+		} finally {
+			$result = $this->close_process( $process, $pipes );
+		}
+
+		$this->assertSame( 0, $result['exit_code'] );
+		$this->assertSame( '', $result['error'] );
+		$this->assertFileDoesNotExist( $legacy_path );
+		$this->assertFileDoesNotExist( $legacy_path . '-wal' );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $database_path ) );
+	}
+
+	public function test_keeps_the_legacy_database_when_migration_fails() {
+		$database_root = $this->create_temporary_directory();
+		$legacy_path   = $database_root . '/.ht.sqlite';
+		$database_path = $database_root . '/.ht.secret/.ht.sqlite';
+		$this->create_sqlite_database( $legacy_path );
+		$this->assertTrue( mkdir( $database_path, 0700, true ) );
+		file_put_contents( $database_root . '/db-path.php', "<?php\nreturn " . var_export( $database_path, true ) . ";\n" );
+
+		try {
+			$this->initialize_managed_storage( $database_root );
+			$this->fail( 'The database was migrated over a directory.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to move the SQLite database file.', $exception->getMessage() );
+			$this->assertStringNotContainsString( $database_path, $exception->getMessage() );
+		}
+
+		$this->assertFileExists( $legacy_path );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $legacy_path ) );
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+
+		// The migration succeeds once the obstacle is removed.
+		$this->assertTrue( rmdir( $database_path ) );
+		$this->assertSame( $database_path, $this->initialize_managed_storage( $database_root ) );
+		$this->assertFileDoesNotExist( $legacy_path );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $database_path ) );
+	}
+
+	public function test_does_not_migrate_an_invalid_legacy_database() {
+		$database_root = $this->create_temporary_directory();
+		$legacy_path   = $database_root . '/.ht.sqlite';
+		file_put_contents( $legacy_path, str_repeat( 'x', 4096 ) );
+
+		try {
+			$this->initialize_managed_storage( $database_root );
+			$this->fail( 'An invalid legacy database was migrated.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to lock the SQLite database.', $exception->getMessage() );
+		}
+
+		$this->assertSame( str_repeat( 'x', 4096 ), file_get_contents( $legacy_path ) );
+		$this->assertFileDoesNotExist( $database_root . '/db-path.php' );
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+	}
+
+	public function test_reports_when_the_migrated_database_cannot_be_locked() {
+		$database_root = $this->create_temporary_directory();
+		$legacy_path   = $database_root . '/.ht.sqlite';
+		$database_path = $database_root . '/managed/.ht.sqlite';
+		file_put_contents( $legacy_path, str_repeat( 'x', 4096 ) );
+		$storage = new WP_SQLite_Storage( $database_root );
+		$move    = Closure::bind(
+			function () use ( $legacy_path, $database_path ) {
+				$this->move_legacy_database( $legacy_path, $database_path );
+			},
+			$storage,
+			WP_SQLite_Storage::class
+		);
+
+		try {
+			$move();
+			$this->fail( 'An invalid migrated database was locked.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to lock the migrated SQLite database.', $exception->getMessage() );
+			$this->assertStringNotContainsString( $database_path, $exception->getMessage() );
+		}
+
+		$this->assertFileDoesNotExist( $legacy_path );
+		$this->assertSame( str_repeat( 'x', 4096 ), file_get_contents( $database_path ) );
 	}
 
 	public function test_locks_and_unlocks_the_storage() {
@@ -574,14 +665,21 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		$storage->unlock();
 	}
 
-	private function assert_legacy_database_is_kept( $filename ) {
+	private function assert_legacy_database_is_migrated( $filename ) {
 		$database_root = $this->create_temporary_directory();
 		$legacy_path   = $database_root . '/' . $filename;
-		$this->create_sqlite_database( $legacy_path );
+		$this->create_wal_sqlite_database_copy( $legacy_path );
 
-		$this->assertSame( $legacy_path, $this->initialize_managed_storage( $database_root ) );
-		$this->assertSame( 'preserved', $this->read_sqlite_value( $legacy_path ) );
-		$this->assertFileDoesNotExist( $database_root . '/db-path.php' );
+		$database_path        = $this->initialize_managed_storage( $database_root );
+		$stored_database_path = require $database_root . '/db-path.php';
+
+		$this->assertSame( $database_path, $stored_database_path );
+		$this->assertSame( 0600, fileperms( $database_path ) & 0777 );
+		$this->assertFileDoesNotExist( $legacy_path );
+		$this->assertFileDoesNotExist( $legacy_path . '-wal' );
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $database_path ) );
+		$this->assert_protected_directory( dirname( $database_path ) );
 	}
 
 	private function assert_creates_no_files( $callback ) {

--- a/tests/phpunit/WP_SQLite_Storage_Test.php
+++ b/tests/phpunit/WP_SQLite_Storage_Test.php
@@ -134,9 +134,23 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 
 		$this->assertFileExists( $database_path );
 		$this->assertFileExists( $database_root . '/.ht.sqlite.maintenance' );
+		$script = sprintf(
+			'$connection = new PDO(%s); $connection->exec("PRAGMA busy_timeout = 5000"); $connection->exec("BEGIN EXCLUSIVE"); echo "locked";',
+			var_export( 'sqlite:' . $database_path, true )
+		);
 
-		$storage->unlock();
+		list( $process, $pipes ) = $this->open_process( $script );
 
+		try {
+			$this->assert_process_is_running( $process );
+		} finally {
+			$storage->unlock();
+			$result = $this->close_process( $process, $pipes );
+		}
+
+		$this->assertSame( 0, $result['exit_code'] );
+		$this->assertSame( '', $result['error'] );
+		$this->assertSame( 'locked', $result['output'] );
 		$this->assertSame( $database_path, $this->initialize_managed_storage( $database_root ) );
 	}
 
@@ -427,6 +441,29 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		$storage->unlock();
 	}
 
+	public function test_blocks_database_access_while_locked() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/database.sqlite';
+		$connection    = $this->create_sqlite_database( $database_path );
+		$this->assertSame( 'wal', $connection->query( 'PRAGMA journal_mode = WAL' )->fetchColumn() );
+		$connection = null;
+
+		$storage = new WP_SQLite_Storage( $database_root, $database_path );
+
+		$storage->lock();
+
+		try {
+			$this->read_sqlite_value( $database_path );
+			$this->fail( 'The database was readable while the storage was locked.' );
+		} catch ( PDOException $exception ) {
+			$this->assertStringContainsString( 'database is locked', $exception->getMessage() );
+		}
+
+		$storage->unlock();
+
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $database_path ) );
+	}
+
 	public function test_ignores_a_legacy_database_for_an_explicit_path() {
 		$database_root = $this->create_temporary_directory();
 		$database_path = $database_root . '/database.sqlite';
@@ -441,6 +478,100 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		$this->assertSame( $database_path, $storage->initialize() );
 		$this->assertSame( 0, filesize( $database_path ) );
 		$this->assertSame( str_repeat( 'x', 4096 ), file_get_contents( $legacy_path ) );
+	}
+
+	public function test_waits_for_an_active_wal_connection() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/database.sqlite';
+		$this->create_wal_sqlite_database_copy( $database_path );
+		$storage = new WP_SQLite_Storage( $database_root, $database_path );
+
+		list( $process, $pipes ) = $this->open_database_connection_process( $database_path );
+		$started                 = microtime( true );
+		try {
+			$storage->lock();
+		} finally {
+			$elapsed = microtime( true ) - $started;
+			$result  = $this->close_process( $process, $pipes );
+		}
+		$storage->unlock();
+
+		$this->assertSame( 0, $result['exit_code'] );
+		$this->assertSame( '', $result['error'] );
+		$this->assertGreaterThan( 0.2, $elapsed );
+		$this->assertFileDoesNotExist( $database_path . '-wal' );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $database_path ) );
+	}
+
+	public function test_does_not_lock_an_invalid_database() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/database.sqlite';
+		file_put_contents( $database_path, str_repeat( 'x', 4096 ) );
+
+		try {
+			$storage = new WP_SQLite_Storage( $database_root, $database_path );
+			$storage->lock();
+			$this->fail( 'An invalid database was locked.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to lock the SQLite database.', $exception->getMessage() );
+			$this->assertStringNotContainsString( $database_root, $exception->getMessage() );
+		}
+
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+		$this->assertFileDoesNotExist( $database_root . '/.ht.sqlite.maintenance' );
+	}
+
+	public function test_does_not_create_a_missing_database() {
+		if ( ! defined( 'PDO::SQLITE_ATTR_OPEN_FLAGS' ) && ! defined( 'Pdo\Sqlite::ATTR_OPEN_FLAGS' ) ) {
+			$this->markTestSkipped( 'SQLite open flags require PHP 7.3.' );
+		}
+
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/missing.sqlite';
+		$storage       = new WP_SQLite_Storage( $database_root, $database_path );
+		$lock_database = Closure::bind(
+			function () use ( $database_path ) {
+				return $this->lock_database( $database_path );
+			},
+			$storage,
+			WP_SQLite_Storage::class
+		);
+
+		try {
+			$lock_database();
+			$this->fail( 'A missing database was created.' );
+		} catch ( PDOException $exception ) {
+			$this->assertStringNotContainsString( $database_path, $exception->getMessage() );
+		}
+
+		$this->assertFileDoesNotExist( $database_path );
+	}
+
+	public function test_does_not_lock_a_busy_database() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/database.sqlite';
+		$connection    = $this->create_sqlite_database( $database_path );
+		$connection->beginTransaction();
+		$connection->exec( "UPDATE storage_test SET value = 'pending'" );
+		$storage = new WP_SQLite_Storage( $database_root, $database_path );
+		$this->set_storage_property( $storage, 'database_lock_timeout', 10 );
+
+		try {
+			$storage->lock();
+			$this->fail( 'A busy database was locked.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to lock the SQLite database.', $exception->getMessage() );
+		} finally {
+			$connection->rollBack();
+		}
+
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+		$this->assertFileDoesNotExist( $database_root . '/.ht.sqlite.maintenance' );
+
+		// The storage can be locked once the database is no longer busy.
+		$storage->lock();
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+		$storage->unlock();
 	}
 
 	private function assert_legacy_database_is_kept( $filename ) {
@@ -514,6 +645,18 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		return $this->open_process( $prelude . $script );
 	}
 
+	private function open_database_connection_process( $database_path ) {
+		$script = sprintf(
+			'$connection = new PDO(%s); $connection->query("SELECT value FROM storage_test")->fetchColumn(); fwrite(STDOUT, "ready\n"); fflush(STDOUT); usleep(250000);',
+			var_export( 'sqlite:' . $database_path, true )
+		);
+
+		list( $process, $pipes ) = $this->open_process( $script );
+		$this->assertSame( "ready\n", fgets( $pipes[1] ) );
+
+		return array( $process, $pipes );
+	}
+
 	private function open_process( $script ) {
 		$command = escapeshellarg( PHP_BINARY ) . ' -d display_errors=stderr -r ' . escapeshellarg( $script );
 		$process = proc_open(
@@ -557,6 +700,22 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		$connection->exec( "INSERT INTO storage_test VALUES ('preserved')" );
 
 		return $connection;
+	}
+
+	private function create_wal_sqlite_database_copy( $database_path ) {
+		$source_path = $this->create_temporary_directory() . '/source.sqlite';
+
+		$connection = new PDO( 'sqlite:' . $source_path );
+		$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+		$this->assertSame( 'wal', $connection->query( 'PRAGMA journal_mode = WAL' )->fetchColumn() );
+		$connection->exec( 'PRAGMA wal_autocheckpoint = 0' );
+		$connection->exec( 'CREATE TABLE storage_test (value TEXT NOT NULL)' );
+		$connection->exec( "INSERT INTO storage_test VALUES ('preserved')" );
+
+		// Copy the WAL while the source stays open, as closing it would checkpoint.
+		$this->assertTrue( copy( $source_path, $database_path ) );
+		$this->assertTrue( copy( $source_path . '-wal', $database_path . '-wal' ) );
+		$connection = null;
 	}
 
 	private function read_sqlite_value( $database_path ) {

--- a/tests/phpunit/WP_SQLite_Storage_Test.php
+++ b/tests/phpunit/WP_SQLite_Storage_Test.php
@@ -17,6 +17,279 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		parent::tear_down();
 	}
 
+	public function test_creates_randomized_database_storage() {
+		$storage_root  = $this->create_temporary_directory_path();
+		$database_root = $storage_root . '/nested/database';
+		$umask         = umask( 0777 );
+
+		try {
+			$database_path = $this->initialize_managed_storage( $database_root );
+		} finally {
+			umask( $umask );
+		}
+
+		$database_path_file = $database_root . '/db-path.php';
+		ob_start();
+		$stored_database_path = require $database_path_file;
+		$database_path_output = ob_get_clean();
+
+		$this->assertSame( $database_path, $stored_database_path );
+		$this->assertSame( '', $database_path_output );
+		$this->assertSame( 1, preg_match( '/\A\.ht\.[0-9a-f]{32}\z/', basename( dirname( $stored_database_path ) ) ) );
+		$this->assertFileExists( $database_path );
+		$this->assertSame( 0, filesize( $database_path ) );
+		$this->assertSame( 0600, fileperms( $database_path ) & 0777 );
+		$this->assertSame( 0600, fileperms( $database_path_file ) & 0777 );
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+		$this->assertFileDoesNotExist( $database_root . '/.ht.sqlite.maintenance' );
+		$this->assertStringContainsString(
+			'IMPORTANT: Keep this path secret. When possible, point it outside the document root.',
+			file_get_contents( $database_path_file )
+		);
+		$this->assertSame( 0700, fileperms( $storage_root ) & 0777 );
+		$this->assertSame( 0700, fileperms( $storage_root . '/nested' ) & 0777 );
+		$this->assert_protected_directory( $database_root );
+		$this->assert_protected_directory( dirname( $database_path ) );
+	}
+
+	public function test_reuses_initialized_storage_without_repairing_protection_files() {
+		$database_root = $this->create_temporary_directory_path();
+		$first_path    = $this->initialize_managed_storage( $database_root );
+		$this->assertTrue( unlink( $database_root . '/.htaccess' ) );
+		$this->assertTrue( unlink( dirname( $first_path ) . '/index.php' ) );
+
+		$second_path = $this->initialize_managed_storage( $database_root );
+
+		$this->assertSame( $first_path, $second_path );
+		$this->assertFileDoesNotExist( $database_root . '/.htaccess' );
+		$this->assertFileDoesNotExist( dirname( $second_path ) . '/index.php' );
+	}
+
+	public function test_reuses_initialized_storage_with_read_only_database_root() {
+		$database_root = $this->create_temporary_directory_path();
+		$database_path = $this->initialize_managed_storage( $database_root );
+		$this->assertTrue( chmod( $database_root, 0500 ) );
+
+		try {
+			$this->assertSame( $database_path, $this->initialize_managed_storage( $database_root ) );
+		} finally {
+			$this->assertTrue( chmod( $database_root, 0700 ) );
+		}
+	}
+
+	public function test_skips_the_inactive_locking_database() {
+		$database_root = $this->create_temporary_directory_path();
+		$database_path = $this->initialize_managed_storage( $database_root );
+		// Opening this invalid database would make initialization fail.
+		file_put_contents( $database_root . '/.ht.sqlite.lock', str_repeat( 'x', 4096 ) );
+
+		$this->assertSame( $database_path, $this->initialize_managed_storage( $database_root ) );
+	}
+
+	public function test_initializes_one_database_for_concurrent_requests() {
+		$database_root = $this->create_temporary_directory_path();
+		$processes     = array();
+		for ( $i = 0; $i < 3; $i++ ) {
+			$processes[] = $this->open_storage_process( $database_root, 'echo $storage->initialize();' );
+		}
+
+		$database_paths = array();
+		foreach ( $processes as $process ) {
+			$result = $this->close_process( ...$process );
+			$this->assertSame( 0, $result['exit_code'] );
+			$this->assertSame( '', $result['error'] );
+			$database_paths[] = $result['output'];
+		}
+
+		$this->assertCount( 1, array_unique( $database_paths ) );
+		$this->assertSame( $database_paths[0], require $database_root . '/db-path.php' );
+		$this->assertFileExists( $database_paths[0] );
+		$this->assertCount( 1, glob( $database_root . '/.ht.*', GLOB_ONLYDIR ) );
+	}
+
+	public function test_waits_for_storage_maintenance_before_initializing() {
+		$database_root = $this->create_temporary_directory_path();
+		$database_path = $this->initialize_managed_storage( $database_root );
+		$storage       = new WP_SQLite_Storage( $database_root );
+		$storage->lock();
+
+		list( $process, $pipes ) = $this->open_storage_process( $database_root, 'echo $storage->initialize();' );
+		$this->assert_process_is_running( $process );
+
+		$storage->unlock();
+		$result = $this->close_process( $process, $pipes );
+
+		$this->assertSame( 0, $result['exit_code'] );
+		$this->assertSame( '', $result['error'] );
+		$this->assertSame( $database_path, $result['output'] );
+	}
+
+	public function test_initializes_the_storage_while_holding_the_lock() {
+		$database_root = $this->create_temporary_directory_path();
+		$storage       = new WP_SQLite_Storage( $database_root );
+		$storage->lock();
+
+		// The lock held by this instance must not block its own initialization.
+		$database_path = $storage->initialize();
+
+		$this->assertFileExists( $database_path );
+		$this->assertFileExists( $database_root . '/.ht.sqlite.maintenance' );
+
+		$storage->unlock();
+
+		$this->assertSame( $database_path, $this->initialize_managed_storage( $database_root ) );
+	}
+
+	public function test_follows_a_moved_database_directory() {
+		$original_root = $this->create_temporary_directory_path();
+		$moved_root    = $this->create_temporary_directory_path();
+		$original_path = $this->initialize_managed_storage( $original_root );
+		$this->assertTrue( rename( $original_root, $moved_root ) );
+
+		$moved_path = $this->initialize_managed_storage( $moved_root );
+
+		$this->assertSame( $moved_root . substr( $original_path, strlen( $original_root ) ), $moved_path );
+		$this->assertFileExists( $moved_path );
+		$this->assertCount( 1, glob( $moved_root . '/.ht.*', GLOB_ONLYDIR ) );
+	}
+
+	public function test_recovers_an_interrupted_database_path_write() {
+		$database_root = $this->create_temporary_directory();
+		file_put_contents( $database_root . '/tmp.db-path.php', 'interrupted write' );
+
+		$database_path = $this->initialize_managed_storage( $database_root );
+
+		$this->assertFileExists( $database_path );
+		$this->assertFileExists( $database_root . '/db-path.php' );
+		$this->assertFileDoesNotExist( $database_root . '/tmp.db-path.php' );
+	}
+
+	public function test_rejects_a_database_path_file_that_does_not_return_a_path() {
+		$database_root = $this->create_temporary_directory();
+		file_put_contents( $database_root . '/db-path.php', "<?php\nreturn array();\n" );
+
+		try {
+			$this->initialize_managed_storage( $database_root );
+			$this->fail( 'An invalid database path file was accepted.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertStringContainsString( 'database path file is invalid', $exception->getMessage() );
+			$this->assertStringNotContainsString( $database_root, $exception->getMessage() );
+		}
+	}
+
+	public function test_handles_a_database_path_file_that_cannot_be_loaded() {
+		$database_root = $this->create_temporary_directory();
+		file_put_contents( $database_root . '/db-path.php', "<?php\nreturn (;\n" );
+
+		try {
+			$this->initialize_managed_storage( $database_root );
+			$this->fail( 'An unreadable database path file was loaded.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to read the SQLite database path file.', $exception->getMessage() );
+			$this->assertStringNotContainsString( $database_root, $exception->getMessage() );
+		}
+	}
+
+	public function test_recovers_a_missing_database_referenced_by_the_path_file() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/.ht.0123456789abcdef0123456789abcdef/.ht.sqlite';
+		file_put_contents(
+			$database_root . '/db-path.php',
+			"<?php\nreturn __DIR__ . '/.ht.0123456789abcdef0123456789abcdef/.ht.sqlite';\n"
+		);
+
+		$this->assertSame( $database_path, $this->initialize_managed_storage( $database_root ) );
+		$this->assertFileExists( $database_path );
+		$this->assertSame( 0600, fileperms( $database_path ) & 0777 );
+		$this->assert_protected_directory( $database_root );
+		$this->assert_protected_directory( dirname( $database_path ) );
+	}
+
+	public function test_initializes_an_explicit_database_file() {
+		$database_root = $this->create_temporary_directory_path();
+		$database_path = $database_root . '/custom/database.sqlite';
+		$storage       = new WP_SQLite_Storage( $database_root, $database_path );
+
+		$this->assertSame( $database_path, $storage->initialize() );
+		$this->assertFileExists( $database_path );
+		$this->assertSame( 0, filesize( $database_path ) );
+		$this->assertSame( 0600, fileperms( $database_path ) & 0777 );
+		$this->assertFileDoesNotExist( $database_root . '/db-path.php' );
+		$this->assertFileDoesNotExist( $database_root . '/.ht.sqlite.lock' );
+		$this->assert_protected_directory( dirname( $database_path ) );
+	}
+
+	public function test_initializes_an_in_memory_database_without_creating_files() {
+		$this->assert_creates_no_files(
+			function () {
+				$storage = new WP_SQLite_Storage( $this->create_temporary_directory_path(), ':memory:' );
+				$this->assertSame( ':memory:', $storage->initialize() );
+			}
+		);
+	}
+
+	public function test_rejects_an_empty_database_path_without_creating_files() {
+		$this->assert_creates_no_files(
+			function () {
+				try {
+					new WP_SQLite_Storage( $this->create_temporary_directory_path(), '' );
+					$this->fail( 'An empty database path was accepted.' );
+				} catch ( RuntimeException $exception ) {
+					$this->assertSame( 'The SQLite database path is invalid.', $exception->getMessage() );
+				}
+			}
+		);
+	}
+
+	public function test_preserves_an_existing_explicit_database_file() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/custom.sqlite';
+		$this->create_sqlite_database( $database_path );
+		chmod( $database_path, 0640 );
+		$storage = new WP_SQLite_Storage( $database_root, $database_path );
+
+		$this->assertSame( $database_path, $storage->initialize() );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $database_path ) );
+		$this->assertSame( 0640, fileperms( $database_path ) & 0777 );
+		$this->assert_protected_directory( $database_root );
+	}
+
+	public function test_does_not_expose_the_database_path_when_initialization_fails() {
+		$database_root = $this->create_temporary_directory();
+		$blocking_path = $database_root . '/blocking-file';
+		$database_path = $blocking_path . '/.ht.secret/.ht.sqlite';
+		file_put_contents( $blocking_path, '' );
+
+		try {
+			$storage = new WP_SQLite_Storage( $database_root, $database_path );
+			$storage->initialize();
+			$this->fail( 'An inaccessible database path was initialized.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to create the SQLite database directory.', $exception->getMessage() );
+			$this->assertStringNotContainsString( $database_path, $exception->getMessage() );
+		}
+	}
+
+	public function test_keeps_using_the_current_legacy_database() {
+		$this->assert_legacy_database_is_kept( '.ht.sqlite' );
+	}
+
+	public function test_keeps_using_the_older_legacy_database() {
+		$this->assert_legacy_database_is_kept( '.ht.sqlite.php' );
+	}
+
+	public function test_prefers_the_current_legacy_database() {
+		$database_root = $this->create_temporary_directory();
+		$current_path  = $database_root . '/.ht.sqlite';
+		$older_path    = $database_root . '/.ht.sqlite.php';
+		$this->create_sqlite_database( $current_path );
+		$this->create_sqlite_database( $older_path );
+
+		$this->assertSame( $current_path, $this->initialize_managed_storage( $database_root ) );
+		$this->assertFileExists( $current_path );
+		$this->assertFileExists( $older_path );
+	}
+
 	public function test_locks_and_unlocks_the_storage() {
 		$database_root    = $this->create_temporary_directory();
 		$lock_path        = $database_root . '/.ht.sqlite.lock';
@@ -67,6 +340,14 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 			$this->assertSame( 'Failed to acquire the SQLite storage lock.', $exception->getMessage() );
 		}
 
+		// Requests stop waiting for maintenance after the same timeout.
+		try {
+			$storage->initialize();
+			$this->fail( 'Storage was initialized during maintenance.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Failed to check the SQLite storage lock.', $exception->getMessage() );
+		}
+
 		$this->assertFileExists( $database_root . '/.ht.sqlite.maintenance' );
 		$owner->unlock();
 	}
@@ -85,18 +366,35 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		$this->assertNotSame( 0, $result['exit_code'] );
 		$this->assertFileExists( $database_root . '/.ht.sqlite.maintenance' );
 
-		// The process releases its SQLite transaction automatically.
+		// The process released its SQLite transaction automatically. The next
+		// request can remove its stale marker and initialize the storage.
 		$storage = new WP_SQLite_Storage( $database_root );
-		$storage->lock();
-		$storage->unlock();
+		$this->assertFileExists( $storage->initialize() );
 		$this->assertFileDoesNotExist( $database_root . '/.ht.sqlite.maintenance' );
+	}
+
+	public function test_clears_a_stale_marker_without_a_locking_database() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $this->initialize_managed_storage( $database_root );
+		$this->assertTrue( unlink( $database_root . '/.ht.sqlite.lock' ) );
+		file_put_contents( $database_root . '/.ht.sqlite.maintenance', '' );
+		$umask = umask( 0000 );
+
+		try {
+			$this->assertSame( $database_path, $this->initialize_managed_storage( $database_root ) );
+		} finally {
+			umask( $umask );
+		}
+
+		$this->assertFileDoesNotExist( $database_root . '/.ht.sqlite.maintenance' );
+		$this->assertFileExists( $database_root . '/.ht.sqlite.lock' );
+		$this->assertSame( 0600, fileperms( $database_root . '/.ht.sqlite.lock' ) & 0777 );
 	}
 
 	public function test_fails_when_the_lock_cannot_be_created() {
 		$database_root = $this->create_temporary_directory();
 		$storage       = new WP_SQLite_Storage( $database_root );
-		$storage->lock();
-		$storage->unlock();
+		$storage->initialize();
 		$this->assertTrue( unlink( $database_root . '/.ht.sqlite.lock' ) );
 		$this->make_read_only( $database_root );
 
@@ -127,6 +425,62 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 		$this->assertTrue( rmdir( $maintenance_path ) );
 		$storage->lock();
 		$storage->unlock();
+	}
+
+	public function test_ignores_a_legacy_database_for_an_explicit_path() {
+		$database_root = $this->create_temporary_directory();
+		$database_path = $database_root . '/database.sqlite';
+		$legacy_path   = $database_root . '/.ht.sqlite';
+		file_put_contents( $legacy_path, str_repeat( 'x', 4096 ) );
+		$storage = new WP_SQLite_Storage( $database_root, $database_path );
+
+		$storage->lock();
+		$storage->unlock();
+		$this->assertFileDoesNotExist( $database_path );
+
+		$this->assertSame( $database_path, $storage->initialize() );
+		$this->assertSame( 0, filesize( $database_path ) );
+		$this->assertSame( str_repeat( 'x', 4096 ), file_get_contents( $legacy_path ) );
+	}
+
+	private function assert_legacy_database_is_kept( $filename ) {
+		$database_root = $this->create_temporary_directory();
+		$legacy_path   = $database_root . '/' . $filename;
+		$this->create_sqlite_database( $legacy_path );
+
+		$this->assertSame( $legacy_path, $this->initialize_managed_storage( $database_root ) );
+		$this->assertSame( 'preserved', $this->read_sqlite_value( $legacy_path ) );
+		$this->assertFileDoesNotExist( $database_root . '/db-path.php' );
+	}
+
+	private function assert_creates_no_files( $callback ) {
+		$working_directory          = $this->create_temporary_directory();
+		$previous_working_directory = getcwd();
+		$this->assertNotFalse( $previous_working_directory );
+		$this->assertTrue( chdir( $working_directory ) );
+
+		try {
+			$callback();
+		} finally {
+			$this->assertTrue( chdir( $previous_working_directory ) );
+		}
+
+		$this->assertSame( array( '.', '..' ), scandir( $working_directory ) );
+	}
+
+	private function initialize_managed_storage( $database_root ) {
+		$storage = new WP_SQLite_Storage( $database_root );
+
+		return $storage->initialize();
+	}
+
+	private function assert_protected_directory( $directory ) {
+		clearstatcache( true, $directory );
+		$this->assertSame( 0700, fileperms( $directory ) & 0777 );
+		$this->assertSame( 'DENY FROM ALL', file_get_contents( $directory . '/.htaccess' ) );
+		$this->assertSame( 0600, fileperms( $directory . '/.htaccess' ) & 0777 );
+		$this->assertSame( '<?php // Silence is golden.', file_get_contents( $directory . '/index.php' ) );
+		$this->assertSame( 0600, fileperms( $directory . '/index.php' ) & 0777 );
 	}
 
 	private function set_storage_property( $storage, $name, $value ) {
@@ -194,6 +548,23 @@ class WP_SQLite_Storage_Test extends WP_UnitTestCase {
 			'output'    => $output,
 			'error'     => $error,
 		);
+	}
+
+	private function create_sqlite_database( $database_path ) {
+		$connection = new PDO( 'sqlite:' . $database_path );
+		$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+		$connection->exec( 'CREATE TABLE storage_test (value TEXT NOT NULL)' );
+		$connection->exec( "INSERT INTO storage_test VALUES ('preserved')" );
+
+		return $connection;
+	}
+
+	private function read_sqlite_value( $database_path ) {
+		$connection = new PDO( 'sqlite:' . $database_path );
+		$connection->setAttribute( PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION );
+		$connection->exec( 'PRAGMA busy_timeout = 100' );
+
+		return $connection->query( 'SELECT value FROM storage_test' )->fetchColumn();
 	}
 
 	private function create_temporary_directory() {


### PR DESCRIPTION
## Summary

> [!NOTE]
> This is an alternative approach to #494. It keeps the same randomized storage design, but delegates coordination to SQLite's VFS and locking protocol through a dedicated SQLite database.

This PR adds **randomized storage** for SQLite databases as an additional layer of protection against direct web access.

- **Randomized paths:** New managed databases are stored in a directory generated from 128 bits of randomness.
- **Portable discovery:** `db-path.php` records the database location relative to the managed database root.
- **SQLite-backed locking:** Setup and maintenance are coordinated through a dedicated SQLite locking database.
- **Database isolation:** Maintenance also acquires an exclusive lock on an existing database before changing it.
- **Automatic migration:** Existing `.ht.sqlite` and `.ht.sqlite.php` databases are moved to the randomized layout.
- **Explicit path compatibility:** User-configured database paths and `:memory:` continue to work unchanged.
- **Retryable setup:** Another request can complete setup after an interruption.
- **Safer failures:** Filesystem errors do not expose the randomized database path.

## Managed storage

When no explicit database path is configured, the default layout is:

```text
wp-content/
└── database/
    ├── .htaccess
    ├── index.php
    ├── .ht.sqlite.lock
    ├── db-path.php
    └── .ht.<32-hex-char-random-key>/
        ├── .htaccess
        ├── index.php
        └── .ht.sqlite
```

The `db-path.php` file returns the database location using `__DIR__`, so copying or moving the complete `database` directory keeps the reference valid. If setup is interrupted after the path is published, another request can finish creating the protected directory and database.

## Storage locking
The storage implements a locking mechanism for initialization and maintenance. Locking uses a dedicated empty SQLite database and a maintenance file:

1. An exclusive lock is acquired on the locking database at ".ht.sqlite.lock".
2. A maintenance marker file is created at ".ht.sqlite.maintenance":
    - When requests see the file, they use the locking database.
    - Its absence provides a fast path for normal traffic.
3. When the lock is released, the maintenance file is automatically removed.

## Legacy migration

Migration is serialized across concurrent requests. Before moving a legacy database, the storage manager checkpoints WAL data, switches to `DELETE` journal mode, and acquires an exclusive SQLite lock. If the database remains busy or migration otherwise fails, the original database file stays in place.

## Why

A SQLite database at a predictable location under the document root may be served directly when the web server does not honor `.htaccess` or equivalent denial rules. The randomized directory makes accidental exposure substantially harder while retaining a stable discovery mechanism for WordPress and external tools.

This is an additional safeguard, not a replacement for private storage. Keeping the database outside the document root or configuring the web server to deny access remains the strongest protection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed SQLite storage with randomized and in-memory database locations.
  * Added support for migrating existing SQLite databases.
  * Improved database protection and concurrent-access handling, including stale-lock recovery.

* **Bug Fixes**
  * Improved handling of database initialization failures with clearer failure responses.
  * Added safeguards for invalid database paths and storage-operation failures.
  * Improved cleanup of WordPress database files during test environment resets.

* **Tests**
  * Expanded coverage for initialization, migration, permissions, locking, concurrency, recovery, and in-memory databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->