### PR TITLE
Release 3.0.2

### DIFF
--- a/packages/mysql-on-sqlite/src/version.php
+++ b/packages/mysql-on-sqlite/src/version.php
@@ -9,4 +9,4 @@ if ( defined( 'SQLITE_DRIVER_VERSION' ) ) {
  *
  * This constant needs to be updated on plugin release!
  */
-define( 'SQLITE_DRIVER_VERSION', '3.0.1' );
+define( 'SQLITE_DRIVER_VERSION', '3.0.2' );

--- a/packages/plugin-sqlite-database-integration/load.php
+++ b/packages/plugin-sqlite-database-integration/load.php
@@ -3,7 +3,7 @@
  * Plugin Name: SQLite Database Integration
  * Description: SQLite database driver drop-in.
  * Author: The WordPress Team
- * Version: 3.0.1
+ * Version: 3.0.2
  * Requires PHP: 7.2
  * Network: true
  * License: GPL-2.0-or-later

--- a/packages/plugin-sqlite-database-integration/readme.txt
+++ b/packages/plugin-sqlite-database-integration/readme.txt
@@ -4,7 +4,7 @@ Contributors:      wordpressdotorg, aristath, janjakes, zieladam, berislav.grgic
 Requires at least: 6.4
 Tested up to:      7.1
 Requires PHP:      7.2
-Stable tag:        3.0.1
+Stable tag:        3.0.2
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 Tags:              sqlite, database
@@ -65,6 +65,13 @@ Contributions are welcome through the [SQLite Database Integration repository on
 Yes. The plugin replaces the default MySQL-based database layer with an SQLite-backed implementation. WordPress continues to use the `wpdb` API, while queries are internally adapted to SQLite syntax and behavior.
 
 == Changelog ==
+
+= 3.0.2 =
+
+* Fix schema reconstruction with native numeric results ([#506](https://github.com/WordPress/sqlite-database-integration/pull/506))
+* Fix lexer edge cases and string handling ([#505](https://github.com/WordPress/sqlite-database-integration/pull/505))
+* Preserve index prefix lengths and order in `SHOW CREATE TABLE` primary keys ([#500](https://github.com/WordPress/sqlite-database-integration/pull/500))
+* Align savepoint handling with MySQL semantics ([#496](https://github.com/WordPress/sqlite-database-integration/pull/496))
 
 = 3.0.1 =
 


### PR DESCRIPTION
## Release `3.0.2`

Version bump and changelog update for release `3.0.2`.

**Changelog draft:**
* Fix schema reconstruction with native numeric results ([#506](https://github.com/WordPress/sqlite-database-integration/pull/506))
* Fix lexer edge cases and string handling ([#505](https://github.com/WordPress/sqlite-database-integration/pull/505))
* Preserve index prefix lengths and order in SHOW CREATE TABLE primary keys ([#500](https://github.com/WordPress/sqlite-database-integration/pull/500))
* Align savepoint handling with MySQL semantics ([#496](https://github.com/WordPress/sqlite-database-integration/pull/496))

**Full changelog:** https://github.com/WordPress/sqlite-database-integration/compare/v3.0.1...release/v3.0.2

## Next steps

1. **Review** the changes in this pull request.
2. **Push** any additional edits to this branch (`release/v3.0.2`).
3. **Merge** this pull request to complete the release.

Merging will automatically build the plugin ZIP, create a [GitHub release](https://github.com/WordPress/sqlite-database-integration/releases), and deploy to [WordPress.org](https://wordpress.org/plugins/sqlite-database-integration/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schema reconstruction when handling native numeric results.
  - Corrected lexer edge cases and string processing.
  - Fixed index prefix lengths and ordering in `SHOW CREATE TABLE` output for primary keys.
  - Improved savepoint handling to better match MySQL behavior.

- **Release**
  - Updated the SQLite integration to version 3.0.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->