### PR TITLE
Fix schema reconstruction with native numeric results

### DIFF
--- a/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
+++ b/packages/mysql-on-sqlite/src/sqlite/class-wp-sqlite-information-schema-reconstructor.php
@@ -377,13 +377,13 @@ class WP_SQLite_Information_Schema_Reconstructor {
 		$definition[] = $mysql_type;
 
 		// NULL/NOT NULL.
-		if ( '1' === $column_info['notnull'] ) {
+		if ( 1 === (int) $column_info['notnull'] ) {
 			$definition[] = 'NOT NULL';
 		}
 
 		// Auto increment.
 		$is_auto_increment = false;
-		if ( '0' !== $column_info['pk'] ) {
+		if ( 0 !== (int) $column_info['pk'] ) {
 			$is_auto_increment = $this->driver->execute_sqlite_query(
 				'SELECT 1 FROM sqlite_master WHERE tbl_name = ? AND sql LIKE ?',
 				array( $table_name, '%AUTOINCREMENT%' )
@@ -421,7 +421,7 @@ class WP_SQLite_Information_Schema_Reconstructor {
 			$definition[] = 'FULLTEXT KEY';
 		} elseif ( 'SPATIAL' === $cached_type ) {
 			$definition[] = 'SPATIAL KEY';
-		} elseif ( 'UNIQUE' === $cached_type || '1' === $key_info['unique'] ) {
+		} elseif ( 'UNIQUE' === $cached_type || 1 === (int) $key_info['unique'] ) {
 			$definition[] = 'UNIQUE KEY';
 		} else {
 			$definition[] = 'KEY';

--- a/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
+++ b/packages/mysql-on-sqlite/tests/WP_SQLite_Information_Schema_Reconstructor_Tests.php
@@ -181,6 +181,64 @@ class WP_SQLite_Information_Schema_Reconstructor_Tests extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider stringifyFetchesProvider
+	 */
+	public function testStringifyFetchesDoesNotAffectReconstruction( bool $enabled ): void {
+		$this->engine->setAttribute( PDO::ATTR_STRINGIFY_FETCHES, $enabled );
+
+		$this->engine->get_connection()->query(
+			"CREATE TABLE t (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				name TEXT NOT NULL UNIQUE,
+				note TEXT DEFAULT 'default',
+				score INTEGER
+			)"
+		);
+		$this->engine->get_connection()->query( 'CREATE INDEX t__score ON t (score)' );
+
+		$this->reconstructor->ensure_correct_information_schema();
+
+		// Use consistent result types when checking the reconstructed metadata.
+		$this->engine->setAttribute( PDO::ATTR_STRINGIFY_FETCHES, true );
+
+		$this->assertSame(
+			array(
+				array( 'id', 'NO', null, 'auto_increment' ),
+				array( 'name', 'NO', null, '' ),
+				array( 'note', 'YES', 'default', '' ),
+				array( 'score', 'YES', null, '' ),
+			),
+			$this->engine->query(
+				"SELECT COLUMN_NAME, IS_NULLABLE, COLUMN_DEFAULT, EXTRA
+				FROM INFORMATION_SCHEMA.COLUMNS
+				WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't'
+				ORDER BY ORDINAL_POSITION"
+			)->fetchAll( PDO::FETCH_NUM )
+		);
+
+		$this->assertSame(
+			array(
+				array( 'PRIMARY', 'id', '0' ),
+				array( 'name', 'name', '0' ),
+				array( 'score', 'score', '1' ),
+			),
+			$this->engine->query(
+				"SELECT INDEX_NAME, COLUMN_NAME, NON_UNIQUE
+				FROM INFORMATION_SCHEMA.STATISTICS
+				WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't'
+				ORDER BY COLUMN_NAME"
+			)->fetchAll( PDO::FETCH_NUM )
+		);
+	}
+
+	public function stringifyFetchesProvider(): array {
+		return array(
+			'stringification disabled' => array( false ),
+			'stringification enabled'  => array( true ),
+		);
+	}
+
 	public function testReconstructWpTable(): void {
 		// Create a WP table with any columns.
 		$this->engine->get_connection()->query( 'CREATE TABLE wp_posts ( id INTEGER )' );


### PR DESCRIPTION
## Summary

Make **schema reconstruction independent of `PDO::ATTR_STRINGIFY_FETCHES`**. Interpret SQLite's primary-key, nullability, and uniqueness flags as integers so reconstruction preserves auto-increment columns, `NOT NULL`, defaults, and unique indexes in either fetch mode.

Add a regression test that creates an existing SQLite table before driver initialization and verifies its reconstructed column and index metadata with string fetching enabled and disabled.

## Why

Reconstruction compared SQLite's numeric flags strictly against strings. Since connection initialization stopped forcing string results in #291, reconstruction can receive integers before WordPress enables string fetching. This could mark every column in an auto-increment table as auto-incrementing, causing a later `ALTER TABLE` to fail with "has more than one primary key."

Related to #422.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when SQLite returns column and index metadata as either strings or integers.
  * Information schema reconstruction now consistently handles numeric metadata values regardless of fetch settings or PHP version.
  * Schema and index details are reconstructed more reliably across different SQLite metadata formats.

* **Tests**
  * Added coverage for schema reconstruction with stringified and native SQLite fetch values.
  * Verified reconstructed column metadata and index statistics across supported configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->